### PR TITLE
Add manifest generation command for generated experiences

### DIFF
--- a/config/experiences.yaml
+++ b/config/experiences.yaml
@@ -8,9 +8,11 @@
   supports:
     locales: ["ja-JP"]
     pageTypes: ["post"]
+    features: ["legacy-html"]
   routePatterns:
-    page: "/ruri/{slug}.html"
-    data: "/ruri/data/{slug}.json"
+    home: "/ruri/"
+    list: "/ruri/list.html"
+    detail: "/ruri/{slug}.html"
 
 - key: hina
   name: "Hina Generated Experience"
@@ -20,10 +22,12 @@
   supports:
     locales: ["ja-JP"]
     pageTypes: ["story"]
+    features: ["story-hero"]
     renderKinds: ["markdown", "external"]
   routePatterns:
-    page: "/hina/{slug}"
-    data: "/hina/data/{slug}.json"
+    home: "/hina/"
+    list: "/hina/list"
+    detail: "/hina/{slug}"
 
 - key: immersive
   name: "Immersive Generated Experience"
@@ -33,9 +37,11 @@
   supports:
     locales: ["ja-JP"]
     pageTypes: ["story"]
+    features: ["full-bleed"]
   routePatterns:
-    page: "/immersive/{slug}"
-    data: "/immersive/data/{slug}.json"
+    home: "/immersive/"
+    list: "/immersive/list"
+    detail: "/immersive/{slug}"
 
 - key: magazine
   name: "Magazine Generated Experience"
@@ -45,6 +51,8 @@
   supports:
     locales: ["ja-JP"]
     pageTypes: ["story"]
+    features: ["grid-list"]
   routePatterns:
-    page: "/magazine/{slug}"
-    data: "/magazine/data/{slug}.json"
+    home: "/magazine/"
+    list: "/magazine/list"
+    detail: "/magazine/{slug}"

--- a/experience_src/hina/manifest.json
+++ b/experience_src/hina/manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "hina",
+  "label": "Hina Generated Experience",
+  "supports": {
+    "pageTypes": [
+      "story"
+    ],
+    "features": [
+      "story-hero"
+    ],
+    "renderKinds": [
+      "markdown",
+      "external"
+    ],
+    "locales": [
+      "ja-JP"
+    ]
+  },
+  "routes": {
+    "home": "/hina/",
+    "list": "/hina/list",
+    "detail": "/hina/{slug}"
+  }
+}

--- a/experience_src/immersive/manifest.json
+++ b/experience_src/immersive/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "immersive",
+  "label": "Immersive Generated Experience",
+  "supports": {
+    "pageTypes": [
+      "story"
+    ],
+    "features": [
+      "full-bleed"
+    ],
+    "renderKinds": [],
+    "locales": [
+      "ja-JP"
+    ]
+  },
+  "routes": {
+    "home": "/immersive/",
+    "list": "/immersive/list",
+    "detail": "/immersive/{slug}"
+  }
+}

--- a/experience_src/magazine/manifest.json
+++ b/experience_src/magazine/manifest.json
@@ -1,0 +1,21 @@
+{
+  "id": "magazine",
+  "label": "Magazine Generated Experience",
+  "supports": {
+    "pageTypes": [
+      "story"
+    ],
+    "features": [
+      "grid-list"
+    ],
+    "renderKinds": [],
+    "locales": [
+      "ja-JP"
+    ]
+  },
+  "routes": {
+    "home": "/magazine/",
+    "list": "/magazine/list",
+    "detail": "/magazine/{slug}"
+  }
+}

--- a/sitegen/models.py
+++ b/sitegen/models.py
@@ -103,6 +103,13 @@ class Supports(BaseModel):
         alias="pageTypes",
         description="Page types allowed for the experience (e.g., post, landing).",
     )
+    features: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Feature flags or capabilities supported by the experience "
+            "(e.g., comments, reactions)."
+        ),
+    )
     render_kinds: List[str] = Field(
         default_factory=list,
         alias="renderKinds",
@@ -119,13 +126,14 @@ class Supports(BaseModel):
 class RoutePatterns(BaseModel):
     """Patterns for deriving hrefs for an experience."""
 
-    page: str = Field(
-        ...,
-        description="Pattern for visible pages, e.g. `/stories/{slug}`.",
+    home: str = Field(
+        ..., description="Route for the experience home page (no slug)."
     )
-    data: str = Field(
-        ...,
-        description="Pattern for JSON route payloads used via data-routes-href.",
+    list: str = Field(
+        ..., description="Route for listing views that show multiple content items."
+    )
+    detail: str = Field(
+        ..., description="Route pattern for individual content pages with {slug}."
     )
 
     model_config = ConfigDict(populate_by_name=True)
@@ -136,8 +144,16 @@ class ExperienceSpec(BaseModel):
 
     key: str = Field(..., description="Identifier for the experience (slug-friendly).")
     name: str = Field(..., description="Human readable name.")
+    kind: Literal["legacy", "generated"] = Field(
+        "legacy", description="Whether the experience is legacy or generated."
+    )
     description: Optional[str] = Field(
         None, description="Short description of the experience goal."
+    )
+    output_dir: Optional[str] = Field(
+        default=None,
+        alias="output_dir",
+        description="Output directory name for generated experiences, if applicable.",
     )
     supports: Supports = Field(
         default_factory=Supports,


### PR DESCRIPTION
## Summary
- extend experience specifications with features support and home/list/detail route patterns
- add `gen-manifests` CLI to emit manifests for generated experiences and update the experience configuration accordingly
- generate example `manifest.json` files for existing generated experiences

## Testing
- python -m sitegen gen-manifests --experiences config/experiences.yaml --src experience_src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c0f030d88333a83c6f3dc4e0c785)