### PR TITLE
Simplify narration UI and add master volume control

### DIFF
--- a/narration.js
+++ b/narration.js
@@ -1,0 +1,148 @@
+import { initStoryTTS } from "./tts.js";
+import { initBeatController } from "./beat.js";
+
+const storageKeys = {
+  voicePreset: "story-voice-preset",
+  beatPreset: "story-beat-preset",
+  masterVolume: "story-master-volume",
+};
+
+const defaultVolumes = {
+  master: 0.85,
+};
+
+const voicePresets = {
+  calmFemale: { label: "落ち着いた女性", preferNames: ["Kyoko", "Mizuki", "Sayaka", "Nanami"], lang: "ja", pitch: 1.08, rateMul: 0.95 },
+  brightFemale: { label: "明るめ女性", preferNames: ["Hikari", "Haruka", "Ayumi"], lang: "ja", pitch: 1.05, rateMul: 1.02 },
+  calmMale: { label: "落ち着いた男性", preferNames: ["Ichiro", "Otoya"], lang: "ja", pitch: 0.95, rateMul: 0.98 },
+  auto: { label: "おまかせ", preferNames: [], lang: "ja", pitch: 1.0, rateMul: 1.0 },
+};
+
+function clamp(val, min, max) {
+  return Math.min(Math.max(val, min), max);
+}
+
+function readNumber(key, fallback) {
+  try {
+    const v = parseFloat(localStorage.getItem(key));
+    if (Number.isFinite(v)) return v;
+  } catch {
+    /* ignore */
+  }
+  return fallback;
+}
+
+function readString(key, fallback) {
+  try {
+    const v = localStorage.getItem(key);
+    if (v) return v;
+  } catch {
+    /* ignore */
+  }
+  return fallback;
+}
+
+function saveValue(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function initNarration() {
+  const toggle = document.getElementById("speechToggle");
+  const pause = document.getElementById("speechPause");
+  const voicePresetSelect = document.getElementById("voicePreset");
+  const beatPresetSelect = document.getElementById("beatPreset");
+  const masterVolume = document.getElementById("masterVolume");
+  const masterVolumeValue = document.getElementById("masterVolumeValue");
+  const tempoStatus = document.getElementById("tempoStatus");
+
+  if (!toggle || !voicePresetSelect || !beatPresetSelect || !masterVolume) return;
+
+  const storedVoicePreset = readString(storageKeys.voicePreset, "calmFemale");
+  const storedBeatPreset = readString(storageKeys.beatPreset, "calm");
+  const storedMaster = clamp(readNumber(storageKeys.masterVolume, defaultVolumes.master), 0, 1);
+
+  masterVolume.value = storedMaster;
+  if (masterVolumeValue) {
+    masterVolumeValue.textContent = storedMaster.toFixed(2);
+  }
+
+  const beatController = initBeatController({
+    presetSelectId: "beatPreset",
+    duckLevel: 0.72,
+  });
+
+  if (storedBeatPreset) {
+    beatController.setPreset(storedBeatPreset);
+    beatPresetSelect.value = storedBeatPreset;
+  }
+
+  const tts = initStoryTTS({
+    voicePresetId: "voicePreset",
+    onStart: () => {
+      beatController.start();
+      beatController.duck();
+    },
+    onStop: () => {
+      beatController.stop();
+      beatController.unduck();
+    },
+    onPause: () => beatController.unduck(),
+    onResume: () => beatController.duck(),
+    voicePresets,
+  });
+
+  function updateTempoStatus(bpm, rate) {
+    if (!tempoStatus) return;
+    tempoStatus.textContent = `BPM ${bpm.toFixed(0)} / rate ${rate.toFixed(2)}`;
+  }
+
+  function syncRateWithBeat() {
+    const bpm = beatController.getBpm ? beatController.getBpm() : 120;
+    const presetId = voicePresetSelect.value || "calmFemale";
+    const preset = voicePresets[presetId];
+    let rate = clamp(bpm / 120, 0.8, 1.35);
+    if (preset?.rateMul) {
+      rate = clamp(rate * preset.rateMul, 0.6, 1.6);
+    }
+    tts.setRate(rate);
+    updateTempoStatus(bpm, rate);
+  }
+
+  syncRateWithBeat();
+  tts.setVoicePreset(voicePresetSelect.value);
+
+  function applyMasterVolume(vol) {
+    const clamped = clamp(vol, 0, 1);
+    const beatVol = beatController.setMasterVolume ? beatController.setMasterVolume(clamped) : clamped;
+    const ttsVol = tts.setVolume ? tts.setVolume(clamped) : clamped;
+    if (masterVolumeValue) {
+      masterVolumeValue.textContent = clamped.toFixed(2);
+    }
+    saveValue(storageKeys.masterVolume, clamped.toString());
+    return { beatVol, ttsVol };
+  }
+
+  applyMasterVolume(storedMaster);
+
+  beatPresetSelect.addEventListener("change", (e) => {
+    beatController.setPreset(e.target.value);
+    saveValue(storageKeys.beatPreset, e.target.value);
+    syncRateWithBeat();
+  });
+
+  masterVolume.addEventListener("input", (e) => {
+    const vol = Number(e.target.value) || 0;
+    applyMasterVolume(vol);
+  });
+
+  voicePresetSelect.addEventListener("change", (e) => {
+    const id = e.target.value;
+    saveValue(storageKeys.voicePreset, id);
+    tts.setVoicePreset(id);
+    syncRateWithBeat();
+  });
+}

--- a/pop3_style.css
+++ b/pop3_style.css
@@ -378,24 +378,58 @@ img{
   background: linear-gradient(180deg, rgba(255,211,122,.14), rgba(9,16,40,.60));
 }
 
-/* 読み上げUI: ビート設定 */
-.tts-beat-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 10px;
-  align-items: flex-end;
+/* 読み上げUI */
+.tts-controls{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  align-items:flex-start;
+  padding:12px 14px;
+  margin: 8px 0 18px;
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: var(--radius2);
+  background: linear-gradient(180deg, rgba(12,23,54,.85), rgba(9,16,40,.70));
+  box-shadow: var(--shadow2);
 }
-.tts-beat-row label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 14px;
+.tts-controls label{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  flex:1 1 220px;
+  min-width: min(260px, 100%);
+  font-size:14px;
+  color: var(--muted);
 }
-.tts-beat-note {
-  font-size: 12px;
-  color: #555;
-  margin-top: 6px;
+.tts-controls select,
+.tts-controls input[type=\"range\"]{
+  width:100%;
+}
+.tts-row.buttons{
+  display:flex;
+  gap:10px;
+  flex:1 1 220px;
+}
+.tts-row.buttons button{
+  flex:1;
+}
+.tts-note{
+  flex:1 1 100%;
+  font-size:13px;
+  color: var(--muted2);
+}
+.tts-status{
+  flex:1 1 100%;
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  font-size:13px;
+  color: var(--muted2);
+}
+#mixStatus{
+  color: #8fa2d8;
+}
+#tempoStatus{
+  color: #ffd37a;
 }
 
 @media (max-width: 720px){

--- a/story1.html
+++ b/story1.html
@@ -7,32 +7,6 @@
     <link rel="stylesheet" href="pop3_style.css">
     <!-- KaTeX CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-    <style>
-      /* 追加: 読み上げUI内のビート設定 */
-      .tts-beat-row {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
-        margin-top: 10px;
-        align-items: flex-end;
-      }
-      .tts-beat-row label {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-        font-size: 14px;
-      }
-      .tts-beat-note {
-        font-size: 12px;
-        color: #555;
-        margin-top: 6px;
-      }
-      #mixStatus {
-        font-size: 12px;
-        color: #666;
-        margin-top: 4px;
-      }
-    </style>
 </head>
 <body>
 
