### PR TITLE
Add experiment plan export CLI and templates

### DIFF
--- a/config/experiment.yaml
+++ b/config/experiment.yaml
@@ -1,0 +1,54 @@
+name: "Template Experiment Plan"
+description: "Experiments across story templates to compare engagement and completion performance."
+templates:
+  - key: hina
+    template_name: "Hina Story"
+    summary: "AI-hosted persona narrative tailored for new visitors."
+    metrics:
+      - name: completion_rate
+        description: "Percentage of sessions reaching the final Hina card."
+        target: "Increase completions relative to control."
+      - name: avg_dwell_time
+        description: "Average seconds spent on the Hina story page."
+        target: "Lift time-on-page for narrative-driven sessions."
+    events:
+      - name: story_load
+        when: "When a Hina story page is shown."
+        properties: ["story_id", "template", "traffic_source"]
+      - name: story_complete
+        when: "When a user finishes the Hina narrative."
+        properties: ["story_id", "template", "duration_seconds"]
+  - key: immersive
+    template_name: "Immersive Panel"
+    summary: "Swipeable immersive reading flow for engaged users."
+    metrics:
+      - name: scroll_depth
+        description: "Median scroll depth across immersive panels."
+        target: "Reach 75% median scroll depth."
+      - name: interaction_rate
+        description: "Share of users interacting with swipe or tap actions."
+        target: "Improve gesture interactions session-over-session."
+    events:
+      - name: panel_swipe
+        when: "On each swipe between immersive panels."
+        properties: ["story_id", "panel_index", "direction", "template"]
+      - name: cta_click
+        when: "When the immersive CTA is clicked."
+        properties: ["story_id", "cta_destination", "template"]
+  - key: magazine
+    template_name: "Magazine Layout"
+    summary: "Editorial-style layout for users browsing multiple articles."
+    metrics:
+      - name: article_click_through
+        description: "Click-through rate from magazine grid to articles."
+        target: "Lift CTR compared to classic listing."
+      - name: session_pages_viewed
+        description: "Average articles opened per session."
+        target: "Reach 2.0+ articles per session."
+    events:
+      - name: grid_impression
+        when: "When the magazine grid loads."
+        properties: ["section", "template", "story_count"]
+      - name: article_open
+        when: "When a user opens an article from the grid."
+        properties: ["story_id", "position", "template"]

--- a/docs/experiment-plan.md
+++ b/docs/experiment-plan.md
@@ -1,0 +1,51 @@
+# Experiment Plan: Template Experiment Plan
+
+Experiments across story templates to compare engagement and completion performance.
+
+## hina – Hina Story
+
+AI-hosted persona narrative tailored for new visitors.
+
+### Metrics
+- **completion_rate**: Percentage of sessions reaching the final Hina card. | Target: Increase completions relative to control.
+- **avg_dwell_time**: Average seconds spent on the Hina story page. | Target: Lift time-on-page for narrative-driven sessions.
+
+### Events
+- **story_load**
+  - When: When a Hina story page is shown.
+  - Properties: story_id, template, traffic_source
+- **story_complete**
+  - When: When a user finishes the Hina narrative.
+  - Properties: story_id, template, duration_seconds
+
+## immersive – Immersive Panel
+
+Swipeable immersive reading flow for engaged users.
+
+### Metrics
+- **scroll_depth**: Median scroll depth across immersive panels. | Target: Reach 75% median scroll depth.
+- **interaction_rate**: Share of users interacting with swipe or tap actions. | Target: Improve gesture interactions session-over-session.
+
+### Events
+- **panel_swipe**
+  - When: On each swipe between immersive panels.
+  - Properties: story_id, panel_index, direction, template
+- **cta_click**
+  - When: When the immersive CTA is clicked.
+  - Properties: story_id, cta_destination, template
+
+## magazine – Magazine Layout
+
+Editorial-style layout for users browsing multiple articles.
+
+### Metrics
+- **article_click_through**: Click-through rate from magazine grid to articles. | Target: Lift CTR compared to classic listing.
+- **session_pages_viewed**: Average articles opened per session. | Target: Reach 2.0+ articles per session.
+
+### Events
+- **grid_impression**
+  - When: When the magazine grid loads.
+  - Properties: section, template, story_count
+- **article_open**
+  - When: When a user opens an article from the grid.
+  - Properties: story_id, position, template

--- a/sitegen/cli.py
+++ b/sitegen/cli.py
@@ -1,6 +1,75 @@
 """Command-line interface for sitegen."""
 
 import argparse
