### PR TITLE
Add IA plan models and export docs command

### DIFF
--- a/config/ia.yaml
+++ b/config/ia.yaml
@@ -1,0 +1,108 @@
+templates:
+  - key: hina
+    name: Hina
+    description: Light storytelling frame with quick scannability.
+    sections:
+      - title: home
+        summary: Story-forward landing with immediate engagement.
+        children:
+          - title: Hero headline
+            summary: Single key story with supporting dek and CTA.
+          - title: Fresh drops
+            summary: Horizontal cards highlighting latest entries.
+          - title: Category sampler
+            summary: Trio of featured topics with compact blurbs.
+          - title: Footer CTA
+            summary: Low-friction signup or follow action.
+      - title: list
+        summary: Browsable catalog for repeat visitors.
+        children:
+          - title: Page heading
+            summary: Context line with optional count and filter chips.
+          - title: Filter rail
+            summary: Sort, tags, and time-range selectors.
+          - title: Story grid
+            summary: Two-column cards with thumbnail, title, and tag pill.
+          - title: Pagination
+            summary: Numbered pagination plus next/previous links.
+      - title: detail
+        summary: Article detail tuned for quick read-through.
+        children:
+          - title: Title + dek
+            summary: Clear promise with social proof metadata.
+          - title: Feature visual
+            summary: Lead image or embed with caption.
+          - title: Body
+            summary: Sectioned narrative with pull quotes.
+          - title: Related stories
+            summary: Inline cluster to jump deeper.
+  - key: immersive
+    name: Immersive
+    description: Full-bleed, cinematic reading path.
+    sections:
+      - title: home
+        summary: Visually rich teaser surface.
+        children:
+          - title: Cover mosaic
+            summary: Full-width cards with parallax image focus.
+          - title: Timeline rail
+            summary: Scroll-linked preview of longform drops.
+          - title: Creator spotlight
+            summary: Bio snippet and latest feature for anchor author.
+      - title: list
+        summary: Longform queue with context.
+        children:
+          - title: Context banner
+            summary: Series description and reading time range.
+          - title: Immersive list
+            summary: Tall cards with hero media and key pull quote.
+          - title: Continue reading
+            summary: Sticky prompt to jump back into last read piece.
+      - title: detail
+        summary: Deep storytelling canvas.
+        children:
+          - title: Cinematic lead
+            summary: Full-bleed hero with overlay headline.
+          - title: Narrative flow
+            summary: Chapters marked by scrolly waypoints.
+          - title: Media interludes
+            summary: Inline galleries and clips for pacing.
+          - title: End slate
+            summary: Series navigation and share block.
+  - key: magazine
+    name: Magazine
+    description: Editorial grid suited to feature packages.
+    sections:
+      - title: home
+        summary: Package hub with multiple entry points.
+        children:
+          - title: Cover stack
+            summary: Lead story with supporting secondary stack.
+          - title: Rubric columns
+            summary: Multi-column mix of departments.
+          - title: Newsletter module
+            summary: Opt-in with promise of cadence.
+      - title: list
+        summary: Section landing tailored for skim.
+        children:
+          - title: Section masthead
+            summary: Section label and synopsis.
+          - title: Featured lead
+            summary: Highlight article with deck and byline.
+          - title: Card river
+            summary: Dense cards with bylines and tags.
+          - title: Archive pagination
+            summary: Jump to older issues via numbered pages.
+      - title: detail
+        summary: Feature article layout.
+        children:
+          - title: Masthead
+            summary: Title, dek, author, and publish metadata.
+          - title: Lead visual
+            summary: Prominent image with credit.
+          - title: Body
+            summary: Rich text with inline pull quotes.
+          - title: Sidebar
+            summary: Sticky references, links, or footnotes.
+          - title: Suggested reads
+            summary: Curated links to sibling pieces.

--- a/docs/ia/hina.md
+++ b/docs/ia/hina.md
@@ -1,0 +1,65 @@
+構造差の核
+
+# Hina (hina)
+
+Light storytelling frame with quick scannability.
+
+## home
+
+Story-forward landing with immediate engagement.
+
+### Hero headline
+
+Single key story with supporting dek and CTA.
+
+### Fresh drops
+
+Horizontal cards highlighting latest entries.
+
+### Category sampler
+
+Trio of featured topics with compact blurbs.
+
+### Footer CTA
+
+Low-friction signup or follow action.
+
+## list
+
+Browsable catalog for repeat visitors.
+
+### Page heading
+
+Context line with optional count and filter chips.
+
+### Filter rail
+
+Sort, tags, and time-range selectors.
+
+### Story grid
+
+Two-column cards with thumbnail, title, and tag pill.
+
+### Pagination
+
+Numbered pagination plus next/previous links.
+
+## detail
+
+Article detail tuned for quick read-through.
+
+### Title + dek
+
+Clear promise with social proof metadata.
+
+### Feature visual
+
+Lead image or embed with caption.
+
+### Body
+
+Sectioned narrative with pull quotes.
+
+### Related stories
+
+Inline cluster to jump deeper.

