### PR TITLE
Add scaffold command for generated experiences

### DIFF
--- a/config/experiences.yaml
+++ b/config/experiences.yaml
@@ -1,10 +1,50 @@
-- key: blog
-  name: "サンプル記事エクスペリエンス"
-  description: "sitegen の validate コマンド検証用のブログ風エクスペリエンス。"
+- key: ruri
+  name: "Ruri Legacy Experience"
+  description: "既存の HTML をそのまま配信するレガシー体験。"
+  kind: legacy
+  home: "index.html"
+  content:
+    ep01: "story1.html"
   supports:
     locales: ["ja-JP"]
     pageTypes: ["post"]
+  routePatterns:
+    page: "/ruri/{slug}.html"
+    data: "/ruri/data/{slug}.json"
+
+- key: hina
+  name: "Hina Generated Experience"
+  description: "Hina バリエーション用のジェネレート体験。"
+  kind: generated
+  output_dir: "hina"
+  supports:
+    locales: ["ja-JP"]
+    pageTypes: ["story"]
     renderKinds: ["markdown", "external"]
   routePatterns:
-    page: "/stories/{slug}"
-    data: "/data/routes/{slug}.json"
+    page: "/hina/{slug}"
+    data: "/hina/data/{slug}.json"
+
+- key: immersive
+  name: "Immersive Generated Experience"
+  description: "全画面で没入感を高めるジェネレート体験。"
+  kind: generated
+  output_dir: "immersive"
+  supports:
+    locales: ["ja-JP"]
+    pageTypes: ["story"]
+  routePatterns:
+    page: "/immersive/{slug}"
+    data: "/immersive/data/{slug}.json"
+
+- key: magazine
+  name: "Magazine Generated Experience"
+  description: "雑誌風の体験を提供するジェネレートテンプレート。"
+  kind: generated
+  output_dir: "magazine"
+  supports:
+    locales: ["ja-JP"]
+    pageTypes: ["story"]
+  routePatterns:
+    page: "/magazine/{slug}"
+    data: "/magazine/data/{slug}.json"

--- a/experience_src/hina/README.md
+++ b/experience_src/hina/README.md
@@ -1,0 +1,11 @@
+# hina scaffolding
+
+このディレクトリは `sitegen scaffold` で生成された雛形です。
+
+- `templates/home.jinja`: ホームページ用テンプレート
+- `templates/list.jinja`: 一覧ページのテンプレート
+- `templates/detail.jinja`: 詳細ページのテンプレート
+- `assets/tokens.css`: ベースとなるカラートークン
+- `assets/components.css`: 簡易なコンポーネントスタイル
+
+必要に応じてテンプレートやアセットを編集し、`hina` 配下への出力を整えてください。

--- a/experience_src/hina/assets/components.css
+++ b/experience_src/hina/assets/components.css
@@ -1,0 +1,75 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 32px;
+  background: var(--sg-surface);
+  color: var(--sg-text);
+  font-family: var(--sg-font);
+}
+
+a {
+  color: var(--sg-accent);
+}
+
+.sg-surface {
+  background: var(--sg-surface);
+}
+
+.sg-header {
+  max-width: 760px;
+  margin: 0 auto var(--sg-gap) auto;
+  padding-bottom: var(--sg-gap);
+  border-bottom: 1px solid var(--sg-border);
+}
+
+.sg-eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sg-muted);
+  font-weight: 600;
+}
+
+.sg-lede {
+  color: var(--sg-muted);
+}
+
+.sg-main {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: var(--sg-gap);
+}
+
+.sg-card {
+  list-style: none;
+  padding: 20px;
+  border: 1px solid var(--sg-border);
+  border-radius: var(--sg-radius);
+  background: var(--sg-panel);
+}
+
+.sg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--sg-gap);
+}
+
+.sg-article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px;
+  border-radius: var(--sg-radius);
+  border: 1px solid var(--sg-border);
+  background: var(--sg-panel);
+}
+
+.sg-meta {
+  margin-top: var(--sg-gap);
+  color: var(--sg-muted);
+  font-size: 14px;
+}