+from pathlib import Path
+from typing import Iterable, Optional
+
+import yaml
+
+from .models import ExperimentPlan
+
+
+def _experiment_plan_to_markdown(plan: ExperimentPlan) -> str:
+    """Render an ExperimentPlan as a simple Markdown document."""
+    lines: list[str] = []
+    lines.append(f"# Experiment Plan: {plan.name}")
+    if plan.description:
+        lines.append("")
+        lines.append(plan.description)
+    lines.append("")
+
+    for template in plan.templates:
+        lines.append(f"## {template.key} – {template.template_name}")
+        if template.summary:
+            lines.append("")
+            lines.append(template.summary)
+        lines.append("")
+
+        lines.append("### Metrics")
+        if template.metrics:
+            for metric in template.metrics:
+                parts: list[str] = [f"- **{metric.name}**"]
+                details: list[str] = []
+                if metric.description:
+                    details.append(metric.description)
+                if metric.target:
+                    details.append(f"Target: {metric.target}")
+                if details:
+                    parts[-1] += f": {' | '.join(details)}"
+                lines.extend(parts)
+        else:
+            lines.append("- None specified.")
+        lines.append("")
+
+        lines.append("### Events")
+        if template.events:
+            for event in template.events:
+                lines.append(f"- **{event.name}**")
+                if event.when:
+                    lines.append(f"  - When: {event.when}")
+                if event.properties:
+                    props = ", ".join(event.properties)
+                    lines.append(f"  - Properties: {props}")
+        else:
+            lines.append("- None specified.")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _load_experiment_plan(path: Path) -> ExperimentPlan:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return ExperimentPlan.parse_obj(data)
+
+
+def _handle_export_docs(args: argparse.Namespace) -> None:
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    plan = _load_experiment_plan(input_path)
+    output = _experiment_plan_to_markdown(plan)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(output, encoding="utf-8")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -14,12 +83,43 @@ def build_parser() -> argparse.ArgumentParser:
         version="sitegen 0.1.0",
         help="Show the sitegen version and exit.",
     )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    plan_parser = subparsers.add_parser(
+        "plan", help="Experiment plan utilities", description="Experiment plan tools."
+    )
+    plan_subparsers = plan_parser.add_subparsers(dest="plan_command")
+
+    export_parser = plan_subparsers.add_parser(
+        "export-docs",
+        help="Export experiment plan documentation from YAML.",
+        description="Validate experiment YAML and export a Markdown summary.",
+    )
+    export_parser.add_argument(
+        "--in",
+        dest="input",
+        required=True,
+        help="Path to the experiment plan YAML file.",
+    )
+    export_parser.add_argument(
+        "--out",
+        dest="output",
+        required=True,
+        help="Path to write the generated Markdown.",
+    )
+    export_parser.set_defaults(func=_handle_export_docs)
+
     return parser
 
 
-def main() -> None:
+def main(argv: Optional[Iterable[str]] = None) -> None:
     parser = build_parser()
-    parser.parse_args()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
 
 
 __all__ = ["build_parser", "main"]

--- a/sitegen/models.py
+++ b/sitegen/models.py
@@ -1,6 +1,59 @@
 """Pydantic models for site generation."""
 
-from pydantic import BaseModel
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Metric(BaseModel):
+    """Represents a measurable outcome for an experiment."""
+
+    name: str = Field(..., description="Short identifier for the metric.")
+    description: Optional[str] = Field(
+        None, description="What the metric means and why it matters."
+    )
+    target: Optional[str] = Field(
+        None, description="Goal or direction for the metric (e.g., higher is better)."
+    )
+
+
+class EventSpec(BaseModel):
+    """Defines an analytics event required for the experiment."""
+
+    name: str = Field(..., description="Event name as emitted to analytics.")
+    when: Optional[str] = Field(None, description="Trigger or scenario for the event.")
+    properties: List[str] = Field(
+        default_factory=list,
+        description="Event properties that must be recorded with the event.",
+    )
+
+
+class TemplateExperiment(BaseModel):
+    """Experiment design for a specific template variant."""
+
+    key: str = Field(..., description="Short handle for the template.")
+    template_name: str = Field(..., description="Display name of the template.")
+    summary: Optional[str] = Field(
+        None, description="Short description of the experiment intent."
+    )
+    metrics: List[Metric] = Field(
+        default_factory=list, description="Metrics to monitor during the experiment."
+    )
+    events: List[EventSpec] = Field(
+        default_factory=list, description="Events required for measurement."
+    )
+
+
+class ExperimentPlan(BaseModel):
+    """Top-level experiment plan covering multiple templates."""
+
+    name: str = Field(..., description="Overall name of the experiment plan.")
+    description: Optional[str] = Field(
+        None, description="High-level context about the plan."
+    )
+    templates: List[TemplateExperiment] = Field(
+        default_factory=list, description="Templates included in the plan."
+    )
 
 
 class SiteConfig(BaseModel):
@@ -10,4 +63,10 @@ class SiteConfig(BaseModel):
         arbitrary_types_allowed = True
 
 
-__all__ = ["SiteConfig"]
+__all__ = [
+    "EventSpec",
+    "ExperimentPlan",
+    "Metric",
+    "SiteConfig",
+    "TemplateExperiment",
+]


### PR DESCRIPTION
## Summary
- add Pydantic models for experiment plans, templates, metrics, and event specs
- add `plan export-docs` CLI to validate experiment YAML and export Markdown documentation
- include sample experiment configuration and generated experiment-plan documentation

## Testing
- Not run (dependency installation blocked by proxy; unable to install required packages in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69525b3534d48333ad22ac397507faef)