--- a/docs/ia/immersive.md
+++ b/docs/ia/immersive.md
@@ -1,0 +1,57 @@
+構造差の核
+
+# Immersive (immersive)
+
+Full-bleed, cinematic reading path.
+
+## home
+
+Visually rich teaser surface.
+
+### Cover mosaic
+
+Full-width cards with parallax image focus.
+
+### Timeline rail
+
+Scroll-linked preview of longform drops.
+
+### Creator spotlight
+
+Bio snippet and latest feature for anchor author.
+
+## list
+
+Longform queue with context.
+
+### Context banner
+
+Series description and reading time range.
+
+### Immersive list
+
+Tall cards with hero media and key pull quote.
+
+### Continue reading
+
+Sticky prompt to jump back into last read piece.
+
+## detail
+
+Deep storytelling canvas.
+
+### Cinematic lead
+
+Full-bleed hero with overlay headline.
+
+### Narrative flow
+
+Chapters marked by scrolly waypoints.
+
+### Media interludes
+
+Inline galleries and clips for pacing.
+
+### End slate
+
+Series navigation and share block.

--- a/docs/ia/magazine.md
+++ b/docs/ia/magazine.md
@@ -1,0 +1,65 @@
+構造差の核
+
+# Magazine (magazine)
+
+Editorial grid suited to feature packages.
+
+## home
+
+Package hub with multiple entry points.
+
+### Cover stack
+
+Lead story with supporting secondary stack.
+
+### Rubric columns
+
+Multi-column mix of departments.
+
+### Newsletter module
+
+Opt-in with promise of cadence.
+
+## list
+
+Section landing tailored for skim.
+
+### Section masthead
+
+Section label and synopsis.
+
+### Featured lead
+
+Highlight article with deck and byline.
+
+### Card river
+
+Dense cards with bylines and tags.
+
+### Archive pagination
+
+Jump to older issues via numbered pages.
+
+## detail
+
+Feature article layout.
+
+### Masthead
+
+Title, dek, author, and publish metadata.
+
+### Lead visual
+
+Prominent image with credit.
+
+### Body
+
+Rich text with inline pull quotes.
+
+### Sidebar
+
+Sticky references, links, or footnotes.
+
+### Suggested reads
+
+Curated links to sibling pieces.

--- a/sitegen/models.py
+++ b/sitegen/models.py
@@ -56,6 +56,39 @@ class ExperimentPlan(BaseModel):
     )
 
 
+class IASection(BaseModel):
+    """Node in an information architecture outline."""
+
+    title: str = Field(..., description="Heading or slot name.")
+    summary: Optional[str] = Field(
+        None, description="Short description of what appears in the section."
+    )
+    children: List["IASection"] = Field(
+        default_factory=list, description="Nested sections under the heading."
+    )
+
+
+class IATemplateSpec(BaseModel):
+    """Information architecture for a template family."""
+
+    key: str = Field(..., description="Identifier for the template style.")
+    name: str = Field(..., description="Human readable template name.")
+    description: Optional[str] = Field(
+        None, description="Short description of the layout intent."
+    )
+    sections: List[IASection] = Field(
+        default_factory=list, description="Hierarchy of headings for the template."
+    )
+
+
+class IAPlan(BaseModel):
+    """Collection of information architecture templates."""
+
+    templates: List[IATemplateSpec] = Field(
+        default_factory=list, description="Templates captured in the plan."
+    )
+
+
 class SiteConfig(BaseModel):
     """Placeholder for site configuration."""
 
@@ -207,6 +240,9 @@ __all__ = [
     "EventSpec",
     "ExperimentPlan",
     "ExperienceSpec",
+    "IAPlan",
+    "IASection",
+    "IATemplateSpec",
     "HtmlRender",
     "Metric",
     "RenderContract",


### PR DESCRIPTION
## Summary
- add IAPlan, IATemplateSpec, and IASection models to describe IA templates
- add `sitegen ia export-docs` command to render IA Markdown from YAML
- seed IA YAML for hina, immersive, and magazine and generate docs under docs/ia

## Testing
- python -m sitegen ia export-docs --in config/ia.yaml --out-dir docs/ia

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695266ecf8bc8333bfdc7a9a3d92cd61)