### PR TITLE
Ensure narration controls initialize reliably across stories

### DIFF
--- a/narration-init.js
+++ b/narration-init.js
@@ -1,0 +1,15 @@
+import { initNarration } from "./narration.js";
+
+function runWhenReady(fn) {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", fn, { once: true });
+  } else {
+    fn();
+  }
+}
+
+runWhenReady(() => initNarration({ reason: "ready" }));
+
+window.addEventListener("pageshow", (e) => {
+  if (e.persisted) initNarration({ reason: "bfcache", force: true });
+});

--- a/narration.js
+++ b/narration.js
@@ -1,6 +1,14 @@
 import { initStoryTTS } from "./tts.js";
 import { initBeatController } from "./beat.js";
 
+export const VOICE_PRESETS = {
+  auto: { label: "自動（おすすめ）", preferNames: [], lang: "ja", pitch: 1.0, rateMul: 1.0 },
+  calmFemale: { label: "落ち着いた女性", preferNames: ["Kyoko", "Mizuki", "Sayaka", "Nanami"], lang: "ja", pitch: 1.04, rateMul: 0.96 },
+  brightFemale: { label: "明るい女性", preferNames: ["Hikari", "Haruka", "Ayumi"], lang: "ja", pitch: 1.05, rateMul: 1.05 },
+  maleLow: { label: "低めの男性", preferNames: ["Ichiro", "Otoya"], lang: "ja", pitch: 0.92, rateMul: 0.98 },
+  narrator: { label: "ナレーター（中立）", preferNames: [], lang: "ja", pitch: 1.0, rateMul: 1.0 },
+};
+
 const storageKeys = {
   voicePreset: "story-voice-preset",
   beatPreset: "story-beat-preset",
@@ -11,12 +19,7 @@ const defaultVolumes = {
   master: 0.85,
 };
 
-const voicePresets = {
-  calmFemale: { label: "落ち着いた女性", preferNames: ["Kyoko", "Mizuki", "Sayaka", "Nanami"], lang: "ja", pitch: 1.08, rateMul: 0.95 },
-  brightFemale: { label: "明るめ女性", preferNames: ["Hikari", "Haruka", "Ayumi"], lang: "ja", pitch: 1.05, rateMul: 1.02 },
-  calmMale: { label: "落ち着いた男性", preferNames: ["Ichiro", "Otoya"], lang: "ja", pitch: 0.95, rateMul: 0.98 },
-  auto: { label: "おまかせ", preferNames: [], lang: "ja", pitch: 1.0, rateMul: 1.0 },
-};
+let activeControllers = null;
 
 function clamp(val, min, max) {
   return Math.min(Math.max(val, min), max);
@@ -50,99 +53,213 @@ function saveValue(key, value) {
   }
 }
 
-export function initNarration() {
-  const toggle = document.getElementById("speechToggle");
-  const pause = document.getElementById("speechPause");
-  const voicePresetSelect = document.getElementById("voicePreset");
-  const beatPresetSelect = document.getElementById("beatPreset");
-  const masterVolume = document.getElementById("masterVolume");
-  const masterVolumeValue = document.getElementById("masterVolumeValue");
-  const tempoStatus = document.getElementById("tempoStatus");
-
-  if (!toggle || !voicePresetSelect || !beatPresetSelect || !masterVolume) return;
-
-  const storedVoicePreset = readString(storageKeys.voicePreset, "calmFemale");
-  const storedBeatPreset = readString(storageKeys.beatPreset, "calm");
-  const storedMaster = clamp(readNumber(storageKeys.masterVolume, defaultVolumes.master), 0, 1);
-
-  masterVolume.value = storedMaster;
-  if (masterVolumeValue) {
-    masterVolumeValue.textContent = storedMaster.toFixed(2);
-  }
-
-  const beatController = initBeatController({
-    presetSelectId: "beatPreset",
-    duckLevel: 0.72,
+function populateVoicePresetOptions(selectEl, initialValue = "auto") {
+  if (!selectEl) return "auto";
+  selectEl.innerHTML = "";
+  Object.entries(VOICE_PRESETS).forEach(([id, preset]) => {
+    const opt = document.createElement("option");
+    opt.value = id;
+    opt.textContent = preset.label;
+    selectEl.appendChild(opt);
   });
-
-  if (storedBeatPreset) {
-    beatController.setPreset(storedBeatPreset);
-    beatPresetSelect.value = storedBeatPreset;
+  if (selectEl.options.length === 0) {
+    const fallback = document.createElement("option");
+    fallback.value = "auto";
+    fallback.textContent = "自動（おすすめ）";
+    selectEl.appendChild(fallback);
   }
+  const value = VOICE_PRESETS[initialValue] ? initialValue : "auto";
+  selectEl.value = value;
+  return value;
+}
 
-  const tts = initStoryTTS({
-    voicePresetId: "voicePreset",
-    onStart: () => {
-      beatController.start();
-      beatController.duck();
-    },
-    onStop: () => {
-      beatController.stop();
-      beatController.unduck();
-    },
-    onPause: () => beatController.unduck(),
-    onResume: () => beatController.duck(),
-    voicePresets,
-  });
+export function initNarration({ reason = "manual", force = false } = {}) {
+  const statusEl = document.getElementById("speechStatus");
 
-  function updateTempoStatus(bpm, rate) {
-    if (!tempoStatus) return;
-    tempoStatus.textContent = `BPM ${bpm.toFixed(0)} / rate ${rate.toFixed(2)}`;
-  }
-
-  function syncRateWithBeat() {
-    const bpm = beatController.getBpm ? beatController.getBpm() : 120;
-    const presetId = voicePresetSelect.value || "calmFemale";
-    const preset = voicePresets[presetId];
-    let rate = clamp(bpm / 120, 0.8, 1.35);
-    if (preset?.rateMul) {
-      rate = clamp(rate * preset.rateMul, 0.6, 1.6);
+  const fail = (message, error = null) => {
+    if (statusEl) {
+      statusEl.textContent = `初期化失敗: ${message}（コンソールも確認）`;
     }
-    tts.setRate(rate);
-    updateTempoStatus(bpm, rate);
-  }
-
-  syncRateWithBeat();
-  tts.setVoicePreset(voicePresetSelect.value);
-
-  function applyMasterVolume(vol) {
-    const clamped = clamp(vol, 0, 1);
-    const beatVol = beatController.setMasterVolume ? beatController.setMasterVolume(clamped) : clamped;
-    const ttsVol = tts.setVolume ? tts.setVolume(clamped) : clamped;
-    if (masterVolumeValue) {
-      masterVolumeValue.textContent = clamped.toFixed(2);
+    if (error) {
+      console.error("[narration] init failed", error);
     }
-    saveValue(storageKeys.masterVolume, clamped.toString());
-    return { beatVol, ttsVol };
+  };
+
+  try {
+    let controls = document.querySelector(".tts-controls");
+    if (!controls) {
+      fail("必須要素(.tts-controls)が見つかりません");
+      return null;
+    }
+
+    if (activeControllers && force) {
+      try {
+        activeControllers.tts?.stop?.();
+      } catch (e) {
+        console.error("[narration] stop tts on force", e);
+      }
+      try {
+        activeControllers.beat?.stop?.();
+      } catch (e) {
+        console.error("[narration] stop beat on force", e);
+      }
+      activeControllers = null;
+    }
+
+    if (controls.dataset.initialized === "1" && !force) {
+      if (statusEl) statusEl.textContent = "準備OK";
+      return activeControllers;
+    }
+
+    if (controls.dataset.initialized === "1" && force) {
+      const replacement = controls.cloneNode(true);
+      controls.replaceWith(replacement);
+      controls = replacement;
+    }
+
+    const storyElement = document.querySelector("#story");
+    if (!storyElement) {
+      fail("必須要素が見つかりません (#story)");
+      return null;
+    }
+
+    const requiredIds = {
+      toggle: "speechToggle",
+      pause: "speechPause",
+      voicePreset: "voicePreset",
+      beatPreset: "beatPreset",
+      masterVolume: "masterVolume",
+      status: "speechStatus",
+    };
+
+    const required = Object.fromEntries(Object.entries(requiredIds).map(([key, id]) => [key, document.getElementById(id)]));
+
+    const missing = Object.entries(required)
+      .filter(([, el]) => !el)
+      .map(([key]) => requiredIds[key]);
+
+    if (missing.length) {
+      fail(`必須要素が見つかりません (${missing.join(", ")})`);
+      return null;
+    }
+
+    const optional = {
+      masterVolumeValue: document.getElementById("masterVolumeValue"),
+      tempoStatus: document.getElementById("tempoStatus"),
+      mixStatus: document.getElementById("mixStatus"),
+      voiceSelectionStatus: document.getElementById("voiceSelectionStatus"),
+    };
+
+    required.status.textContent = "準備中...";
+    if (optional.voiceSelectionStatus) {
+      optional.voiceSelectionStatus.textContent = "音声を取得中...";
+    }
+
+    const storedVoicePreset = readString(storageKeys.voicePreset, "auto");
+    const storedBeatPreset = readString(storageKeys.beatPreset, "calm");
+    const storedMaster = clamp(readNumber(storageKeys.masterVolume, defaultVolumes.master), 0, 1);
+
+    required.masterVolume.value = storedMaster;
+    if (optional.masterVolumeValue) {
+      optional.masterVolumeValue.textContent = storedMaster.toFixed(2);
+    }
+
+    const voicePresetValue = populateVoicePresetOptions(required.voicePreset, storedVoicePreset);
+
+    const beatController = initBeatController({
+      presetSelectId: "beatPreset",
+      duckLevel: 0.72,
+    });
+
+    if (storedBeatPreset) {
+      beatController.setPreset(storedBeatPreset);
+      required.beatPreset.value = storedBeatPreset;
+    }
+
+    const tts = initStoryTTS({
+      toggleId: "speechToggle",
+      pauseId: "speechPause",
+      statusId: "speechStatus",
+      voicePresetId: "voicePreset",
+      voiceLabelId: optional.voiceSelectionStatus ? "voiceSelectionStatus" : undefined,
+      onStart: () => {
+        beatController.start();
+        beatController.duck();
+      },
+      onStop: () => {
+        beatController.stop();
+        beatController.unduck();
+      },
+      onPause: () => beatController.unduck(),
+      onResume: () => beatController.duck(),
+      voicePresets: VOICE_PRESETS,
+    });
+
+    if (!tts) {
+      controls.dataset.initialized = "1";
+      controls.dataset.initReason = reason;
+      return null;
+    }
+
+    function updateTempoStatus(bpm, rate) {
+      if (!optional.tempoStatus) return;
+      optional.tempoStatus.textContent = `BPM ${bpm.toFixed(0)} / rate ${rate.toFixed(2)}`;
+    }
+
+    function syncRateWithBeat() {
+      const bpm = beatController.getBpm ? beatController.getBpm() : 120;
+      const presetId = required.voicePreset.value || "auto";
+      const preset = VOICE_PRESETS[presetId];
+      let rate = clamp(bpm / 120, 0.8, 1.35);
+      if (preset?.rateMul) {
+        rate = clamp(rate * preset.rateMul, 0.6, 1.6);
+      }
+      tts.setRate(rate);
+      updateTempoStatus(bpm, rate);
+    }
+
+    tts.setVoicePreset(voicePresetValue);
+    syncRateWithBeat();
+
+    function applyMasterVolume(vol) {
+      const clamped = clamp(vol, 0, 1);
+      const beatVol = beatController.setMasterVolume ? beatController.setMasterVolume(clamped) : clamped;
+      const ttsVol = tts.setVolume ? tts.setVolume(clamped) : clamped;
+      if (optional.masterVolumeValue) {
+        optional.masterVolumeValue.textContent = clamped.toFixed(2);
+      }
+      saveValue(storageKeys.masterVolume, clamped.toString());
+      return { beatVol, ttsVol };
+    }
+
+    applyMasterVolume(storedMaster);
+
+    required.beatPreset.addEventListener("change", (e) => {
+      beatController.setPreset(e.target.value);
+      saveValue(storageKeys.beatPreset, e.target.value);
+      syncRateWithBeat();
+    });
+
+    required.masterVolume.addEventListener("input", (e) => {
+      const vol = Number(e.target.value) || 0;
+      applyMasterVolume(vol);
+    });
+
+    required.voicePreset.addEventListener("change", (e) => {
+      const id = e.target.value;
+      saveValue(storageKeys.voicePreset, id);
+      tts.setVoicePreset(id);
+      syncRateWithBeat();
+    });
+
+    controls.dataset.initialized = "1";
+    controls.dataset.initReason = reason;
+    required.status.textContent = "準備OK";
+
+    activeControllers = { beat: beatController, tts };
+    return activeControllers;
+  } catch (error) {
+    fail(error?.message || String(error), error);
+    return null;
   }
-
-  applyMasterVolume(storedMaster);
-
-  beatPresetSelect.addEventListener("change", (e) => {
-    beatController.setPreset(e.target.value);
-    saveValue(storageKeys.beatPreset, e.target.value);
-    syncRateWithBeat();
-  });
-
-  masterVolume.addEventListener("input", (e) => {
-    const vol = Number(e.target.value) || 0;
-    applyMasterVolume(vol);
-  });
-
-  voicePresetSelect.addEventListener("change", (e) => {
-    const id = e.target.value;
-    saveValue(storageKeys.voicePreset, id);
-    tts.setVoicePreset(id);
-    syncRateWithBeat();
-  });
 }

--- a/story1.html
+++ b/story1.html
@@ -39,7 +39,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -301,11 +303,6 @@
             });
         });
     </script>
-    <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+    <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story10.html
+++ b/story10.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -162,11 +164,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story11.html
+++ b/story11.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -193,11 +195,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story12.html
+++ b/story12.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -155,11 +157,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story2.html
+++ b/story2.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -288,11 +290,6 @@
             });
         });
     </script>
-    <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+    <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story3.html
+++ b/story3.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -314,11 +316,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story4.html
+++ b/story4.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -246,11 +248,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story5.html
+++ b/story5.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -257,11 +259,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story6.html
+++ b/story6.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -222,11 +224,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story7.html
+++ b/story7.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -214,11 +216,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story8.html
+++ b/story8.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -182,11 +184,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>

--- a/story9.html
+++ b/story9.html
@@ -38,7 +38,9 @@
           <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
         </div>
         <label for="voicePreset">音声プリセット
-            <select id="voicePreset" name="voicePreset"></select>
+            <select id="voicePreset" name="voicePreset">
+                <option value="auto">自動（おすすめ）</option>
+            </select>
         </label>
         <label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
@@ -186,11 +188,6 @@
             });
         });
     </script>
-        <script type="module">
-        import { initNarration } from "./narration.js";
-        document.addEventListener("DOMContentLoaded", () => {
-            initNarration();
-        });
-    </script>
+        <script type="module" src="./narration-init.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize narration initialization through a shared module with BFCache-safe re-entry
- harden TTS preset handling and voice selection fallback to default voices when unavailable
- add fallback voice preset options to every story page and surface initialization errors to the UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950ece6691c833390a283c00af7b6e5)