### PR TITLE
Translate documentation to Japanese

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,26 +1,26 @@
-# Architecture Overview
+# アーキテクチャ概要
 
-This document outlines the foundational terms for the site generator:
+このドキュメントは、サイトジェネレーターにおける基本用語をまとめています。
 
-- **experience**: A collection of pages or flows that share a common goal.
-- **pageType**: A category describing the layout or purpose of a page within an experience.
-- **contentId**: An identifier used to locate or reference specific content assets.
-- **routes.json**: A manifest describing the routes available in an experience.
+- **experience**: 共通の目的を持つページやフローの集合。
+- **pageType**: エクスペリエンス内でページのレイアウトや目的を表すカテゴリ。
+- **contentId**: 特定のコンテンツアセットを見つけたり参照したりするための識別子。
+- **routes.json**: エクスペリエンスで利用可能なルートを記述したマニフェスト。
 
-## Data attribute contract
+## データ属性の取り決め
 
-Markup rendered by the generator is annotated with data attributes so that hydration and
-client-side navigation can resolve the correct assets:
+ジェネレーターが生成するマークアップにはデータ属性が付与され、ハイドレーションや
+クライアントサイドのナビゲーションが正しいアセットを解決できるようになっています。
 
-- `data-experience`: The experience key (e.g., `blog`) that owns the current DOM tree.
-- `data-page-type`: The page type used to select a template (e.g., `post`).
-- `data-content-id`: The stable `contentId` for the bound content item.
-- `data-routes-href`: An absolute or relative path to a `routes.json` payload.
-  This JSON follows the `RouteMap` schema and lists each route with its `href`,
-  `pageType`, `contentId`, and optional `dataHref`. Client code can dereference the
-  attribute to prefetch or hydrate navigation models without hard-coding URLs.
+- `data-experience`: 現在の DOM ツリーを所有するエクスペリエンスキー（例: `blog`）。
+- `data-page-type`: テンプレートを選択するためのページタイプ（例: `post`）。
+- `data-content-id`: バインドされたコンテンツ項目の安定した `contentId`。
+- `data-routes-href`: `routes.json` ペイロードへの絶対または相対パス。
+  この JSON は `RouteMap` スキーマに従い、各ルートの `href`、`pageType`、`contentId`、
+  任意の `dataHref` を列挙します。クライアントコードはこの属性を参照して、URL を
+  ハードコードせずにナビゲーションモデルをプリフェッチまたはハイドレートできます。
 
-Example linkage in markup:
+マークアップでの紐づけ例:
 
 ```html
 <nav
@@ -33,7 +33,7 @@ Example linkage in markup:
 </nav>
 ```
 
-The referenced `routes.json` would look like:
+参照される `routes.json` の例:
 
 ```json
 {
@@ -50,5 +50,5 @@ The referenced `routes.json` would look like:
 }
 ```
 
-These conventions ensure that runtime components can discover routing metadata
-without coupling to build-time file layouts.
+これらの取り決めにより、ランタイムコンポーネントはビルド時のファイル構成に依存せずに
+ルーティングメタデータを発見できます。

--- a/docs/experiment-plan.md
+++ b/docs/experiment-plan.md
@@ -1,51 +1,51 @@
-# Experiment Plan: Template Experiment Plan
+# 実験計画: テンプレート実験計画
 
-Experiments across story templates to compare engagement and completion performance.
+ストーリーテンプレート全体でエンゲージメントと完読パフォーマンスを比較する実験。
 
 ## hina – Hina Story
 
-AI-hosted persona narrative tailored for new visitors.
+新規訪問者向けに調整された、AI ホストのペルソナナラティブ。
 
-### Metrics
-- **completion_rate**: Percentage of sessions reaching the final Hina card. | Target: Increase completions relative to control.
-- **avg_dwell_time**: Average seconds spent on the Hina story page. | Target: Lift time-on-page for narrative-driven sessions.
+### 指標
+- **completion_rate**: Hina の最終カードに到達したセッションの割合。 | 目標: コントロールより完了数を増やす。
+- **avg_dwell_time**: Hina ストーリーページでの平均滞在秒数。 | 目標: ナラティブ主導セッションの滞在時間を向上。
 
-### Events
+### イベント
 - **story_load**
-  - When: When a Hina story page is shown.
-  - Properties: story_id, template, traffic_source
+  - 発生タイミング: Hina ストーリーページが表示されたとき。
+  - プロパティ: story_id, template, traffic_source
 - **story_complete**
-  - When: When a user finishes the Hina narrative.
-  - Properties: story_id, template, duration_seconds
+  - 発生タイミング: ユーザーが Hina のナラティブを完了したとき。
+  - プロパティ: story_id, template, duration_seconds
 
 ## immersive – Immersive Panel
 
-Swipeable immersive reading flow for engaged users.
+エンゲージ度の高いユーザー向けのスワイプ可能な没入型リーディングフロー。
 
