### PR TITLE
Add TTS support to remaining story pages

### DIFF
--- a/story10.html
+++ b/story10.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第10話「魔導書と職人の手、Fθと G」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>サキュバスメイド喫茶《∞（インフィニティ）》の新人テストエンジニア・結城ユイ（ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれ、世界 <span class="katex">W</span> の見方を育ててきた。客を同値クラスでまとめ、心の境界値にぶつかり、決定表で分岐を地図にし、状態遷移図で関係を眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹でテストの濃淡を確かめ、ログを「システムからのラブレター」と読むようになった。</p>
@@ -130,6 +151,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story11.html
+++ b/story11.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第11話「先輩も、迷っていた」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>サキュバスメイド喫茶《∞》の新人テストエンジニア・ユイ（ユイリア）は、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という神崎ナギの言葉に導かれ、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジの虹、ログ解析、そして魔導書 Fθ と現場写像 G といった道具を手にしてきた。いつかナギのように <span class="katex">W</span> と制約 <span class="katex">E</span> から観点 <span class="katex">S</span> を選び取りたいと願い始めている。</p>
@@ -161,6 +182,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story12.html
+++ b/story12.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第12話「次の子に渡す、G の地図」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>サキュバスメイド喫茶《∞（インフィニティ）》で新人テストエンジニアとして働き始めたユイリア。場当たり運営でオープン初夜を炎上させかけた彼女は、伝説のテストアーキテクト神崎ナギと出会い、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という言葉に導かれる。仕様書の外に広がる世界 <span class="katex">W</span> と制約 <span class="katex">E</span> を意識し、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジ、ログ解析、魔導書 Fθ と写像 <span class="katex">G</span> などの道具を手にしてきた。</p>
@@ -123,6 +144,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story2.html
+++ b/story2.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第2話「世界 W は、仕様書の外に広がってる」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》オープン初夜、新人サキュバスで“なんでも屋のダメダメテストエンジニア”結城ユイ（源氏名ユイリア）は感覚だけでイベントを回し、店を炎上寸前にしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームのログとメモを一瞥しただけで「客のパターン」を整理し、あっという間に状況を見える化。ユイは同じ世界を見ているはずなのに全く違う景色を切り取る先輩の背中に、強く憧れ始める。</p>
@@ -257,6 +278,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story3.html
+++ b/story3.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第3話「同値クラスという、お守りの石」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街にオープンしたサキュバスメイド喫茶《∞（インフィニティ）》。新人メイド・ユイリアこと結城ユイは、“なんでも屋のダメダメテストエンジニア”として場当たりでイベントを回し、オープン初夜にクレーム祭りを引き起こしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、山のようなクレームログを一瞥しただけで客を三つのパターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
@@ -282,6 +303,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story4.html
+++ b/story4.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第4話「境界線を、一緒に歩いた夜」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で働く新人メイド兼テストエンジニア・結城ユイ（ユイリア）は、場当たり運営でオープン初夜を炎上させてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、クレームログを一瞬で三つの客パターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
@@ -214,6 +235,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story5.html
+++ b/story5.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第5話「分岐の森と、先輩の地図」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、テストエンジニア見習いとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させてしまう。しかし現れた伝説級テストアーキテクト・神崎ナギが、クレームログを三つの客パターンに整理して見せ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
@@ -225,6 +246,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story6.html
+++ b/story6.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第6話「関係は、状態遷移で語れる」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で見習いテストエンジニアとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させかける。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームを三つの客パターンに整理してみせ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
@@ -190,6 +211,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story7.html
+++ b/story7.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第7話「全部は試せない、という優しさ」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働き始めた結城ユイ──ユイリアは、炎上しかけたオープン初夜を伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」と教わる。その後、世界 <span class="katex">W</span> が仕様書の外側まで広がること、同値クラスでばらばらの客をまとめられること、境界値分析で踏み込み方を調整できること、決定表で分岐を地図にできること、状態遷移図で関係の変化を見通せることを少しずつ身に付け、図で世界を扱う感覚を育てている。</p>
@@ -182,6 +203,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story8.html
+++ b/story8.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第8話「カバレッジの虹を見上げて」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働く結城ユイ──源氏名ユイリア。場当たり運営で炎上しかけたオープン初夜、伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」だと知る。</p>
@@ -150,6 +171,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>

--- a/story9.html
+++ b/story9.html
@@ -10,7 +10,7 @@
 <body>
 
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner">
+<header class="topbar" role="banner" data-tts="ignore">
   <div class="topbar-inner">
     <a class="brand" href="index.html" aria-label="トップページへ">
       <div class="mark" aria-hidden="true"></div>
@@ -32,7 +32,28 @@
         第9話「ログは、システムからのラブレター」
     </header>
 
-    <div class="container">
+    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        <label for="ttsVoice">音声:
+            <select id="ttsVoice" name="ttsVoice"></select>
+        </label>
+        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
+        <label for="ttsPreset">プリセット:
+            <select id="ttsPreset" name="ttsPreset">
+                <option value="default">通常</option>
+                <option value="calmFemale">落ち着いた女性ナレーション</option>
+                <option value="custom">カスタム</option>
+            </select>
+        </label>
+        <label for="speechRate">速度:
+            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
+            <span id="speechRateValue">1.0</span>
+        </label>
+        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
+    </section>
+
+    <div class="container" id="story">
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>新人テストエンジニア・結城ユイ（源氏名ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれながら、サキュバスメイド喫茶《∞（インフィニティ）》で世界 <span class="katex">W</span> の見方を学び続けている。客を同値クラスで捉え、境界値で踏み込み方を調整し、決定表で分岐を地図にし、状態遷移図で関係の揺れを眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹で自分のテストの濃淡を確かめるようになった。</p>
@@ -154,6 +175,23 @@
                     {left: '\\(', right: '\\)', display: false},
                     {left: '\\[', right: '\\]', display: true}
                 ]
+            });
+        });
+    </script>
+    <script type="module">
+        import { initStoryTTS } from "./tts.js";
+
+        document.addEventListener("DOMContentLoaded", () => {
+            initStoryTTS({
+                storySelector: "#story",
+                toggleId: "speechToggle",
+                pauseId: "speechPause",
+                statusId: "speechStatus",
+                rateId: "speechRate",
+                rateValueId: "speechRateValue",
+                voiceSelectId: "ttsVoice",
+                voiceLabelId: "voiceSelectionStatus",
+                presetId: "ttsPreset"
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- add the story1 text-to-speech controls to story2–story12 pages
- mark headers as non-readable, identify story containers, and keep existing story text intact
- load the shared tts module on each page alongside existing assets

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505946dd788333830da2cfbfe5f80d)