--- a/experience_src/hina/assets/tokens.css
+++ b/experience_src/hina/assets/tokens.css
@@ -1,0 +1,11 @@
+:root {
+  --sg-surface: #0d1117;
+  --sg-panel: #161b22;
+  --sg-border: #30363d;
+  --sg-text: #e6edf3;
+  --sg-muted: #9ea7b3;
+  --sg-accent: #80b3ff;
+  --sg-radius: 12px;
+  --sg-gap: 16px;
+  --sg-font: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+}

--- a/experience_src/hina/templates/detail.jinja
+++ b/experience_src/hina/templates/detail.jinja
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>hina | Detail</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <article class="sg-article">
+      <header class="sg-header">
+        <p class="sg-eyebrow">Detail</p>
+        <h1>タイトルをここに</h1>
+        <p class="sg-lede">本文の概要をここに記載します。</p>
+      </header>
+      <section class="sg-main">
+        <p>TODO: 本文をレンダリングしてください。</p>
+      </section>
+      <footer class="sg-meta">
+        <p>作者名や日付などのメタ情報を表示します。</p>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/experience_src/hina/templates/home.jinja
+++ b/experience_src/hina/templates/home.jinja
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>hina | Home</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <header class="sg-header">
+      <p class="sg-eyebrow">Experience</p>
+      <h1>hina ホーム</h1>
+      <p class="sg-lede">テンプレートの起点となるシンプルなページです。</p>
+    </header>
+    <main class="sg-main">
+      <section class="sg-card">
+        <h2>最新コンテンツ</h2>
+        <p>TODO: コンテンツ一覧をここにレンダリングします。</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/experience_src/hina/templates/list.jinja
+++ b/experience_src/hina/templates/list.jinja
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>hina | List</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <header class="sg-header">
+      <p class="sg-eyebrow">Listing</p>
+      <h1>hina コンテンツ一覧</h1>
+      <p class="sg-lede">カード一覧でコンテンツを紹介するページです。</p>
+    </header>
+    <main class="sg-main">
+      <ul class="sg-list">
+        <li class="sg-card">
+          <h2>サンプルタイトル</h2>
+          <p>ここにサマリーが入ります。</p>
+        </li>
+        <li class="sg-card">
+          <h2>次のコンテンツ</h2>
+          <p>TODO: ループでデータを差し込みます。</p>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/experience_src/immersive/README.md
+++ b/experience_src/immersive/README.md
@@ -1,0 +1,11 @@
+# immersive scaffolding
+
+このディレクトリは `sitegen scaffold` で生成された雛形です。
+
+- `templates/home.jinja`: ホームページ用テンプレート
+- `templates/list.jinja`: 一覧ページのテンプレート
+- `templates/detail.jinja`: 詳細ページのテンプレート
+- `assets/tokens.css`: ベースとなるカラートークン
+- `assets/components.css`: 簡易なコンポーネントスタイル
+
+必要に応じてテンプレートやアセットを編集し、`immersive` 配下への出力を整えてください。

--- a/experience_src/immersive/assets/components.css
+++ b/experience_src/immersive/assets/components.css
@@ -1,0 +1,75 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 32px;
+  background: var(--sg-surface);
+  color: var(--sg-text);
+  font-family: var(--sg-font);
+}
+
+a {
+  color: var(--sg-accent);
+}
+
+.sg-surface {
+  background: var(--sg-surface);
+}
+
+.sg-header {
+  max-width: 760px;
+  margin: 0 auto var(--sg-gap) auto;
+  padding-bottom: var(--sg-gap);
+  border-bottom: 1px solid var(--sg-border);
+}
+
+.sg-eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sg-muted);
+  font-weight: 600;
+}
+
+.sg-lede {
+  color: var(--sg-muted);
+}
+
+.sg-main {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: var(--sg-gap);
+}
+
+.sg-card {
+  list-style: none;
+  padding: 20px;
+  border: 1px solid var(--sg-border);
+  border-radius: var(--sg-radius);
+  background: var(--sg-panel);
+}
+
+.sg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--sg-gap);
+}
+
+.sg-article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px;
+  border-radius: var(--sg-radius);
+  border: 1px solid var(--sg-border);
+  background: var(--sg-panel);
+}
+
+.sg-meta {
+  margin-top: var(--sg-gap);
+  color: var(--sg-muted);
+  font-size: 14px;
+}