-### Metrics
-- **scroll_depth**: Median scroll depth across immersive panels. | Target: Reach 75% median scroll depth.
-- **interaction_rate**: Share of users interacting with swipe or tap actions. | Target: Improve gesture interactions session-over-session.
+### 指標
+- **scroll_depth**: 没入型パネル全体の中央値スクロール深度。 | 目標: 中央値 75% まで到達。
+- **interaction_rate**: スワイプやタップ操作に参加したユーザーの割合。 | 目標: セッションごとのジェスチャー操作率を改善。
 
-### Events
+### イベント
 - **panel_swipe**
-  - When: On each swipe between immersive panels.
-  - Properties: story_id, panel_index, direction, template
+  - 発生タイミング: 没入型パネル間の各スワイプ時。
+  - プロパティ: story_id, panel_index, direction, template
 - **cta_click**
-  - When: When the immersive CTA is clicked.
-  - Properties: story_id, cta_destination, template
+  - 発生タイミング: 没入型 CTA がクリックされたとき。
+  - プロパティ: story_id, cta_destination, template
 
 ## magazine – Magazine Layout
 
-Editorial-style layout for users browsing multiple articles.
+複数記事を閲覧するユーザー向けの編集レイアウト。
 
-### Metrics
-- **article_click_through**: Click-through rate from magazine grid to articles. | Target: Lift CTR compared to classic listing.
-- **session_pages_viewed**: Average articles opened per session. | Target: Reach 2.0+ articles per session.
+### 指標
+- **article_click_through**: マガジングリッドから記事へのクリック率。 | 目標: 従来リストと比較して CTR を向上。
+- **session_pages_viewed**: セッションあたりに開かれた記事数の平均。 | 目標: 1 セッション 2.0 記事以上。
 
-### Events
+### イベント
 - **grid_impression**
-  - When: When the magazine grid loads.
-  - Properties: section, template, story_count
+  - 発生タイミング: マガジングリッドが読み込まれたとき。
+  - プロパティ: section, template, story_count
 - **article_open**
-  - When: When a user opens an article from the grid.
-  - Properties: story_id, position, template
+  - 発生タイミング: ユーザーがグリッドから記事を開いたとき。
+  - プロパティ: story_id, position, template

--- a/docs/ia/hina.md
+++ b/docs/ia/hina.md
@@ -2,64 +2,64 @@
 
 # Hina (hina)
 
-Light storytelling frame with quick scannability.
+軽量なストーリーテリング枠組みで、素早く全体像を掴める構成。
 
 ## home
 
-Story-forward landing with immediate engagement.
+即時にエンゲージメントを生むストーリー主導のランディング。
 
 ### Hero headline
 
-Single key story with supporting dek and CTA.
+主要な 1 本のストーリーにデックと CTA を添える。
 
 ### Fresh drops
 
-Horizontal cards highlighting latest entries.
+最新の投稿を強調する横並びカード。
 
 ### Category sampler
 
-Trio of featured topics with compact blurbs.
+コンパクトな説明付きで注目トピックを 3 つ並べる。
 
 ### Footer CTA
 
-Low-friction signup or follow action.
+負担の少ないサインアップまたはフォローの動線。
 
 ## list
 
-Browsable catalog for repeat visitors.
+リピート訪問者向けのブラウズ可能なカタログ。
 
 ### Page heading
 
-Context line with optional count and filter chips.
+件数やフィルタチップを任意で含めるコンテキスト行。
 
 ### Filter rail
 
-Sort, tags, and time-range selectors.
+並べ替え、タグ、期間セレクター。
 
 ### Story grid
 
-Two-column cards with thumbnail, title, and tag pill.
+サムネイル・タイトル・タグピル付きの 2 カラムカード。
 
 ### Pagination
 
-Numbered pagination plus next/previous links.
+番号付きページネーションと次/前リンク。
 
 ## detail
 
-Article detail tuned for quick read-through.
+素早い読了に最適化した記事詳細。
 
 ### Title + dek
 
-Clear promise with social proof metadata.
+明確な約束とソーシャルプルーフのメタデータ。
 
 ### Feature visual
 
-Lead image or embed with caption.
+キャプション付きのリード画像または埋め込み。
 
 ### Body
 
-Sectioned narrative with pull quotes.
+プルクオートを交えたセクション構成のナラティブ。
 
 ### Related stories
 
-Inline cluster to jump deeper.
+深堀りのためのインラインな関連記事クラスター。

--- a/docs/ia/immersive.md
+++ b/docs/ia/immersive.md
@@ -2,56 +2,56 @@
 
 # Immersive (immersive)
 
-Full-bleed, cinematic reading path.
+フルブリードで映画的な読書体験。
 
 ## home
 
-Visually rich teaser surface.
+ビジュアルが豊富なティーザー面。
 
 ### Cover mosaic
 
