### PR TITLE
Improve story1 TTS voice selection and pacing

### DIFF
--- a/story1.html
+++ b/story1.html
@@ -36,6 +36,17 @@
     <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
         <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
         <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
         <label for="speechRate">速度:
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
@@ -293,7 +304,10 @@
                 pauseId: "speechPause",
                 statusId: "speechStatus",
                 rateId: "speechRate",
-                rateValueId: "speechRateValue"
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/tts.js
+++ b/tts.js
@@ -5,6 +5,9 @@ export function initStoryTTS({
   statusId = "speechStatus",
   rateId = "speechRate",
   rateValueId = "speechRateValue",
+  voiceSelectId = "ttsVoice",
+  voiceLabelId = "voiceSelectionStatus",
+  presetId = "ttsPreset",
 } = {}) {
   const storyElement = document.querySelector(storySelector);
   const toggleButton = document.getElementById(toggleId);
@@ -12,13 +15,25 @@ export function initStoryTTS({
   const statusElement = document.getElementById(statusId);
   const rateInput = document.getElementById(rateId);
   const rateValue = document.getElementById(rateValueId);
+  const voiceSelect = document.getElementById(voiceSelectId);
+  const voiceLabel = document.getElementById(voiceLabelId);
+  const presetSelect = document.getElementById(presetId);
 
   const speechSupported =
     typeof window !== "undefined" &&
     "speechSynthesis" in window &&
     "SpeechSynthesisUtterance" in window;
 
-  if (!toggleButton || !pauseButton || !statusElement || !rateInput || !rateValue) {
+  if (
+    !toggleButton ||
+    !pauseButton ||
+    !statusElement ||
+    !rateInput ||
+    !rateValue ||
+    !voiceSelect ||
+    !voiceLabel ||
+    !presetSelect
+  ) {
     return;
   }
 
@@ -29,6 +44,47 @@ export function initStoryTTS({
   let isReading = false;
   let isPaused = false;
   let rate = parseFloat(rateInput.value) || 1.0;
+  let pitch = 1.0;
+  let volume = 1.0;
+  let pendingTimeout = null;
+  const storageKeys = {
+    voice: "story-tts-voice",
+    preset: "story-tts-preset",
+  };
+  let currentPreset = localStorage.getItem(storageKeys.preset) || "calmFemale";
+  const presets = {
+    default: { label: "通常", rate: 1.0, pitch: 1.0, volume: 1.0 },
+    calmFemale: { label: "落ち着いた女性ナレーション", rate: 0.9, pitch: 1.14, volume: 1.0 },
+    custom: { label: "カスタム", rate: rate, pitch: pitch, volume: volume },
+  };
+
+  function applyPreset(name, { updateSelect = true } = {}) {
+    const preset = presets[name] || presets.calmFemale;
+    currentPreset = name;
+    if (name === "custom") {
+      rate = preset.rate ?? rate;
+      pitch = preset.pitch ?? pitch;
+      volume = preset.volume ?? volume;
+      rateInput.value = rate;
+    } else {
+      rate = preset.rate;
+      pitch = preset.pitch;
+      volume = preset.volume;
+      rateInput.value = preset.rate;
+    }
+    updateRateDisplay();
+    if (updateSelect) {
+      presetSelect.value = name;
+    }
+    localStorage.setItem(storageKeys.preset, name);
+  }
+
+  function markCustomPreset() {
+    currentPreset = "custom";
+    presets.custom = { ...presets.custom, rate, pitch, volume };
+    presetSelect.value = "custom";
+    localStorage.setItem(storageKeys.preset, "custom");
+  }
 
   function setStatus(text) {
     statusElement.textContent = text;
@@ -49,12 +105,15 @@ export function initStoryTTS({
     rateValue.textContent = Number(rateInput.value).toFixed(1);
   }
 
-  function pickVoice() {
-    if (!speechSupported) return;
-    const voices = synth.getVoices();
-    selectedVoice =
-      voices.find((voice) => voice.lang && voice.lang.toLowerCase().startsWith("ja")) ||
-      voices.find((voice) => voice.lang && voice.lang.toLowerCase().includes("ja"));
+  function setVoiceLabel(text) {
+    voiceLabel.textContent = text || "音声を取得中...";
+  }
+
+  function clearPendingTimeout() {
+    if (pendingTimeout) {
+      clearTimeout(pendingTimeout);
+      pendingTimeout = null;
+    }
   }
 
   function splitByNaturalBreaks(text, limit = 80) {
@@ -81,6 +140,20 @@ export function initStoryTTS({
     return results;
   }
 
+  function normalizeSpeechText(text) {
+    if (!text) return "";
+    let normalized = text;
+    normalized = normalized.replace(/……+/g, "… 。");
+    normalized = normalized.replace(/―+|──+/g, "。 ");
+    normalized = normalized.replace(/《∞（インフィニティ）》/g, "インフィニティ");
+    normalized = normalized.replace(/\bSNS\b/gi, "エスエヌエス");
+    normalized = normalized.replace(/フロア\s*A/gi, "フロア エー");
+    normalized = normalized.replace(/[「『]/g, "");
+    normalized = normalized.replace(/[」』]/g, "");
+    normalized = normalized.replace(/\s{2,}/g, " ");
+    return normalized.trim();
+  }
+
   function createChunks(text) {
     const cleanText = text
       .replace(/\s+\n/g, "\n")
@@ -88,7 +161,7 @@ export function initStoryTTS({
       .replace(/\s{2,}/g, " ")
       .trim();
     const sentences = cleanText
-      .split(/(?<=[。！？\?])/)
+      .split(/(?<=[。！？\?])|(?<=！)|(?<=？)/)
       .map((part) => part.trim())
       .filter(Boolean);
 
@@ -103,8 +176,170 @@ export function initStoryTTS({
     return finalChunks;
   }
 
+  function isJapaneseVoice(voice) {
+    return voice.lang && voice.lang.toLowerCase().startsWith("ja");
+  }
+
+  function includesKeyword(voice, keywords) {
+    const lowerName = voice.name.toLowerCase();
+    return keywords.some((kw) => lowerName.includes(kw.toLowerCase()));
+  }
+
+  function chooseVoice(voices) {
+    const savedVoiceId = localStorage.getItem(storageKeys.voice);
+    const femaleKeywords = ["female", "女性", "女", "kyoko", "haruka", "ayumi", "nanami", "mizuki", "sayaka", "hikari"];
+    const maleKeywords = ["male", "男性", "男", "otoya", "ichiro", "hiroshi", "takeo"];
+
+    if (savedVoiceId) {
+      const saved = voices.find((voice) => voice.voiceURI === savedVoiceId);
+      if (saved) return saved;
+    }
+
+    const jaVoices = voices.filter(isJapaneseVoice);
+    const targetList = jaVoices.length ? jaVoices : voices;
+    const femaleCandidates = targetList.filter(
+      (voice) => includesKeyword(voice, femaleKeywords) && !includesKeyword(voice, maleKeywords)
+    );
+    if (femaleCandidates.length) {
+      return femaleCandidates[0];
+    }
+    const nonMale = targetList.filter((voice) => !includesKeyword(voice, maleKeywords));
+    if (nonMale.length) {
+      return nonMale[0];
+    }
+    return targetList[0] || null;
+  }
+
+  function buildVoiceOptions() {
+    if (!speechSupported) return;
+    const voices = synth.getVoices();
+    voiceSelect.innerHTML = "";
+    const prioritized = voices.filter(isJapaneseVoice);
+    const remainder = voices.filter((v) => !isJapaneseVoice(v));
+    const orderedVoices = [...prioritized, ...remainder];
+    if (!orderedVoices.length) {
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "音声を準備中...";
+      voiceSelect.appendChild(placeholder);
+      setVoiceLabel("音声を取得中...");
+      return;
+    }
+
+    orderedVoices.forEach((voice) => {
+      const option = document.createElement("option");
+      option.value = voice.voiceURI;
+      option.textContent = `${voice.name} (${voice.lang || "unknown"})`;
+      voiceSelect.appendChild(option);
+    });
+
+    selectedVoice = chooseVoice(orderedVoices);
+    if (selectedVoice) {
+      voiceSelect.value = selectedVoice.voiceURI;
+      setVoiceLabel(`${selectedVoice.name} / ${selectedVoice.lang || "lang不明"}`);
+      localStorage.setItem(storageKeys.voice, selectedVoice.voiceURI);
+    }
+  }
+
+  function handleVoiceChange() {
+    if (!speechSupported) return;
+    const voices = synth.getVoices();
+    const nextVoice = voices.find((voice) => voice.voiceURI === voiceSelect.value);
+    if (nextVoice) {
+      selectedVoice = nextVoice;
+      localStorage.setItem(storageKeys.voice, nextVoice.voiceURI);
+      setVoiceLabel(`${nextVoice.name} / ${nextVoice.lang || "lang不明"}`);
+    }
+  }
+
+  function pauseDurationFromText(chunk, fallback = 250) {
+    if (chunk && typeof chunk.pauseAfter === "number") return chunk.pauseAfter;
+    const text = chunk?.text || "";
+    const trimmed = text.trim();
+    const lastChar = trimmed.slice(-1);
+    if (lastChar === "。") return 320;
+    if (lastChar === "！" || lastChar === "!") return 380;
+    if (lastChar === "？" || lastChar === "?") return 380;
+    return fallback;
+  }
+
+  function speechItemsFromStory() {
+    if (!storyElement) return [];
+    const queue = [];
+
+    const traverse = (node) => {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node;
+        if (el.dataset && el.dataset.tts === "ignore") return;
+
+        if (el.classList.contains("scene-break")) {
+          queue.push({ pauseOnly: true, pauseAfter: 1000 });
+          return;
+        }
+
+        if (el.matches("h2")) {
+          const text = normalizeSpeechText(el.innerText);
+          if (text) queue.push({ text, pauseAfter: 450 });
+          return;
+        }
+
+        if (el.classList.contains("dialogue")) {
+          const nameEl = el.querySelector(".character-name");
+          const speaker = nameEl ? nameEl.textContent.trim() : "";
+          const contentParts = [];
+          el.childNodes.forEach((child) => {
+            if (child === nameEl) return;
+            if (child.nodeType === Node.TEXT_NODE) {
+              contentParts.push(child.textContent);
+            } else if (child.nodeType === Node.ELEMENT_NODE && !child.matches(".character-name")) {
+              contentParts.push(child.textContent);
+            }
+          });
+          const dialogueText = normalizeSpeechText(contentParts.join(" "));
+          const finalText = speaker ? `${speaker}。 ${dialogueText}` : dialogueText;
+          if (finalText) queue.push({ text: finalText, pauseAfter: 350 });
+          return;
+        }
+
+        if (el.matches("p")) {
+          const text = normalizeSpeechText(el.innerText);
+          if (text) queue.push({ text, pauseAfter: 600 });
+          return;
+        }
+      }
+
+      if (node.childNodes && node.childNodes.length) {
+        node.childNodes.forEach((child) => traverse(child));
+      }
+    };
+
+    traverse(storyElement);
+    return queue;
+  }
+
+  function expandQueue(items) {
+    const expanded = [];
+    items.forEach((item) => {
+      if (item.pauseOnly) {
+        expanded.push({ pauseOnly: true, pauseAfter: item.pauseAfter });
+        return;
+      }
+      const parts = createChunks(item.text);
+      if (!parts.length) return;
+      parts.forEach((part, idx) => {
+        const isLast = idx === parts.length - 1;
+        expanded.push({
+          text: part,
+          pauseAfter: isLast ? item.pauseAfter : 220,
+        });
+      });
+    });
+    return expanded;
+  }
+
   function stopSpeech(reason = "停止") {
     if (speechSupported) {
+      clearPendingTimeout();
       synth.cancel();
     }
     isReading = false;
@@ -123,9 +358,23 @@ export function initStoryTTS({
       return;
     }
 
-    const utterance = new SpeechSynthesisUtterance(chunks[currentIndex]);
+    const chunk = chunks[currentIndex];
+    if (chunk.pauseOnly) {
+      setStatus(`読み上げ中 ${Math.min(currentIndex + 1, chunks.length)}/${chunks.length}`);
+      pendingTimeout = setTimeout(() => {
+        pendingTimeout = null;
+        if (!isReading) return;
+        currentIndex += 1;
+        speakNext();
+      }, chunk.pauseAfter || 400);
+      return;
+    }
+
+    const utterance = new SpeechSynthesisUtterance(chunk.text);
     utterance.lang = "ja-JP";
     utterance.rate = rate;
+    utterance.pitch = pitch;
+    utterance.volume = volume;
     if (selectedVoice) {
       utterance.voice = selectedVoice;
     }
@@ -134,7 +383,11 @@ export function initStoryTTS({
       if (!isReading) return;
       currentIndex += 1;
       setStatus(`読み上げ中 ${Math.min(currentIndex + 1, chunks.length)}/${chunks.length}`);
-      speakNext();
+      const wait = pauseDurationFromText(chunk, 300);
+      pendingTimeout = setTimeout(() => {
+        pendingTimeout = null;
+        speakNext();
+      }, wait);
     };
 
     utterance.onerror = () => {
@@ -147,12 +400,12 @@ export function initStoryTTS({
 
   function startSpeech() {
     if (!speechSupported) return;
-    const text = storyElement?.innerText?.trim();
-    if (!text) {
-      setStatus("本文が見つかりません");
-      return;
+    clearPendingTimeout();
+    if (!selectedVoice) {
+      buildVoiceOptions();
     }
-    chunks = createChunks(text);
+    const items = speechItemsFromStory();
+    chunks = expandQueue(items);
     if (!chunks.length) {
       setStatus("本文が見つかりません");
       return;
@@ -176,6 +429,7 @@ export function initStoryTTS({
   function togglePause() {
     if (!speechSupported || !isReading) return;
     if (!isPaused) {
+      clearPendingTimeout();
       synth.pause();
       isPaused = true;
       setPauseState(true, true);
@@ -184,7 +438,11 @@ export function initStoryTTS({
       synth.resume();
       isPaused = false;
       setPauseState(true, false);
-      setStatus(`読み上げ中 ${currentIndex + 1}/${chunks.length}`);
+      if (!synth.speaking && !pendingTimeout) {
+        speakNext();
+      } else {
+        setStatus(`読み上げ中 ${currentIndex + 1}/${chunks.length}`);
+      }
     }
   }
 
@@ -194,22 +452,36 @@ export function initStoryTTS({
     }
   }
 
+  if (!presets[currentPreset]) {
+    currentPreset = "calmFemale";
+  }
+  applyPreset(currentPreset);
+  setVoiceLabel("音声を取得中...");
+
   if (!speechSupported) {
     toggleButton.disabled = true;
     pauseButton.disabled = true;
+    voiceSelect.disabled = true;
+    presetSelect.disabled = true;
+    setVoiceLabel("このブラウザでは読み上げが利用できません");
     setStatus("このブラウザでは読み上げが利用できません");
     updateRateDisplay();
     return;
   }
 
-  pickVoice();
-  synth.addEventListener("voiceschanged", pickVoice);
+  buildVoiceOptions();
+  synth.addEventListener("voiceschanged", buildVoiceOptions);
 
   toggleButton.addEventListener("click", toggleSpeech);
   pauseButton.addEventListener("click", togglePause);
   rateInput.addEventListener("input", () => {
     rate = parseFloat(rateInput.value) || 1.0;
     updateRateDisplay();
+    markCustomPreset();
+  });
+  voiceSelect.addEventListener("change", handleVoiceChange);
+  presetSelect.addEventListener("change", (event) => {
+    applyPreset(event.target.value, { updateSelect: false });
   });
   document.addEventListener("visibilitychange", handleVisibilityChange);
 


### PR DESCRIPTION
## Summary
- add voice selection and preset controls to story1 so users can pick or persist a preferred Japanese female voice
- rework TTS text preparation with dialogue-aware queueing, normalization, and pause handling for cleaner narration pacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504d02465483339bcff87b42f18b60)