--- a/experience_src/immersive/assets/tokens.css
+++ b/experience_src/immersive/assets/tokens.css
@@ -1,0 +1,11 @@
+:root {
+  --sg-surface: #0d1117;
+  --sg-panel: #161b22;
+  --sg-border: #30363d;
+  --sg-text: #e6edf3;
+  --sg-muted: #9ea7b3;
+  --sg-accent: #80b3ff;
+  --sg-radius: 12px;
+  --sg-gap: 16px;
+  --sg-font: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+}

--- a/experience_src/immersive/templates/detail.jinja
+++ b/experience_src/immersive/templates/detail.jinja
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>immersive | Detail</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <article class="sg-article">
+      <header class="sg-header">
+        <p class="sg-eyebrow">Detail</p>
+        <h1>タイトルをここに</h1>
+        <p class="sg-lede">本文の概要をここに記載します。</p>
+      </header>
+      <section class="sg-main">
+        <p>TODO: 本文をレンダリングしてください。</p>
+      </section>
+      <footer class="sg-meta">
+        <p>作者名や日付などのメタ情報を表示します。</p>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/experience_src/immersive/templates/home.jinja
+++ b/experience_src/immersive/templates/home.jinja
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>immersive | Home</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <header class="sg-header">
+      <p class="sg-eyebrow">Experience</p>
+      <h1>immersive ホーム</h1>
+      <p class="sg-lede">テンプレートの起点となるシンプルなページです。</p>
+    </header>
+    <main class="sg-main">
+      <section class="sg-card">
+        <h2>最新コンテンツ</h2>
+        <p>TODO: コンテンツ一覧をここにレンダリングします。</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/experience_src/immersive/templates/list.jinja
+++ b/experience_src/immersive/templates/list.jinja
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>immersive | List</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <header class="sg-header">
+      <p class="sg-eyebrow">Listing</p>
+      <h1>immersive コンテンツ一覧</h1>
+      <p class="sg-lede">カード一覧でコンテンツを紹介するページです。</p>
+    </header>
+    <main class="sg-main">
+      <ul class="sg-list">
+        <li class="sg-card">
+          <h2>サンプルタイトル</h2>
+          <p>ここにサマリーが入ります。</p>
+        </li>
+        <li class="sg-card">
+          <h2>次のコンテンツ</h2>
+          <p>TODO: ループでデータを差し込みます。</p>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/experience_src/magazine/README.md
+++ b/experience_src/magazine/README.md
@@ -1,0 +1,11 @@
+# magazine scaffolding
+
+このディレクトリは `sitegen scaffold` で生成された雛形です。
+
+- `templates/home.jinja`: ホームページ用テンプレート
+- `templates/list.jinja`: 一覧ページのテンプレート
+- `templates/detail.jinja`: 詳細ページのテンプレート
+- `assets/tokens.css`: ベースとなるカラートークン
+- `assets/components.css`: 簡易なコンポーネントスタイル
+
+必要に応じてテンプレートやアセットを編集し、`magazine` 配下への出力を整えてください。