-Full-width cards with parallax image focus.
+パララックスで際立たせる全幅カード。
 
 ### Timeline rail
 
-Scroll-linked preview of longform drops.
+ロングフォームの投稿をスクロール連動でプレビュー。
 
 ### Creator spotlight
 
-Bio snippet and latest feature for anchor author.
+主要オーサーの略歴スニペットと最新記事。
 
 ## list
 
-Longform queue with context.
+文脈付きのロングフォームキュー。
 
 ### Context banner
 
-Series description and reading time range.
+シリーズ説明と読了時間の目安。
 
 ### Immersive list
 
-Tall cards with hero media and key pull quote.
+ヒーローメディアと主要プルクオートを備えた縦長カード。
 
 ### Continue reading
 
-Sticky prompt to jump back into last read piece.
+最後に読んだ記事へ戻るためのスティッキープロンプト。
 
 ## detail
 
-Deep storytelling canvas.
+深いストーリーテリングのキャンバス。
 
 ### Cinematic lead
 
-Full-bleed hero with overlay headline.
+オーバーレイ見出し付きのフルブリードヒーロー。
 
 ### Narrative flow
 
-Chapters marked by scrolly waypoints.
+スクロールの到達点で区切られた章構成。
 
 ### Media interludes
 
-Inline galleries and clips for pacing.
+リズムを整えるためのインラインギャラリーやクリップ。
 
 ### End slate
 
-Series navigation and share block.
+シリーズナビゲーションとシェアブロック。

--- a/docs/ia/magazine.md
+++ b/docs/ia/magazine.md
@@ -2,64 +2,64 @@
 
 # Magazine (magazine)
 
-Editorial grid suited to feature packages.
+特集パッケージに適した編集型グリッド。
 
 ## home
 
-Package hub with multiple entry points.
+複数の導線を持つパッケージハブ。
 
 ### Cover stack
 
-Lead story with supporting secondary stack.
+リードストーリーと補足するセカンダリースタック。
 
 ### Rubric columns
 
-Multi-column mix of departments.
+複数のコラムを並べたセクション構成。
 
 ### Newsletter module
 
-Opt-in with promise of cadence.
+配信頻度を約束するオプトイン導線。
 
 ## list
 
-Section landing tailored for skim.
+流し読み向けに調整したセクションランディング。
 
 ### Section masthead
 
-Section label and synopsis.
+セクションラベルと概要。
 
 ### Featured lead
 
-Highlight article with deck and byline.
+デックと署名付きで記事を強調。
 
 ### Card river
 
-Dense cards with bylines and tags.
+署名とタグを備えた密度の高いカード群。
 
 ### Archive pagination
 
-Jump to older issues via numbered pages.
+番号ページで過去号へ遷移。
 
 ## detail
 
-Feature article layout.
+特集記事レイアウト。
 
 ### Masthead
 
-Title, dek, author, and publish metadata.
+タイトル、デック、著者、公開メタデータ。
 
 ### Lead visual
 
-Prominent image with credit.
+クレジット付きの印象的な画像。
 
 ### Body
 
-Rich text with inline pull quotes.
+インラインのプルクオートを含むリッチテキスト。
 
 ### Sidebar
 
-Sticky references, links, or footnotes.
+スティッキーな参考情報、リンク、脚注。
 
 ### Suggested reads
 
-Curated links to sibling pieces.
+関連する記事へのキュレーションリンク。

--- a/docs/template-pack-checklist.md
+++ b/docs/template-pack-checklist.md
@@ -1,11 +1,11 @@
-# Template Pack Checklist
+# テンプレートパックのチェックリスト
 
-Use this checklist to evaluate template packs across key categories:
+テンプレートパックを主要なカテゴリで評価するためのチェックリストです。
 
-- **A11y**: Accessibility requirements and best practices.
-- **CSS**: Styling structure, variables, and theming considerations.
-- **切替**: Locale, theme, or layout switching behaviors.
-- **SEO**: Metadata, structured data, and search index readiness.
-- **機能フック**: Extension points for custom logic and integrations.
+- **A11y**: アクセシビリティ要件とベストプラクティス。
+- **CSS**: スタイル構造、変数、テーマ適用の考慮事項。
+- **切替**: ロケール、テーマ、レイアウトの切り替え挙動。
+- **SEO**: メタデータ、構造化データ、検索インデックス準備。
+- **機能フック**: カスタムロジックや統合のための拡張ポイント。
 
-Expand each category with detailed items as the project progresses.
+各カテゴリは、プロジェクトの進行に合わせて詳細項目を追加してください。


### PR DESCRIPTION
## Summary
- translate core documentation under docs/ to Japanese
- localize IA reference pages for hina, immersive, and magazine templates
- update template pack checklist with Japanese copy

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69526a8350708333967c602fb1e83d1c)