@@ -60,42 +34,31 @@
     </header>
 
     <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.8" max="1.4" step="0.05" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <label for="speechVolume">読み上げ音量:
-            <input type="range" id="speechVolume" name="speechVolume" min="0.6" max="1.0" step="0.05" value="0.85">
-            <span id="speechVolumeValue">0.85</span>
-        </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
-        <div id="mixStatus" aria-live="polite"></div>
     </section>
     
     <div class="container" id="story">
@@ -339,38 +302,9 @@
         });
     </script>
     <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            // 既存TTSを拡張: 読み上げ開始/停止でビートを連動
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story10.html
+++ b/story10.html
@@ -32,39 +32,34 @@
         第10話「魔導書と職人の手、Fθと G」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -167,38 +162,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story11.html
+++ b/story11.html
@@ -32,39 +32,34 @@
         第11話「先輩も、迷っていた」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -198,38 +193,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story12.html
+++ b/story12.html
@@ -32,39 +32,34 @@
         第12話「次の子に渡す、G の地図」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -160,38 +155,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story2.html
+++ b/story2.html
@@ -33,37 +33,31 @@
     </header>
 
     <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
 
     <div class="container" id="story">
@@ -295,37 +289,9 @@
         });
     </script>
     <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story3.html
+++ b/story3.html
@@ -32,39 +32,34 @@
         第3話「同値クラスという、お守りの石」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -319,38 +314,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story4.html
