### PR TITLE
Add beat playback controls to story pages 2-12

### DIFF
--- a/pop3_style.css
+++ b/pop3_style.css
@@ -378,6 +378,26 @@ img{
   background: linear-gradient(180deg, rgba(255,211,122,.14), rgba(9,16,40,.60));
 }
 
+/* 読み上げUI: ビート設定 */
+.tts-beat-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 10px;
+  align-items: flex-end;
+}
+.tts-beat-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+}
+.tts-beat-note {
+  font-size: 12px;
+  color: #555;
+  margin-top: 6px;
+}
+
 @media (max-width: 720px){
   .nav a{ padding:9px 10px; }
   body > header:not(.topbar){ font-size: clamp(20px, 5vw, 26px); padding: 18px 18px 14px; }

--- a/story10.html
+++ b/story10.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -156,8 +169,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -167,7 +187,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story11.html
+++ b/story11.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -187,8 +200,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -198,7 +218,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story12.html
+++ b/story12.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -149,8 +162,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -160,7 +180,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story2.html
+++ b/story2.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -283,8 +296,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -294,7 +314,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story3.html
+++ b/story3.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -308,8 +321,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -319,7 +339,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story4.html
+++ b/story4.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -240,8 +253,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -251,7 +271,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story5.html
+++ b/story5.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -251,8 +264,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -262,7 +282,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story6.html
+++ b/story6.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -216,8 +229,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -227,7 +247,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story7.html
+++ b/story7.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -208,8 +221,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -219,7 +239,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story8.html
+++ b/story8.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -176,8 +189,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -187,7 +207,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>

--- a/story9.html
+++ b/story9.html
@@ -50,6 +50,19 @@
             <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
             <span id="speechRateValue">1.0</span>
         </label>
+        <div class="tts-beat-row">
+            <label for="beatPreset">ビート:
+                <select id="beatPreset" name="beatPreset">
+                    <option value="calm">明るい・落ち着く</option>
+                    <option value="hype">テンション上げる</option>
+                    <option value="neutral">当たり障りない（人ビート）</option>
+                </select>
+            </label>
+            <label for="beatVolume">ビート音量:
+                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
+            </label>
+        </div>
+        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
         <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
@@ -180,8 +193,15 @@
     </script>
     <script type="module">
         import { initStoryTTS } from "./tts.js";
+        import { initBeatController } from "./beat.js";
 
         document.addEventListener("DOMContentLoaded", () => {
+            const beatController = initBeatController({
+                presetSelectId: "beatPreset",
+                volumeSliderId: "beatVolume",
+                duckLevel: 0.72,
+            });
+
             initStoryTTS({
                 storySelector: "#story",
                 toggleId: "speechToggle",
@@ -191,7 +211,17 @@
                 rateValueId: "speechRateValue",
                 voiceSelectId: "ttsVoice",
                 voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset"
+                presetId: "ttsPreset",
+                onStart: () => {
+                    beatController.start();
+                    beatController.duck();
+                },
+                onStop: () => {
+                    beatController.stop();
+                    beatController.unduck();
+                },
+                onPause: () => beatController.unduck(),
+                onResume: () => beatController.duck(),
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- add shared beat control styling to the shared CSS
- add beat preset and volume controls to story pages 2-12
- synchronize beat playback start/stop/ducking with TTS callbacks on every story page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950b18483f08333bda3a5859859fcec)