### PR TITLE
Add content validation schema and CLI command

### DIFF
--- a/config/experiences.yaml
+++ b/config/experiences.yaml
@@ -1,1 +1,10 @@
-[]
+- key: blog
+  name: "サンプル記事エクスペリエンス"
+  description: "sitegen の validate コマンド検証用のブログ風エクスペリエンス。"
+  supports:
+    locales: ["ja-JP"]
+    pageTypes: ["post"]
+    renderKinds: ["markdown", "external"]
+  routePatterns:
+    page: "/stories/{slug}"
+    data: "/data/routes/{slug}.json"

--- a/config/routes.json
+++ b/config/routes.json
@@ -1,0 +1,13 @@
+{
+  "experience": "blog",
+  "version": "1.0",
+  "generatedAt": "2024-01-01T00:00:00Z",
+  "routes": [
+    {
+      "href": "/stories/welcome-post",
+      "contentId": "welcome-post",
+      "pageType": "post",
+      "dataHref": "/data/routes/welcome-post.json"
+    }
+  ]
+}

--- a/content/posts/welcome.json
+++ b/content/posts/welcome.json
@@ -1,0 +1,13 @@
+{
+  "contentId": "welcome-post",
+  "experience": "blog",
+  "pageType": "post",
+  "title": "ようこそ、魔界喫茶《∞》へ",
+  "summary": "サイトジェネレータの検証用サンプルコンテンツ。",
+  "render": {
+    "kind": "markdown",
+    "markdown": "# ようこそ\n\nここは `sitegen validate` コマンドのためのサンプル記事です。"
+  },
+  "dataHref": "/data/routes/welcome-post.json",
+  "tags": ["sample", "intro"]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,49 @@ This document outlines the foundational terms for the site generator:
 - **pageType**: A category describing the layout or purpose of a page within an experience.
 - **contentId**: An identifier used to locate or reference specific content assets.
 - **routes.json**: A manifest describing the routes available in an experience.
-- **data-routes-href**: An attribute linking elements to route data sources.
 
-Further architectural details will be added as the generator evolves.
+## Data attribute contract
+
+Markup rendered by the generator is annotated with data attributes so that hydration and
+client-side navigation can resolve the correct assets:
+
+- `data-experience`: The experience key (e.g., `blog`) that owns the current DOM tree.
+- `data-page-type`: The page type used to select a template (e.g., `post`).
+- `data-content-id`: The stable `contentId` for the bound content item.
+- `data-routes-href`: An absolute or relative path to a `routes.json` payload.
+  This JSON follows the `RouteMap` schema and lists each route with its `href`,
+  `pageType`, `contentId`, and optional `dataHref`. Client code can dereference the
+  attribute to prefetch or hydrate navigation models without hard-coding URLs.
+
+Example linkage in markup:
+
+```html
+<nav
+  data-experience="blog"
+  data-page-type="post"
+  data-content-id="welcome-post"
+  data-routes-href="/config/routes.json"
+>
+  ...
+</nav>
+```
+
+The referenced `routes.json` would look like:
+
+```json
+{
+  "experience": "blog",
+  "version": "1.0",
+  "routes": [
+    {
+      "href": "/stories/welcome-post",
+      "pageType": "post",
+      "contentId": "welcome-post",
+      "dataHref": "/data/routes/welcome-post.json"
+    }
+  ]
+}
+```
+
+These conventions ensure that runtime components can discover routing metadata
+without coupling to build-time file layouts.

--- a/sitegen/cli.py
+++ b/sitegen/cli.py
@@ -1,12 +1,15 @@
 """Command-line interface for sitegen."""
 
 import argparse
+import json
+import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
 import yaml
+from pydantic import ValidationError
 
-from .models import ExperimentPlan
+from .models import ContentItem, ExperienceSpec, ExperimentPlan
 
 
 def _experiment_plan_to_markdown(plan: ExperimentPlan) -> str:
@@ -72,6 +75,76 @@ def _handle_export_docs(args: argparse.Namespace) -> None:
     output_path.write_text(output, encoding="utf-8")
 
 
+def _load_experiences(path: Path) -> list[ExperienceSpec]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    if not isinstance(data, list):
+        raise SystemExit("experiences.yaml must contain a list of experiences.")
+    try:
+        return [ExperienceSpec.model_validate(item) for item in data]
+    except ValidationError as exc:
+        raise SystemExit(f"Invalid experience spec in {path}: {exc}") from exc
+
+
+def _load_content_item(path: Path) -> ContentItem:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return ContentItem.model_validate(payload)
+
+
+def _handle_validate(args: argparse.Namespace) -> None:
+    experiences_path = Path(args.experiences)
+    content_dir = Path(args.content)
+
+    experiences = _load_experiences(experiences_path)
+    experience_index = {exp.key: exp for exp in experiences}
+
+    errors: list[str] = []
+    validated: list[ContentItem] = []
+
+    if not content_dir.exists():
+        raise SystemExit(f"Content directory not found: {content_dir}")
+
+    for json_path in sorted(content_dir.glob("*.json")):
+        try:
+            item = _load_content_item(json_path)
+            validated.append(item)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            errors.append(f"{json_path}: {exc}")
+            continue
+
+        if item.experience not in experience_index:
+            errors.append(
+                f"{json_path}: experience '{item.experience}' not found in "
+                f"{experiences_path.name}"
+            )
+            continue
+
+        spec = experience_index[item.experience]
+        if spec.supports.page_types and item.page_type not in spec.supports.page_types:
+            errors.append(
+                f"{json_path}: pageType '{item.page_type}' is not allowed "
+                f"for experience '{item.experience}'"
+            )
+
+        if spec.supports.render_kinds:
+            # Render contract has a discriminating field named kind.
+            render_kind = getattr(item.render, "kind", "")
+            if render_kind not in spec.supports.render_kinds:
+                errors.append(
+                    f"{json_path}: render kind '{render_kind}' not allowed; "
+                    f"supported kinds: {', '.join(spec.supports.render_kinds)}"
+                )
+
+    if errors:
+        for message in errors:
+            print(message, file=sys.stderr)
+        raise SystemExit(1)
+
+    print(
+        f"Validated {len(validated)} content items against "
+        f"{len(experience_index)} experiences."
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="sitegen",
@@ -109,6 +182,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to write the generated Markdown.",
     )
     export_parser.set_defaults(func=_handle_export_docs)
+
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Validate experiences.yaml and content posts.",
+        description=(
+            "Validate experience specifications and ensure content items match them."
+        ),
+    )
+    validate_parser.add_argument(
+        "--experiences",
+        required=True,
+        help="Path to experiences.yaml",
+    )
+    validate_parser.add_argument(
+        "--content",
+        required=True,
+        help="Directory containing content JSON files (e.g., content/posts).",
+    )
+    validate_parser.set_defaults(func=_handle_validate)
 
     return parser
 


### PR DESCRIPTION
## Summary
- define content, routing, and experience Pydantic models for sitegen
- add a validate subcommand that checks experiences.yaml against content JSON
- document the data attribute contract and add sample data for validation

## Testing
- python -m sitegen validate --experiences config/experiences.yaml --content content/posts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952610a4cac833382db938a14a44d8f)