+++ b/story4.html
@@ -32,39 +32,34 @@
         第4話「境界線を、一緒に歩いた夜」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -251,38 +246,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story5.html
+++ b/story5.html
@@ -32,39 +32,34 @@
         第5話「分岐の森と、先輩の地図」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -262,38 +257,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story6.html
+++ b/story6.html
@@ -32,39 +32,34 @@
         第6話「関係は、状態遷移で語れる」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -227,38 +222,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story7.html
+++ b/story7.html
@@ -32,39 +32,34 @@
         第7話「全部は試せない、という優しさ」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -219,38 +214,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story8.html
+++ b/story8.html
@@ -32,39 +32,34 @@
         第8話「カバレッジの虹を見上げて」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -187,38 +182,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>

--- a/story9.html
+++ b/story9.html
@@ -32,39 +32,34 @@
         第9話「ログは、システムからのラブレター」
     </header>
 
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-        <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        <label for="ttsVoice">音声:
-            <select id="ttsVoice" name="ttsVoice"></select>
+        <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
+        <div class="tts-row buttons">
+          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
+          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
+        </div>
+        <label for="voicePreset">音声プリセット
+            <select id="voicePreset" name="voicePreset"></select>
         </label>
-        <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        <label for="ttsPreset">プリセット:
-            <select id="ttsPreset" name="ttsPreset">
-                <option value="default">通常</option>
-                <option value="calmFemale">落ち着いた女性ナレーション</option>
-                <option value="custom">カスタム</option>
+        <label for="beatPreset">ビート
+            <select id="beatPreset" name="beatPreset">
+                <option value="calm">明るい・落ち着く</option>
+                <option value="hype">テンション上げる</option>
+                <option value="neutral">当たり障りない（人ビート）</option>
             </select>
         </label>
-        <label for="speechRate">速度:
-            <input type="range" id="speechRate" name="speechRate" min="0.7" max="1.3" step="0.1" value="1">
-            <span id="speechRateValue">1.0</span>
+        <label for="masterVolume">音量 VOL
+            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
+            <span id="masterVolumeValue">0.85</span>
         </label>
-        <div class="tts-beat-row">
-            <label for="beatPreset">ビート:
-                <select id="beatPreset" name="beatPreset">
-                    <option value="calm">明るい・落ち着く</option>
-                    <option value="hype">テンション上げる</option>
-                    <option value="neutral">当たり障りない（人ビート）</option>
-                </select>
-            </label>
-            <label for="beatVolume">ビート音量:
-                <input type="range" id="beatVolume" name="beatVolume" min="0" max="1" step="0.05" value="0.5">
-            </label>
+        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+        <div class="tts-status">
+          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
+          <span id="tempoStatus" aria-live="polite"></span>
+          <span id="mixStatus" aria-live="polite"></span>
+          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
         </div>
-        <div class="tts-beat-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div id="speechStatus" role="status" aria-live="polite">準備中...</div>
     </section>
+
 
     <div class="container" id="story">
         <div class="section">
@@ -191,38 +186,10 @@
             });
         });
     </script>
-    <script type="module">
-        import { initStoryTTS } from "./tts.js";
-        import { initBeatController } from "./beat.js";
-
+        <script type="module">
+        import { initNarration } from "./narration.js";
         document.addEventListener("DOMContentLoaded", () => {
-            const beatController = initBeatController({
-                presetSelectId: "beatPreset",
-                volumeSliderId: "beatVolume",
-                duckLevel: 0.72,
-            });
-
-            initStoryTTS({
-                storySelector: "#story",
-                toggleId: "speechToggle",
-                pauseId: "speechPause",
-                statusId: "speechStatus",
-                rateId: "speechRate",
-                rateValueId: "speechRateValue",
-                voiceSelectId: "ttsVoice",
-                voiceLabelId: "voiceSelectionStatus",
-                presetId: "ttsPreset",
-                onStart: () => {
-                    beatController.start();
-                    beatController.duck();
-                },
-                onStop: () => {
-                    beatController.stop();
-                    beatController.unduck();
-                },
-                onPause: () => beatController.unduck(),
-                onResume: () => beatController.duck(),
-            });
+            initNarration();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Simplified the TTS/beat controls on every story page to the required five inputs with responsive styling and status displays.
- Added a narration glue module to coordinate voice presets, beat presets, tempo/rate syncing, and shared master volume with localStorage defaults.
- Extended beat.js and tts.js with master gain, BPM access, voice preset selection, and pause scaling so volume/rate changes apply across playback.

## Testing
- Not run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950dd42d34c8333a0d10394ec54e49a)