### PR TITLE
Align story subpages with index theme

### DIFF
--- a/pop3_style.css
+++ b/pop3_style.css
@@ -1,155 +1,389 @@
-body {
-    font-family: 'Arial', sans-serif;
-    margin: 0;
-    padding: 0;
-    background-color: #ffdd57; /* Bold pop art colors */
-    color: #333;
+:root{
+  --bg0:#050814;
+  --bg1:#08102a;
+  --card:#0c1736cc;
+  --card2:#0b1430b3;
+  --text:#eaf1ff;
+  --muted:#b9c7ea;
+  --muted2:#9ab0e8;
+
+  --lapis:#2d63ff;
+  --lapis2:#1f3bb5;
+  --teal:#32e3d6;
+  --gold:#ffd37a;
+  --pink:#ff4d8d;
+
+  --shadow: 0 18px 60px rgba(0,0,0,.55);
+  --shadow2: 0 10px 24px rgba(0,0,0,.35);
+  --radius: 22px;
+  --radius2: 16px;
+  --stroke: 1px solid rgba(255,255,255,.10);
+
+  --container: min(1100px, 92vw);
+  --font: ui-sans-serif, system-ui, -apple-system, "Hiragino Sans", "Noto Sans JP", "Yu Gothic", "Meiryo", sans-serif;
 }
 
-header {
-    background-color: #ff4081;
-    color: white;
-    padding: 10px 0;
-    text-align: center;
-    position: relative;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
-    text-transform: uppercase;
-    font-weight: bold;
-    font-size: 2.5rem;
-    animation: glow 1.5s infinite alternate;
+*{ box-sizing:border-box; }
+html,body{ height:100%; }
+body{
+  margin:0;
+  font-family: var(--font);
+  color: var(--text);
+  background:
+    radial-gradient(1200px 800px at 20% 10%, rgba(45, 99, 255, .20), transparent 55%),
+    radial-gradient(900px 700px at 80% 20%, rgba(50, 227, 214, .16), transparent 55%),
+    radial-gradient(900px 700px at 70% 85%, rgba(255, 77, 141, .12), transparent 55%),
+    radial-gradient(900px 700px at 15% 90%, rgba(255, 211, 122, .10), transparent 55%),
+    linear-gradient(180deg, var(--bg0), var(--bg1));
+  overflow-x:hidden;
 }
 
-@media (max-width: 768px) {
-    header {
-        font-size: 1.8rem; /* Smaller font for mobile devices */
-    }
+a{ color: var(--teal); text-decoration:none; transition: color .18s ease, transform .18s ease; }
+a:hover{ color: var(--gold); transform: translateY(-1px); }
+
+.skip{
+  position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden;
+}
+.skip:focus{
+  position:fixed; left:12px; top:12px; width:auto; height:auto; padding:10px 12px;
+  background:#000; border:1px solid rgba(255,255,255,.2); border-radius:12px; z-index:9999;
 }
 
-@keyframes glow {
-    from {
-        text-shadow: 0 0 10px #ff4081, 0 0 20px #ff4081;
-    }
-    to {
-        text-shadow: 0 0 30px #ff4081, 0 0 40px #ff4081;
-    }
+.topbar{
+  position:sticky;
+  top:0;
+  z-index:50;
+  padding: 12px 0;
+  backdrop-filter: blur(14px);
+  background: linear-gradient(180deg, rgba(6,10,26,.80), rgba(6,10,26,.55));
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.topbar-inner{
+  width: var(--container);
+  margin:0 auto;
+  display:flex;
+  align-items:center;
+  gap:14px;
+}
+.brand{
+  display:flex; align-items:center; gap:10px;
+  min-width: 210px;
+  color:inherit;
+}
+.mark{
+  width:32px; height:32px; flex:0 0 32px;
+  border-radius: 12px;
+  background:
+    radial-gradient(14px 14px at 30% 35%, rgba(255,255,255,.50), transparent 55%),
+    conic-gradient(from 160deg, rgba(50,227,214,.95), rgba(45,99,255,.95), rgba(255,77,141,.85), rgba(255,211,122,.90), rgba(50,227,214,.95));
+  box-shadow: 0 10px 24px rgba(0,0,0,.35);
+  position:relative;
+  overflow:hidden;
+  border: 1px solid rgba(255,255,255,.16);
+}
+.mark::after{
+  content:"";
+  position:absolute; inset:-60%;
+  background: radial-gradient(circle, rgba(255,255,255,.22), transparent 55%);
+  transform: rotate(25deg);
+  animation: shimmer 6.5s linear infinite;
+}
+@keyframes shimmer{
+  0%{ transform: translate(-18%, -18%) rotate(25deg); }
+  100%{ transform: translate(18%, 18%) rotate(25deg); }
+}
+.brand-title{
+  display:flex; flex-direction:column;
+  line-height:1.15;
+}
+.brand-title b{
+  font-size: 14px;
+  letter-spacing:.04em;
+  opacity:.95;
+}
+.brand-title span{
+  font-size: 12px;
+  color: var(--muted);
+}
+.nav{
+  margin-left:auto;
+  display:flex; gap:10px; align-items:center; flex-wrap:wrap;
+  justify-content:flex-end;
+}
+.nav a{
+  font-size: 13px;
+  color: var(--muted);
+  padding:10px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.10);
+  background: rgba(255,255,255,.04);
+  transition: transform .18s ease, background .18s ease, border-color .18s ease;
+  will-change: transform;
+}
+.nav a:hover{
+  transform: translateY(-1px);
+  background: rgba(255,255,255,.07);
+  border-color: rgba(255,255,255,.16);
+}
+.nav a.cta{
+  color: #051022;
+  border: none;
+  background:
+    linear-gradient(90deg, rgba(255,211,122,.95), rgba(50,227,214,.90));
+  box-shadow: 0 12px 28px rgba(0,0,0,.35);
+  font-weight: 700;
 }
 
-.container {
-    max-width: 1000px;
-    margin: 20px auto;
-    padding: 20px;
-    background-color: white;
-    border-radius: 15px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
-    animation: popEffect 1s ease-in-out;
+main{
+  width: var(--container);
+  margin: 14px auto 70px;
+  padding-bottom: 40px;
 }
 
-@keyframes popEffect {
-    0% {
-        transform: scale(0.8);
-        opacity: 0.6;
-    }
-    100% {
-        transform: scale(1);
-        opacity: 1;
-    }
+body > header:not(.topbar){
+  width: var(--container);
+  margin: 20px auto 14px;
+  padding: 22px 22px 16px;
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03));
+  border: var(--stroke);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow2);
+  font-size: clamp(22px, 4vw, 32px);
+  font-weight: 800;
+  letter-spacing:.01em;
+  line-height:1.3;
 }
 
-h2 {
-    color: #ff4081;
-    font-size: 2rem;
-    font-weight: bold;
+body > header:not(.topbar) .sparkle{ color: var(--gold); }
+
+.container{
+  width: 100%;
+  margin: 10px 0 30px;
+  display:flex;
+  flex-direction:column;
+  gap: 12px;
 }
 
-a {
-    text-decoration: none;
-    color: #1e90ff;
-    font-weight: bold;
-    transition: all 0.3s ease;
+.sparkle{ color: var(--gold); text-shadow: 0 0 12px rgba(255,211,122,.35); }
+
+.section,
+.content,
+.character,
+.story-section,
+.summary-box,
+.math-box,
+.boundary-lesson,
+.feedback-card,
+.story-container{
+  border-radius: var(--radius2);
+  border: 1px solid rgba(255,255,255,.10);
+  background: linear-gradient(180deg, rgba(12,23,54,.72), rgba(9,16,40,.55));
+  box-shadow: var(--shadow2);
+  padding: 16px 18px 14px;
+  position:relative;
+  overflow:hidden;
 }
 
-a:hover {
-    text-decoration: underline;
-    color: #ff4081;
-    text-shadow: 0 0 5px #ff4081;
+.section::before,
+.content::before,
+.character::before,
+.story-section::before,
+.summary-box::before,
+.math-box::before,
+.boundary-lesson::before,
+.feedback-card::before,
+.story-container::before{
+  content:"";
+  position:absolute; inset:-30%;
+  background:
+    radial-gradient(circle at 15% 20%, rgba(255,255,255,.10), transparent 52%),
+    radial-gradient(circle at 80% 30%, rgba(45,99,255,.12), transparent 55%),
+    radial-gradient(circle at 40% 90%, rgba(255,211,122,.08), transparent 55%);
+  filter: blur(10px);
+  opacity: .8;
+  transform: rotate(-8deg);
+  pointer-events:none;
 }
 
-img {
-    width: 100%;
-    max-width: 400px;
-    height: auto;
-    display: block;
-    margin: 10px auto;
-    border-radius: 10px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+h1,h2,h3{
+  color: var(--text);
+  margin-top:0;
+  letter-spacing:.01em;
+}
+h2{
+  font-size: clamp(18px, 2.4vw, 22px);
+  display:flex;
+  align-items:center;
+  gap:10px;
 }
 
-table {
-    border-collapse: collapse;
-    width: 100%;
+p, li{
+  color: var(--muted);
+  line-height: 1.85;
+  letter-spacing:.01em;
 }
 
-th, td {
-    border: 2px solid black;
-    padding: 8px;
-    text-align: left;
+.section-title{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  margin: 6px 2px 12px;
+}
+.section-title h2{ margin:0; }
+.section-title p{ margin:0; color: var(--muted2); }
+
+ul{ padding-left: 1.2em; }
+ul li{ margin-bottom:6px; }
+
+.highlight{
+  background: linear-gradient(90deg, rgba(255,211,122,.35), rgba(50,227,214,.20));
+  color: var(--text);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-weight: 800;
 }
 
-pre {
-    background-color: #f4f4f4;
-    padding: 10px;
-    border-radius: 5px;
-    overflow-x: auto; /* Allow horizontal scrolling */
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    font-family: 'Courier New', Courier, monospace;
-    max-width: 100%; /* Ensure it fits within the container */
-    box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.2);
+.dialogue{
+  margin: 14px 0;
+  padding: 14px 14px 12px;
+  border-radius: 14px;
+  background: rgba(255,255,255,.04);
+  border: 1px solid rgba(255,255,255,.10);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.03);
+}
+.character-name{
+  font-weight: 800;
+  color: var(--gold);
+  display:block;
+  margin-bottom: 5px;
+  letter-spacing:.04em;
 }
 
-.footer {
-    text-align: center;
-    padding: 10px;
-    background-color: #ff4081;
-    color: white;
-    position: fixed;
-    bottom: 0;
-    width: 100%;
+.quote,
+.thought{
+  margin: 14px 0;
+  padding: 14px;
+  border-radius: 14px;
+  background: rgba(45,99,255,.10);
+  border-left: 3px solid var(--teal);
+  color: var(--muted);
 }
 
-.character {
-    margin-bottom: 30px;
-    border: 3px solid #ff4081;
-    padding: 20px;
-    border-radius: 10px;
-    background: #ffdd57;
-    box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
+.scene-break,
+.scene-change{
+  text-align:center;
+  color: var(--muted2);
+  margin: 18px 0;
+  letter-spacing: .3em;
 }
 
-.character:hover {
-    transform: scale(1.05);
-    background-color: #ffcc00;
-    box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.2);
+.scene{
+  margin: 14px 0;
+  padding: 6px 0;
+  color: var(--muted2);
+  font-weight:700;
+  letter-spacing:.08em;
 }
 
-@media (max-width: 768px) {
-    .container {
-        width: 90%;
-    }
+.text-center{ text-align:center; }
+
+pre{
+  background-color: #0e1836 !important;
+  color: #f8f8ff !important;
+  border: 1px solid rgba(255,255,255,.16);
+  padding: 14px;
+  border-radius: 12px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-family: 'SFMono-Regular', 'Menlo', 'Consolas', monospace;
+  box-shadow: inset 0 0 10px rgba(0,0,0,0.45);
+}
+pre code{
+  color: inherit !important;
+  background: transparent !important;
 }
 
-/* KaTeXの数式がはみ出ないようにするためのスタイル */
-.katex {
-    font-size: 1.1em !important; /* 数式のフォントサイズを調整 */
-    overflow-x: auto; /* 横スクロールを許可 */
-    overflow-y: hidden; /* 縦スクロールは不要 */
-    max-width: 100%; /* コンテナ幅に合わせる */
-    white-space: nowrap; /* 数式が折り返されないようにする */
+table{
+  width: 100%;
+  border-collapse: collapse;
+  margin: 12px 0;
+  background: rgba(255,255,255,.02);
+  border-radius: 12px;
+  overflow:hidden;
+}
+th, td{
+  border: 1px solid rgba(255,255,255,.10);
+  padding: 10px;
+  text-align:left;
+  color: var(--muted);
+}
+th{
+  background: linear-gradient(90deg, rgba(45,99,255,.28), rgba(50,227,214,.18));
+  color: var(--text);
+}
+tr:nth-child(even){ background: rgba(255,255,255,.02); }
+
+img{
+  max-width: 100%;
+  border-radius: 12px;
+  box-shadow: var(--shadow2);
 }
 
-.katex-display {
-    margin: 0.5em 0; /* 数式の上下の余白を調整 */
-    overflow-x: auto; /* 横スクロールを許可 */
-    max-width: 100%; /* コンテナ幅に合わせる */
+.footer{
+  width: var(--container);
+  margin: 0 auto 24px;
+  color: rgba(234,241,255,.75);
+  font-size: 13px;
+  line-height:1.7;
+  padding: 12px 0 4px;
+  border-top: 1px solid rgba(255,255,255,.08);
+}
+
+.katex, .formula{ color: var(--text); }
+.math-container, .math-box{
+  border: 1px dashed rgba(255,255,255,.16);
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(12,23,54,.40);
+}
+
+.decision-table{
+  border-radius: 14px;
+  overflow:hidden;
+  border: 1px solid rgba(255,255,255,.10);
+}
+
+.boundary-lesson{
+  background: linear-gradient(180deg, rgba(50,227,214,.10), rgba(12,23,54,.70));
+  border-color: rgba(50,227,214,.25);
+}
+
+.summary-box{
+  background: linear-gradient(180deg, rgba(45,99,255,.12), rgba(9,16,40,.60));
+  border-color: rgba(45,99,255,.22);
+}
+
+.rainbow-arc{
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--lapis), var(--teal), var(--gold), var(--pink));
+  margin: 6px 0 10px;
+  opacity:.8;
+}
+
+.feedback-card{
+  border-color: rgba(255,211,122,.28);
+  background: linear-gradient(180deg, rgba(255,211,122,.14), rgba(9,16,40,.60));
+}
+
+@media (max-width: 720px){
+  .nav a{ padding:9px 10px; }
+  body > header:not(.topbar){ font-size: clamp(20px, 5vw, 26px); padding: 18px 18px 14px; }
+  main{ margin-bottom: 50px; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  *{ animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; }
 }

--- a/story1.html
+++ b/story1.html
@@ -7,146 +7,28 @@
     <link rel="stylesheet" href="pop3_style.css">
     <!-- KaTeX CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <style>
-        /* 追加スタイル: コントラスト強化とカラフルな要素 */
-        body {
-            background: linear-gradient(135deg, #ffdd57 0%, #ff9a57 100%);
-            color: #222;
-        }
-        
-        .container {
-            background: linear-gradient(to bottom, #ffffff, #fff9e6);
-            border: 3px solid #ff4081;
-        }
-        
-        h2 {
-            background-color: #ff4081;
-            color: white;
-            padding: 10px;
-            border-radius: 10px;
-            text-shadow: 2px 2px 0px #d81b60;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-        }
-        
-        .section {
-            margin: 25px 0;
-            padding: 20px;
-            border-radius: 15px;
-            background: linear-gradient(145deg, #ffffff, #ffedb3);
-            box-shadow: 0 5px 15px rgba(0,0,0,0.1);
-            border-left: 5px solid #ff4081;
-        }
-        
-        .dialogue {
-            margin: 15px 0;
-            padding: 15px;
-            background-color: #e3f2fd;
-            border-radius: 10px;
-            border-left: 5px solid #1e90ff;
-            font-style: italic;
-        }
-        
-        .character-name {
-            font-weight: bold;
-            color: #ff4081;
-            display: block;
-            margin-bottom: 5px;
-        }
-        
-        .scene-break {
-            text-align: center;
-            margin: 20px 0;
-            color: #ff4081;
-            font-weight: bold;
-        }
-        
-        /* preタグ内の表示問題修正 */
-        pre {
-            background-color: #2d2d2d !important;
-            color: #f8f8f2 !important;
-            border: 2px solid #ff4081;
-            padding: 15px;
-            border-radius: 10px;
-            overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5);
-        }
-        
-        pre code {
-            color: #f8f8f2 !important;
-            background: transparent !important;
-        }
-        
-        /* カラフルなリストスタイル */
-        ul {
-            list-style-type: none;
-            padding-left: 0;
-        }
-        
-        li {
-            padding: 8px 15px;
-            margin: 5px 0;
-            background-color: #ffdd57;
-            border-radius: 20px;
-            border: 2px solid #ff4081;
-            font-weight: bold;
-        }
-        
-        /* テーブルスタイル強化 */
-        table {
-            border-collapse: collapse;
-            width: 100%;
-            margin: 15px 0;
-            box-shadow: 0 0 10px rgba(0,0,0,0.1);
-        }
-        
-        th {
-            background-color: #ff4081;
-            color: white;
-            font-weight: bold;
-        }
-        
-        th, td {
-            border: 2px solid #333;
-            padding: 12px;
-            text-align: left;
-        }
-        
-        tr:nth-child(even) {
-            background-color: #ffedb3;
-        }
-        
-        /* キラキラ効果 */
-        .sparkle {
-            display: inline-block;
-            position: relative;
-        }
-        
-        .sparkle::after {
-            content: '✨';
-            position: absolute;
-            top: -10px;
-            right: -15px;
-            font-size: 0.7em;
-        }
-        
-        /* フッタースタイル */
-        .footer {
-            text-align: center;
-            padding: 15px;
-            background: linear-gradient(90deg, #ff4081, #ff9a57);
-            color: white;
-            position: relative;
-            bottom: 0;
-            width: 100%;
-            font-weight: bold;
-            text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第1話「キラキラした背中と、<span class="sparkle">ダメ出しの夜</span>」
     </header>
@@ -370,7 +252,8 @@
             <p>そのときの私はまだ気づいていなかった。</p>
         </div>
     </div>
-    
+  </main>
+
     <div class="footer">
         © 魔界歓楽街 サキュバスメイド喫茶《∞（インフィニティ）》
     </div>

--- a/story10.html
+++ b/story10.html
@@ -7,84 +7,28 @@
     <link rel="stylesheet" href="pop3_style.css">
     <!-- KaTeX CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <style>
-        /* 追加スタイル：コントラスト強化とカラフルな要素 */
-        body {
-            background: linear-gradient(135deg, #ffdd57 0%, #ff9a57 100%);
-            color: #222;
-        }
-        
-        .story-section {
-            background: linear-gradient(135deg, #ffffff 0%, #f8f8f8 100%);
-            margin: 20px 0;
-            padding: 25px;
-            border-radius: 15px;
-            border-left: 8px solid #ff4081;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.1);
-        }
-        
-        .dialogue {
-            background-color: #f0f8ff;
-            border-left: 5px solid #1e90ff;
-            padding: 15px;
-            margin: 15px 0;
-            border-radius: 0 10px 10px 0;
-            font-style: italic;
-        }
-        
-        .character-name {
-            font-weight: bold;
-            color: #ff4081;
-            display: inline-block;
-            margin-right: 10px;
-        }
-        
-        .thought {
-            background-color: #fff8dc;
-            border-left: 5px solid #ffcc00;
-            padding: 15px;
-            margin: 15px 0;
-            border-radius: 0 10px 10px 0;
-            color: #666;
-        }
-        
-        pre {
-            background-color: #2d2d2d;
-            color: #f8f8f2;
-            padding: 15px;
-            border-radius: 8px;
-            border: 2px solid #ff4081;
-            overflow-x: auto;
-            font-family: 'Courier New', Courier, monospace;
-            box-shadow: inset 0 0 10px rgba(0,0,0,0.3);
-        }
-        
-        .formula {
-            background-color: #e6f7ff;
-            padding: 15px;
-            border-radius: 8px;
-            border: 2px dashed #1e90ff;
-            margin: 15px 0;
-            text-align: center;
-            font-size: 1.2em;
-        }
-        
-        .highlight {
-            background-color: #ffff00;
-            padding: 2px 5px;
-            border-radius: 3px;
-            font-weight: bold;
-        }
-        
-        .scene-break {
-            text-align: center;
-            margin: 30px 0;
-            color: #ff4081;
-            font-size: 1.5em;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         魔界歓楽街のサキュバスメイド喫茶《∞》 第10話「魔導書と職人の手、Fθと G」
     </header>
@@ -269,6 +213,7 @@
             <p>その文字は、どこかナギの字に少しだけ似ていた。</p>
         </section>
     </div>
+  </main>
 
     <div class="footer">
         © 魔界歓楽街のサキュバスメイド喫茶《∞》 第10話

--- a/story11.html
+++ b/story11.html
@@ -6,59 +6,30 @@
     <link rel="stylesheet" href="pop3_style.css">
     <!-- KaTeX CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
-    <style>
-        /* 追加スタイル: コントラスト強化とカラフルな要素 */
-        body {
-            background: linear-gradient(135deg, #ffdd57 0%, #ff4081 50%, #1e90ff 100%);
-            color: #000;
-            font-weight: bold;
-        }```
-    .container {
-        background: rgba(255, 255, 255, 0.95);
-        border: 5px solid #ff4081;
-        animation: popEffect 1s ease-in-out, glowBorder 2s infinite alternate;
-    }
-
-    @keyframes glowBorder {
-        from { border-color: #ff4081; box-shadow: 0 0 20px #ff4081; }
-        to { border-color: #1e90ff; box-shadow: 0 0 30px #1e90ff; }
-    }
-
-    pre {
-        background: #000 !important;
-        color: #ffdd57 !important;
-        border: 3px double #ff4081;
-        padding: 15px;
-        font-size: 1.1em;
-        border-radius: 10px;
-        box-shadow: inset 0 0 10px #ff4081, 0 0 10px #1e90ff;
-    }
-
-    .katex {
-        color: #ff4081;
-        font-weight: bold;
-    }
-
-    .dialogue {
-        color: #1e90ff;
-        font-style: italic;
-        margin: 10px 0;
-        padding: 10px;
-        border-left: 4px solid #ff4081;
-        background: rgba(255, 221, 87, 0.3);
-    }
-
-    .highlight {
-        background: linear-gradient(90deg, #ff4081, #1e90ff);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        font-weight: bold;
-    }
-</style>
 ```
 
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         テストエンジニアユイ 第11話「先輩も、迷っていた」
     </header>```
@@ -164,8 +135,9 @@
 
     <p>届かないと思っていた背中が、同じスタートラインの延長にあると知った夜。ユイは、自分もその線の上を歩いていいのだと、初めて素直に思えた。</p>
 </div>
+  </main>
 
-<div class="footer">
+    <div class="footer">
     © テストエンジニアユイ 第11話
 </div>
 

--- a/story12.html
+++ b/story12.html
@@ -7,60 +7,28 @@
     <link rel="stylesheet" href="pop3_style.css">
     <!-- KaTeX CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
-    <style>
-        /* 追加スタイル: preタグ内の表示バグ修正とコントラスト強化 */
-        pre {
-            background-color: #f8f8f8;
-            color: #333;
-            border: 2px solid #ff4081;
-            padding: 15px;
-            border-radius: 10px;
-            overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            max-width: 100%;
-            box-shadow: inset 0 0 10px rgba(255, 64, 129, 0.2);
-        }
-        
-        /* 数式スタイルの追加 */
-        .math-container {
-            margin: 15px 0;
-            padding: 10px;
-            background-color: #ffeb3b;
-            border-radius: 8px;
-            border: 2px dashed #ff4081;
-            text-align: center;
-        }
-        
-        /* 会話スタイル */
-        .dialogue {
-            margin: 15px 0;
-            padding: 15px;
-            background-color: #e3f2fd;
-            border-left: 5px solid #2196f3;
-            border-radius: 5px;
-            font-style: italic;
-        }
-        
-        /* 強調テキスト */
-        .highlight {
-            background-color: #ffeb3b;
-            padding: 2px 5px;
-            border-radius: 3px;
-            font-weight: bold;
-        }
-        
-        /* セクション見出し */
-        .section-title {
-            color: #ff4081;
-            border-bottom: 3px solid #ff4081;
-            padding-bottom: 10px;
-            margin-top: 30px;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第12話「次の子に渡す、G の地図」
     </header>
@@ -239,8 +207,8 @@
             <p>そう言ってマーカーを差し出すユイの背中は、どこか昔のナギに、少しだけ似ていた。</p>
         </section>
     </div>
-    
-    <footer class="footer">
+  </main>
+>
         © 2024 サキュバスメイド喫茶《∞（インフィニティ）》
     </footer>
 

--- a/story2.html
+++ b/story2.html
@@ -8,71 +8,28 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" onload="renderMathInElement(document.body);"></script>
-    <style>
-        /* 追加のカラフルスタイル */
-        body {
-            background: linear-gradient(135deg, #ffdd57, #ff4081, #1e90ff);
-            background-attachment: fixed;
-            color: #000;
-            font-weight: bold;
-        }
-        .container {
-            background: rgba(255, 255, 255, 0.95);
-            border: 5px dashed #ff4081;
-        }
-        pre {
-            background: #000;
-            color: #00ff00;
-            border: 3px solid #ff4081;
-            font-weight: bold;
-            padding: 15px;
-            border-radius: 10px;
-            box-shadow: 0 0 15px #ff4081;
-        }
-        .character {
-            background: linear-gradient(45deg, #ffdd57, #ffcc00);
-            border: 3px solid #ff4081;
-            color: #000;
-        }
-        .footer {
-            background: #000;
-            color: #ffdd57;
-            font-weight: bold;
-            border-top: 5px solid #ff4081;
-        }
-        h2 {
-            color: #1e90ff;
-            text-shadow: 2px 2px 0 #ff4081;
-        }
-        a {
-            color: #ff00ff;
-            text-shadow: 1px 1px 0 #000;
-        }
-        a:hover {
-            color: #00ffff;
-            text-shadow: 0 0 10px #00ffff;
-        }
-        /* 吹き出し風の会話スタイル */
-        .dialogue {
-            background: #e0f7ff;
-            border: 2px solid #1e90ff;
-            border-radius: 20px;
-            padding: 10px 15px;
-            margin: 10px 0;
-            position: relative;
-            box-shadow: 3px 3px 0 #1e90ff;
-        }
-        .dialogue::before {
-            content: '';
-            position: absolute;
-            left: -10px;
-            top: 10px;
-            border: 10px solid transparent;
-            border-right-color: #1e90ff;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         魔界歓楽街サキュバスメイド喫茶《∞》第2話
     </header>
@@ -145,6 +102,8 @@
             <p>仕様書の外側に広がる、揺れるような世界 W。その中からどんな瞬間をすくい上げられるだろう――そんなことを思いながら、彼女は「本日開店」のプレートをそっと裏返した。</p>
         </section>
     </div>
+  </main>
+
     <div class="footer">
         © 魔界歓楽街サキュバスメイド喫茶《∞》 All rights reserved.
     </div>

--- a/story3.html
+++ b/story3.html
@@ -6,58 +6,28 @@
     <title>第3話「同値クラスという、お守りの石」</title>
     <link rel="stylesheet" href="pop3_style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <style>
-        /* 追加スタイル: コントラスト強化 & カラフルな要素 */
-        .content {
-            margin-bottom: 30px;
-            border: 3px solid #ff4081;
-            padding: 20px;
-            border-radius: 10px;
-            background: linear-gradient(135deg, #ffdd57, #ffcc00);
-            box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-        }
-        .content:hover {
-            transform: scale(1.02);
-            background: linear-gradient(135deg, #ffcc00, #ffaa00);
-            box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.2);
-        }
-        pre {
-            background-color: #2d2d2d !important; /* ダーク背景 */
-            color: #f8f8f2 !important; /* 明るい文字色 */
-            border: 2px solid #ff4081;
-            padding: 15px;
-            border-radius: 10px;
-            overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            max-width: 100%;
-            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5);
-        }
-        .katex {
-            font-size: 1.1em !important;
-            color: #d33682 !important; /* 数式の文字色をピンクに */
-        }
-        .highlight {
-            background-color: #ff4081;
-            color: white;
-            padding: 2px 5px;
-            border-radius: 3px;
-            font-weight: bold;
-        }
-        .quote {
-            border-left: 5px solid #1e90ff;
-            padding-left: 15px;
-            margin: 10px 0;
-            font-style: italic;
-            background-color: #f0f8ff;
-            padding: 10px;
-            border-radius: 5px;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第3話「同値クラスという、お守りの石」
     </header>
@@ -201,8 +171,8 @@
             同値クラスという小さな石を手に入れた、一人のテスト屋の地図が描かれ始めていた。</p>
         </section>
     </div>
-
-    <footer class="footer">
+  </main>
+>
         © 2024 テストエンジニア物語
     </footer>
 

--- a/story4.html
+++ b/story4.html
@@ -6,92 +6,28 @@
     <title>第4話「境界線を、一緒に歩いた夜」</title>
     <link rel="stylesheet" href="pop3_style.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
-    <style>
-        /* 追加スタイル：コントラスト強化 & カラフル要素 */
-        body {
-            background: linear-gradient(135deg, #ffdd57 0%, #ff9e80 100%);
-            color: #222;
-            font-weight: 500;
-        }
-        .container {
-            background: #fff;
-            border: 4px solid #ff4081;
-            border-radius: 20px;
-            box-shadow: 0 10px 30px rgba(255, 64, 129, 0.3);
-        }
-        h2 {
-            color: #ff0066;
-            text-shadow: 2px 2px 0 #ffdd57;
-            border-bottom: 3px dashed #ff4081;
-            padding-bottom: 10px;
-        }
-        .summary-box {
-            background: #e3f2fd;
-            border: 3px solid #2196f3;
-            border-radius: 15px;
-            padding: 20px;
-            margin: 20px 0;
-            box-shadow: inset 0 0 10px rgba(33, 150, 243, 0.2);
-        }
-        .scene {
-            background: #fff8e1;
-            border: 3px solid #ffca28;
-            border-radius: 15px;
-            padding: 20px;
-            margin: 20px 0;
-            box-shadow: 0 5px 15px rgba(255, 202, 40, 0.3);
-        }
-        .thought {
-            background: #fce4ec;
-            border-left: 5px solid #ec407a;
-            padding: 10px 15px;
-            margin: 10px 0;
-            font-style: italic;
-            color: #880e4f;
-        }
-        .feedback-card {
-            background: #fff;
-            border: 3px solid #7e57c2;
-            border-radius: 10px;
-            padding: 15px;
-            margin: 15px 0;
-            font-family: 'Courier New', monospace;
-            color: #4a148c;
-            box-shadow: 0 0 10px rgba(126, 87, 194, 0.5);
-        }
-        .boundary-lesson {
-            background: #e8f5e9;
-            border: 3px solid #66bb6a;
-            border-radius: 15px;
-            padding: 20px;
-            margin: 20px 0;
-            box-shadow: 0 5px 15px rgba(102, 187, 106, 0.3);
-        }
-        pre {
-            background: #2d2d2d !important;
-            color: #f8f8f2 !important;
-            border: 3px solid #ff4081 !important;
-            border-radius: 10px !important;
-            padding: 15px !important;
-            overflow-x: auto;
-            font-size: 1rem;
-            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5);
-        }
-        .katex {
-            font-size: 1.2em;
-            color: #d81b60;
-        }
-        .footer {
-            background: #ff4081;
-            color: #fff;
-            text-align: center;
-            padding: 15px;
-            font-weight: bold;
-            box-shadow: 0 -5px 15px rgba(255, 64, 129, 0.5);
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第4話「境界線を、一緒に歩いた夜」
     </header>
@@ -160,8 +96,8 @@
             <p>境界線を一緒に歩いた夜。ユイの中で「失敗」というラベルが、そっと「発見」に書き換わっていった。</p>
         </div>
     </div>
-
-    <footer class="footer">
+  </main>
+>
         © 2024 テスト技法物語 - 境界値分析の章
     </footer>
 

--- a/story5.html
+++ b/story5.html
@@ -9,73 +9,28 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" onload="renderMathInElement(document.body);"></script>
-    <style>
-        /* 追加のカラフルスタイル */
-        body {
-            background: linear-gradient(135deg, #ffdd57, #ff4081, #1e90ff);
-            background-attachment: fixed;
-            color: #000;
-            font-weight: bold;
-        }
-        .container {
-            background: rgba(255, 255, 255, 0.95);
-            border: 5px dashed #ff4081;
-            animation: popEffect 1s ease-in-out;
-        }
-        h2 {
-            color: #1e90ff;
-            text-shadow: 2px 2px 0 #ff4081;
-        }
-        pre {
-            background: #000 !important;
-            color: #ffdd57 !important;
-            border: 3px solid #1e90ff;
-            font-weight: bold;
-            padding: 15px;
-            border-radius: 10px;
-            box-shadow: 0 0 15px #ff4081;
-        }
-        .footer {
-            background: #1e90ff;
-            color: #ffdd57;
-            font-weight: bold;
-            text-shadow: 1px 1px 0 #000;
-        }
-        .character {
-            background: linear-gradient(45deg, #ffdd57, #ff4081);
-            border: 3px solid #1e90ff;
-            color: #000;
-            box-shadow: 0 0 20px #1e90ff;
-        }
-        .decision-table {
-            background: #000;
-            color: #ffdd57;
-            border: 3px solid #ff4081;
-            padding: 10px;
-            margin: 20px 0;
-            border-radius: 10px;
-            box-shadow: 0 0 15px #1e90ff;
-        }
-        .decision-table table {
-            border: 2px solid #ffdd57;
-        }
-        .decision-table th, .decision-table td {
-            border: 2px solid #ffdd57;
-            padding: 10px;
-            text-align: center;
-            color: #ffdd57;
-        }
-        .decision-table th {
-            background: #1e90ff;
-            color: #000;
-        }
-        .katex {
-            color: #ff4081;
-            font-weight: bold;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         魔界歓楽街のサキュバスメイド喫茶《∞》第5話
     </header>
@@ -198,6 +153,8 @@
         <p>　手作りの決定表は、まだ粗い線だらけの地図だ。</p>
         <p>　けれどユイには、その端っこから、遠くの“先輩の背中”へ伸びる細い道が続いているように見えた。</p>
     </div>
+  </main>
+
     <div class="footer">
         © 2023 魔界歓楽街のサキュバスメイド喫茶《∞》シリーズ
     </div>

--- a/story6.html
+++ b/story6.html
@@ -5,186 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第6話「関係は、状態遷移で語れる」</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <style>
-        body {
-            font-family: 'Arial', sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #ffdd57;
-            color: #333;
-            line-height: 1.6;
-        }
-
-        header {
-            background-color: #ff4081;
-            color: white;
-            padding: 10px 0;
-            text-align: center;
-            position: relative;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
-            text-transform: uppercase;
-            font-weight: bold;
-            font-size: 2.5rem;
-            animation: glow 1.5s infinite alternate;
-        }
-
-        @media (max-width: 768px) {
-            header {
-                font-size: 1.8rem;
-            }
-        }
-
-        @keyframes glow {
-            from {
-                text-shadow: 0 0 10px #ff4081, 0 0 20px #ff4081;
-            }
-            to {
-                text-shadow: 0 0 30px #ff4081, 0 0 40px #ff4081;
-            }
-        }
-
-        .container {
-            max-width: 1000px;
-            margin: 20px auto;
-            padding: 20px;
-            background-color: white;
-            border-radius: 15px;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
-            animation: popEffect 1s ease-in-out;
-        }
-
-        @keyframes popEffect {
-            0% {
-                transform: scale(0.8);
-                opacity: 0.6;
-            }
-            100% {
-                transform: scale(1);
-                opacity: 1;
-            }
-        }
-
-        h1, h2 {
-            color: #ff4081;
-            font-size: 2rem;
-            font-weight: bold;
-        }
-
-        a {
-            text-decoration: none;
-            color: #1e90ff;
-            font-weight: bold;
-            transition: all 0.3s ease;
-        }
-
-        a:hover {
-            text-decoration: underline;
-            color: #ff4081;
-            text-shadow: 0 0 5px #ff4081;
-        }
-
-        img {
-            width: 100%;
-            max-width: 400px;
-            height: auto;
-            display: block;
-            margin: 10px auto;
-            border-radius: 10px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-        }
-
-        table {
-            border-collapse: collapse;
-            width: 100%;
-        }
-
-        th, td {
-            border: 2px solid black;
-            padding: 8px;
-            text-align: left;
-        }
-
-        pre {
-            background-color: #2d2d2d;
-            color: #f8f8f2;
-            padding: 15px;
-            border-radius: 8px;
-            overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            max-width: 100%;
-            box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.3);
-            border: 2px solid #ff4081;
-            margin: 15px 0;
-        }
-
-        .footer {
-            text-align: center;
-            padding: 10px;
-            background-color: #ff4081;
-            color: white;
-            position: fixed;
-            bottom: 0;
-            width: 100%;
-        }
-
-        .character {
-            margin-bottom: 30px;
-            border: 3px solid #ff4081;
-            padding: 20px;
-            border-radius: 10px;
-            background: #ffdd57;
-            box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-        }
-
-        .character:hover {
-            transform: scale(1.05);
-            background-color: #ffcc00;
-            box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.2);
-        }
-
-        @media (max-width: 768px) {
-            .container {
-                width: 90%;
-            }
-        }
-
-        .katex {
-            font-size: 1.1em !important;
-            overflow-x: auto;
-            overflow-y: hidden;
-            max-width: 100%;
-            white-space: nowrap;
-        }
-
-        .katex-display {
-            margin: 0.5em 0;
-            overflow-x: auto;
-            max-width: 100%;
-        }
-
-        .state-diagram {
-            background: #1e1e1e;
-            color: #00ff00;
-            padding: 15px;
-            border-radius: 8px;
-            font-family: 'Courier New', monospace;
-            border: 2px solid #00ff00;
-            margin: 15px 0;
-        }
-
-        .highlight {
-            background: linear-gradient(45deg, #ff4081, #1e90ff);
-            color: white;
-            padding: 5px 10px;
-            border-radius: 5px;
-            font-weight: bold;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第6話「関係は、状態遷移で語れる」
     </header>
@@ -288,6 +130,7 @@
 
         <p>立ちのぼる湯気の向こうで、ユイリアの小さな決意が、静かに新しい状態へと遷移していった。</p>
     </div>
+  </main>
 
     <div class="footer">
         © 2023 テストエンジニア物語

--- a/story7.html
+++ b/story7.html
@@ -7,157 +7,28 @@
     <link rel="stylesheet" href="pop3_style.css">
     <!-- KaTeX CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
-    <style>
-        /* 追加スタイル: コントラスト強化とカラフルな要素 */
-        body {
-            background: linear-gradient(135deg, #ffdd57 0%, #ff4081 50%, #1e90ff 100%);
-            background-attachment: fixed;
-        }
-        
-        .story-container {
-            max-width: 1000px;
-            margin: 20px auto;
-            padding: 30px;
-            background-color: white;
-            border-radius: 15px;
-            box-shadow: 0 0 30px rgba(0, 0, 0, 0.3);
-            position: relative;
-            overflow: hidden;
-        }
-        
-        .story-container::before {
-            content: "";
-            position: absolute;
-            top: -10px;
-            left: -10px;
-            right: -10px;
-            bottom: -10px;
-            background: linear-gradient(45deg, #ff4081, #1e90ff, #ffdd57, #ff4081);
-            z-index: -1;
-            border-radius: 20px;
-            animation: borderGlow 3s infinite linear;
-        }
-        
-        @keyframes borderGlow {
-            0% { filter: hue-rotate(0deg); }
-            100% { filter: hue-rotate(360deg); }
-        }
-        
-        h1 {
-            color: #ff4081;
-            text-align: center;
-            font-size: 2.5rem;
-            text-transform: uppercase;
-            text-shadow: 3px 3px 0 #ffdd57;
-            margin-bottom: 30px;
-            position: relative;
-            display: inline-block;
-            padding: 0 20px;
-        }
-        
-        h1::after {
-            content: "";
-            position: absolute;
-            bottom: -10px;
-            left: 10%;
-            width: 80%;
-            height: 5px;
-            background: linear-gradient(to right, #ff4081, #1e90ff, #ffdd57);
-            border-radius: 5px;
-        }
-        
-        .summary-box {
-            background: linear-gradient(135deg, #ffdd57 0%, #ffcc00 100%);
-            border: 3px dashed #ff4081;
-            padding: 20px;
-            margin: 20px 0;
-            border-radius: 10px;
-            box-shadow: 5px 5px 0 #ff4081;
-        }
-        
-        .summary-box h2 {
-            color: #ff4081;
-            margin-top: 0;
-            font-size: 1.8rem;
-            text-shadow: 2px 2px 0 white;
-        }
-        
-        .dialogue {
-            background-color: #f0f8ff;
-            border-left: 5px solid #1e90ff;
-            padding: 15px 20px;
-            margin: 15px 0;
-            border-radius: 0 10px 10px 0;
-            box-shadow: 3px 3px 5px rgba(0,0,0,0.1);
-        }
-        
-        .character-name {
-            font-weight: bold;
-            color: #ff4081;
-            display: block;
-            margin-bottom: 5px;
-            font-size: 1.1rem;
-        }
-        
-        .math-box {
-            background-color: #f8f8f8;
-            border: 2px solid #1e90ff;
-            padding: 15px;
-            margin: 20px 0;
-            border-radius: 10px;
-            text-align: center;
-        }
-        
-        .highlight {
-            background-color: #ffdd57;
-            padding: 2px 5px;
-            border-radius: 3px;
-            font-weight: bold;
-        }
-        
-        /* preコード内のバグ修正 */
-        pre {
-            background-color: #2d2d2d !important;
-            color: #f8f8f2 !important;
-            border: 2px solid #ff4081 !important;
-            padding: 15px !important;
-            border-radius: 10px !important;
-            overflow-x: auto !important;
-            white-space: pre-wrap !important;
-            word-wrap: break-word !important;
-            font-family: 'Courier New', Courier, monospace !important;
-            max-width: 100% !important;
-            box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5) !important;
-            margin: 20px 0 !important;
-        }
-        
-        /* フッタースタイル調整 */
-        .footer {
-            text-align: center;
-            padding: 15px;
-            background: linear-gradient(135deg, #ff4081 0%, #1e90ff 100%);
-            color: white;
-            position: relative;
-            bottom: 0;
-            width: 100%;
-            margin-top: 40px;
-            box-shadow: 0 -5px 15px rgba(0, 0, 0, 0.3);
-        }
-        
-        /* レスポンシブ調整 */
-        @media (max-width: 768px) {
-            .story-container {
-                padding: 20px;
-                margin: 10px;
-            }
-            
-            h1 {
-                font-size: 1.8rem;
-            }
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第7話「全部は試せない、という優しさ」
     </header>
@@ -391,6 +262,7 @@
         
         <p>ナギの笑顔は、少し遠くて、でも前よりずっと近く感じられた。</p>
     </div>
+  </main>
 
     <div class="footer">
         &copy; 魔界歓楽街 サキュバスメイド喫茶《∞（インフィニティ）》

--- a/story8.html
+++ b/story8.html
@@ -9,47 +9,28 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" onload="renderMathInElement(document.body);"></script>
-    <style>
-        /* 追加スタイル: コントラスト強化とカラフルな要素 */
-        body {
-            background: linear-gradient(135deg, #ffdd57, #ff4081, #1e90ff);
-            background-attachment: fixed;
-            color: #222;
-        }
-        .container {
-            background: rgba(255,255,255,0.95);
-            border: 5px dashed #ff4081;
-        }
-        pre {
-            background: #222 !important;
-            color: #ffdd57 !important;
-            border: 3px solid #1e90ff;
-            font-weight: bold;
-            padding: 15px;
-        }
-        .character {
-            background: linear-gradient(45deg, #ffdd57, #ffcc00);
-            border: 4px dotted #ff4081;
-        }
-        .footer {
-            background: #1e90ff;
-            font-weight: bold;
-            text-shadow: 2px 2px 0 #000;
-        }
-        h2 {
-            text-shadow: 3px 3px 0 #ffdd57;
-            color: #ff4081;
-        }
-        /* 虹の弧を表現する装飾 */
-        .rainbow-arc {
-            height: 10px;
-            background: linear-gradient(90deg, blue, red, orange);
-            margin: 10px 0;
-            border-radius: 5px;
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         テストは世界の見方を設計する ─ 第8話「カバレッジの虹を見上げて」
     </header>
@@ -297,6 +278,7 @@
         <!-- 虹の弧を可視化 -->
         <div class="rainbow-arc"></div>
     </div>
+  </main>
 
     <div class="footer">
         © テストは世界の見方を設計する | 魔界歓楽街シリーズ

--- a/story9.html
+++ b/story9.html
@@ -19,202 +19,28 @@
             });
         });
     </script>
-    <style>
-        body {
-            font-family: 'Arial', sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #ffdd57; /* Bold pop art colors */
-            color: #333;
-        }
-
-        header {
-            background-color: #ff4081;
-            color: white;
-            padding: 10px 0;
-            text-align: center;
-            position: relative;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
-            text-transform: uppercase;
-            font-weight: bold;
-            font-size: 2.5rem;
-            animation: glow 1.5s infinite alternate;
-        }
-
-        @media (max-width: 768px) {
-            header {
-                font-size: 1.8rem; /* Smaller font for mobile devices */
-            }
-        }
-
-        @keyframes glow {
-            from {
-                text-shadow: 0 0 10px #ff4081, 0 0 20px #ff4081;
-            }
-            to {
-                text-shadow: 0 0 30px #ff4081, 0 0 40px #ff4081;
-            }
-        }
-
-        .container {
-            max-width: 1000px;
-            margin: 20px auto;
-            padding: 20px;
-            background-color: white;
-            border-radius: 15px;
-            box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
-            animation: popEffect 1s ease-in-out;
-        }
-
-        @keyframes popEffect {
-            0% {
-                transform: scale(0.8);
-                opacity: 0.6;
-            }
-            100% {
-                transform: scale(1);
-                opacity: 1;
-            }
-        }
-
-        h2 {
-            color: #ff4081;
-            font-size: 2rem;
-            font-weight: bold;
-        }
-
-        a {
-            text-decoration: none;
-            color: #1e90ff;
-            font-weight: bold;
-            transition: all 0.3s ease;
-        }
-
-        a:hover {
-            text-decoration: underline;
-            color: #ff4081;
-            text-shadow: 0 0 5px #ff4081;
-        }
-
-        img {
-            width: 100%;
-            max-width: 400px;
-            height: auto;
-            display: block;
-            margin: 10px auto;
-            border-radius: 10px;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-        }
-
-        table {
-            border-collapse: collapse;
-            width: 100%;
-        }
-
-        th, td {
-            border: 2px solid black;
-            padding: 8px;
-            text-align: left;
-        }
-
-        pre {
-            background-color: #f4f4f4;
-            padding: 10px;
-            border-radius: 5px;
-            overflow-x: auto; /* Allow horizontal scrolling */
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            max-width: 100%; /* Ensure it fits within the container */
-            box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.2);
-            color: #333; /* 白文字バグ修正 */
-            border: 2px solid #ff4081; /* カラフルな枠線追加 */
-        }
-
-        .footer {
-            text-align: center;
-            padding: 10px;
-            background-color: #ff4081;
-            color: white;
-            position: fixed;
-            bottom: 0;
-            width: 100%;
-        }
-
-        .character {
-            margin-bottom: 30px;
-            border: 3px solid #ff4081;
-            padding: 20px;
-            border-radius: 10px;
-            background: #ffdd57;
-            box-shadow: 5px 5px 15px rgba(0, 0, 0, 0.1);
-            transition: all 0.3s ease;
-        }
-
-        .character:hover {
-            transform: scale(1.05);
-            background-color: #ffcc00;
-            box-shadow: 10px 10px 20px rgba(0, 0, 0, 0.2);
-        }
-
-        @media (max-width: 768px) {
-            .container {
-                width: 90%;
-            }
-        }
-
-        /* KaTeXの数式がはみ出ないようにするためのスタイル */
-        .katex {
-            font-size: 1.1em !important; /* 数式のフォントサイズを調整 */
-            overflow-x: auto; /* 横スクロールを許可 */
-            overflow-y: hidden; /* 縦スクロールは不要 */
-            max-width: 100%; /* コンテナ幅に合わせる */
-            white-space: nowrap; /* 数式が折り返されないようにする */
-        }
-
-        .katex-display {
-            margin: 0.5em 0; /* 数式の上下の余白を調整 */
-            overflow-x: auto; /* 横スクロールを許可 */
-            max-width: 100%; /* コンテナ幅に合わせる */
-        }
-
-        /* 追加のカラフルスタイル */
-        .highlight {
-            background-color: #ff4081;
-            color: white;
-            padding: 2px 5px;
-            border-radius: 3px;
-        }
-
-        .quote {
-            border-left: 5px solid #1e90ff;
-            padding-left: 15px;
-            margin: 15px 0;
-            font-style: italic;
-            background-color: #f0f8ff;
-            padding: 10px;
-            border-radius: 0 10px 10px 0;
-        }
-
-        .log-entry {
-            background: linear-gradient(90deg, #ff4081, #1e90ff);
-            color: white;
-            padding: 15px;
-            border-radius: 10px;
-            margin: 10px 0;
-            box-shadow: 0 5px 15px rgba(0,0,0,0.2);
-        }
-
-        .scene-change {
-            text-align: center;
-            margin: 20px 0;
-            font-weight: bold;
-            color: #ff4081;
-            text-shadow: 0 0 5px rgba(255,64,129,0.5);
-        }
-    </style>
 </head>
 <body>
+
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+  <div class="topbar-inner">
+    <a class="brand" href="index.html" aria-label="トップページへ">
+      <div class="mark" aria-hidden="true"></div>
+      <div class="brand-title">
+        <b>結城ユイの成長物語</b>
+        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+      </div>
+    </a>
+    <nav class="nav" aria-label="関連ナビゲーション">
+      <a href="index.html#episodes">12話一覧</a>
+      <a href="index.html#about">紹介</a>
+      <a class="cta" href="index.html">トップへ戻る</a>
+    </nav>
+  </div>
+</header>
+  <main id="content">
+
     <header>
         第9話「ログは、システムからのラブレター」
     </header>
@@ -331,6 +157,7 @@
 
         <p>それはまるで、《∞》からユイへ届き続ける、少し不器用なラブレターのように見えた。</p>
     </div>
+  </main>
 
     <div class="footer">
         &copy; 魔界歓楽街のサキュバスメイド喫茶《∞》シリーズ


### PR DESCRIPTION
## Summary
- restyle all story subpages with the Ruri Gem palette and shared glassmorphism
- add shared top navigation linking back to the index and episode list
- centralize story page layout, cards, and utility styles in a single stylesheet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950237b021083338cb24302d455a315)