--- a/experience_src/magazine/assets/components.css
+++ b/experience_src/magazine/assets/components.css
@@ -1,0 +1,75 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 32px;
+  background: var(--sg-surface);
+  color: var(--sg-text);
+  font-family: var(--sg-font);
+}
+
+a {
+  color: var(--sg-accent);
+}
+
+.sg-surface {
+  background: var(--sg-surface);
+}
+
+.sg-header {
+  max-width: 760px;
+  margin: 0 auto var(--sg-gap) auto;
+  padding-bottom: var(--sg-gap);
+  border-bottom: 1px solid var(--sg-border);
+}
+
+.sg-eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sg-muted);
+  font-weight: 600;
+}
+
+.sg-lede {
+  color: var(--sg-muted);
+}
+
+.sg-main {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: var(--sg-gap);
+}
+
+.sg-card {
+  list-style: none;
+  padding: 20px;
+  border: 1px solid var(--sg-border);
+  border-radius: var(--sg-radius);
+  background: var(--sg-panel);
+}
+
+.sg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--sg-gap);
+}
+
+.sg-article {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px;
+  border-radius: var(--sg-radius);
+  border: 1px solid var(--sg-border);
+  background: var(--sg-panel);
+}
+
+.sg-meta {
+  margin-top: var(--sg-gap);
+  color: var(--sg-muted);
+  font-size: 14px;
+}

--- a/experience_src/magazine/assets/tokens.css
+++ b/experience_src/magazine/assets/tokens.css
@@ -1,0 +1,11 @@
+:root {
+  --sg-surface: #0d1117;
+  --sg-panel: #161b22;
+  --sg-border: #30363d;
+  --sg-text: #e6edf3;
+  --sg-muted: #9ea7b3;
+  --sg-accent: #80b3ff;
+  --sg-radius: 12px;
+  --sg-gap: 16px;
+  --sg-font: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+}

--- a/experience_src/magazine/templates/detail.jinja
+++ b/experience_src/magazine/templates/detail.jinja
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>magazine | Detail</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <article class="sg-article">
+      <header class="sg-header">
+        <p class="sg-eyebrow">Detail</p>
+        <h1>タイトルをここに</h1>
+        <p class="sg-lede">本文の概要をここに記載します。</p>
+      </header>
+      <section class="sg-main">
+        <p>TODO: 本文をレンダリングしてください。</p>
+      </section>
+      <footer class="sg-meta">
+        <p>作者名や日付などのメタ情報を表示します。</p>
+      </footer>
+    </article>
+  </body>
+</html>

--- a/experience_src/magazine/templates/home.jinja
+++ b/experience_src/magazine/templates/home.jinja
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>magazine | Home</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <header class="sg-header">
+      <p class="sg-eyebrow">Experience</p>
+      <h1>magazine ホーム</h1>
+      <p class="sg-lede">テンプレートの起点となるシンプルなページです。</p>
+    </header>
+    <main class="sg-main">
+      <section class="sg-card">
+        <h2>最新コンテンツ</h2>
+        <p>TODO: コンテンツ一覧をここにレンダリングします。</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/experience_src/magazine/templates/list.jinja
+++ b/experience_src/magazine/templates/list.jinja
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <title>magazine | List</title>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+  </head>
+  <body class="sg-surface">
+    <header class="sg-header">
+      <p class="sg-eyebrow">Listing</p>
+      <h1>magazine コンテンツ一覧</h1>
+      <p class="sg-lede">カード一覧でコンテンツを紹介するページです。</p>
+    </header>
+    <main class="sg-main">
+      <ul class="sg-list">
+        <li class="sg-card">
+          <h2>サンプルタイトル</h2>
+          <p>ここにサマリーが入ります。</p>
+        </li>
+        <li class="sg-card">
+          <h2>次のコンテンツ</h2>
+          <p>TODO: ループでデータを差し込みます。</p>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a `sitegen scaffold` subcommand that prepares template and asset skeletons for generated experiences
- refresh `config/experiences.yaml` with legacy and generated entries for upcoming routes work
- add starter templates, styles, and README files for the hina, immersive, and magazine experiences

## Testing
- python -m sitegen scaffold --experiences config/experiences.yaml --src experience_src --out-root .


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952752b4a44833390c4dddd5abfc6cb)