### PR TITLE
Add asset copying and relative CSS prefixes for generated experiences

### DIFF
--- a/experience_src/hina/assets/components.css
+++ b/experience_src/hina/assets/components.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-body {
+body[data-experience] {
   margin: 0;
   padding: 32px;
   background: var(--sg-surface);
@@ -10,22 +10,22 @@ body {
   font-family: var(--sg-font);
 }
 
-a {
+body[data-experience] a {
   color: var(--sg-accent);
 }
 
-.sg-surface {
+body[data-experience] .sg-surface {
   background: var(--sg-surface);
 }
 
-.sg-header {
+body[data-experience] .sg-header {
   max-width: 760px;
   margin: 0 auto var(--sg-gap) auto;
   padding-bottom: var(--sg-gap);
   border-bottom: 1px solid var(--sg-border);
 }
 
-.sg-nav {
+body[data-experience] .sg-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,7 +33,7 @@ a {
   margin-bottom: var(--sg-gap);
 }
 
-.sg-nav-links {
+body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -41,7 +41,7 @@ a {
   gap: 12px;
 }
 
-.sg-nav-links a {
+body[data-experience] .sg-nav-links a {
   color: var(--sg-text);
   text-decoration: none;
   padding: 6px 10px;
@@ -49,13 +49,13 @@ a {
   transition: background 0.2s ease;
 }
 
-.sg-nav-links a:hover,
-.sg-nav-links a:focus-visible {
+body[data-experience] .sg-nav-links a:hover,
+body[data-experience] .sg-nav-links a:focus-visible {
   background: var(--sg-border);
   outline: none;
 }
 
-.sg-toggle {
+body[data-experience] .sg-toggle {
   background: var(--sg-panel);
   color: var(--sg-text);
   border: 1px solid var(--sg-border);
@@ -64,12 +64,12 @@ a {
   cursor: pointer;
 }
 
-.sg-toggle:focus-visible {
+body[data-experience] .sg-toggle:focus-visible {
   outline: 2px solid var(--sg-accent);
   outline-offset: 2px;
 }
 
-.sg-skip {
+body[data-experience] .sg-skip {
   position: absolute;
   left: -999px;
   top: auto;
@@ -78,7 +78,7 @@ a {
   overflow: hidden;
 }
 
-.sg-skip:focus {
+body[data-experience] .sg-skip:focus {
   position: static;
   width: auto;
   height: auto;
@@ -88,25 +88,25 @@ a {
   border-radius: var(--sg-radius);
 }
 
-.sg-eyebrow {
+body[data-experience] .sg-eyebrow {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--sg-muted);
   font-weight: 600;
 }
 
-.sg-lede {
+body[data-experience] .sg-lede {
   color: var(--sg-muted);
 }
 
-.sg-main {
+body[data-experience] .sg-main {
   max-width: 960px;
   margin: 0 auto;
   display: grid;
   gap: var(--sg-gap);
 }
 
-.sg-card {
+body[data-experience] .sg-card {
   list-style: none;
   padding: 20px;
   border: 1px solid var(--sg-border);
@@ -114,7 +114,7 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-list {
+body[data-experience] .sg-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -122,7 +122,7 @@ a {
   gap: var(--sg-gap);
 }
 
-.sg-article {
+body[data-experience] .sg-article {
   max-width: 760px;
   margin: 0 auto;
   padding: 24px;
@@ -131,17 +131,29 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-meta {
+body[data-experience] .sg-meta {
   margin-top: var(--sg-gap);
   color: var(--sg-muted);
   font-size: 14px;
 }
 
-.sg-footer {
+body[data-experience] .sg-footer {
   max-width: 960px;
   margin: var(--sg-gap) auto 0 auto;
   padding: 16px 0 var(--sg-gap) 0;
   border-top: 1px solid var(--sg-border);
   color: var(--sg-muted);
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-experience] {
+    scroll-behavior: auto;
+  }
+
+  body[data-experience] * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/experience_src/hina/templates/detail.jinja
+++ b/experience_src/hina/templates/detail.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>hina | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
       <header class="sg-header">
         <p class="sg-eyebrow">Detail</p>

--- a/experience_src/hina/templates/home.jinja
+++ b/experience_src/hina/templates/home.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>{{ experience.name }} | Home</title>
-    <link rel="stylesheet" href="./assets/tokens.css">
-    <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav

--- a/experience_src/hina/templates/list.jinja
+++ b/experience_src/hina/templates/list.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>hina | List</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>hina コンテンツ一覧</h1>

--- a/experience_src/immersive/assets/components.css
+++ b/experience_src/immersive/assets/components.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-body {
+body[data-experience] {
   margin: 0;
   padding: 32px;
   background: var(--sg-surface);
@@ -10,22 +10,22 @@ body {
   font-family: var(--sg-font);
 }
 
-a {
+body[data-experience] a {
   color: var(--sg-accent);
 }
 
-.sg-surface {
+body[data-experience] .sg-surface {
   background: var(--sg-surface);
 }
 
-.sg-header {
+body[data-experience] .sg-header {
   max-width: 760px;
   margin: 0 auto var(--sg-gap) auto;
   padding-bottom: var(--sg-gap);
   border-bottom: 1px solid var(--sg-border);
 }
 
-.sg-nav {
+body[data-experience] .sg-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,7 +33,7 @@ a {
   margin-bottom: var(--sg-gap);
 }
 
-.sg-nav-links {
+body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -41,7 +41,7 @@ a {
   gap: 12px;
 }
 
-.sg-nav-links a {
+body[data-experience] .sg-nav-links a {
   color: var(--sg-text);
   text-decoration: none;
   padding: 6px 10px;
@@ -49,13 +49,13 @@ a {
   transition: background 0.2s ease;
 }
 
-.sg-nav-links a:hover,
-.sg-nav-links a:focus-visible {
+body[data-experience] .sg-nav-links a:hover,
+body[data-experience] .sg-nav-links a:focus-visible {
   background: var(--sg-border);
   outline: none;
 }
 
-.sg-toggle {
+body[data-experience] .sg-toggle {
   background: var(--sg-panel);
   color: var(--sg-text);
   border: 1px solid var(--sg-border);
@@ -64,12 +64,12 @@ a {
   cursor: pointer;
 }
 
-.sg-toggle:focus-visible {
+body[data-experience] .sg-toggle:focus-visible {
   outline: 2px solid var(--sg-accent);
   outline-offset: 2px;
 }
 
-.sg-skip {
+body[data-experience] .sg-skip {
   position: absolute;
   left: -999px;
   top: auto;
@@ -78,7 +78,7 @@ a {
   overflow: hidden;
 }
 
-.sg-skip:focus {
+body[data-experience] .sg-skip:focus {
   position: static;
   width: auto;
   height: auto;
@@ -88,25 +88,25 @@ a {
   border-radius: var(--sg-radius);
 }
 
-.sg-eyebrow {
+body[data-experience] .sg-eyebrow {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--sg-muted);
   font-weight: 600;
 }
 
-.sg-lede {
+body[data-experience] .sg-lede {
   color: var(--sg-muted);
 }
 
-.sg-main {
+body[data-experience] .sg-main {
   max-width: 960px;
   margin: 0 auto;
   display: grid;
   gap: var(--sg-gap);
 }
 
-.sg-card {
+body[data-experience] .sg-card {
   list-style: none;
   padding: 20px;
   border: 1px solid var(--sg-border);
@@ -114,7 +114,7 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-list {
+body[data-experience] .sg-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -122,7 +122,7 @@ a {
   gap: var(--sg-gap);
 }
 
-.sg-article {
+body[data-experience] .sg-article {
   max-width: 760px;
   margin: 0 auto;
   padding: 24px;
@@ -131,17 +131,29 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-meta {
+body[data-experience] .sg-meta {
   margin-top: var(--sg-gap);
   color: var(--sg-muted);
   font-size: 14px;
 }
 
-.sg-footer {
+body[data-experience] .sg-footer {
   max-width: 960px;
   margin: var(--sg-gap) auto 0 auto;
   padding: 16px 0 var(--sg-gap) 0;
   border-top: 1px solid var(--sg-border);
   color: var(--sg-muted);
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-experience] {
+    scroll-behavior: auto;
+  }
+
+  body[data-experience] * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/experience_src/immersive/templates/detail.jinja
+++ b/experience_src/immersive/templates/detail.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>immersive | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
       <header class="sg-header">
         <p class="sg-eyebrow">Detail</p>

--- a/experience_src/immersive/templates/home.jinja
+++ b/experience_src/immersive/templates/home.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>{{ experience.name }} | Home</title>
-    <link rel="stylesheet" href="./assets/tokens.css">
-    <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav

--- a/experience_src/immersive/templates/list.jinja
+++ b/experience_src/immersive/templates/list.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>immersive | List</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>immersive コンテンツ一覧</h1>

--- a/experience_src/magazine/assets/components.css
+++ b/experience_src/magazine/assets/components.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-body {
+body[data-experience] {
   margin: 0;
   padding: 32px;
   background: var(--sg-surface);
@@ -10,22 +10,22 @@ body {
   font-family: var(--sg-font);
 }
 
-a {
+body[data-experience] a {
   color: var(--sg-accent);
 }
 
-.sg-surface {
+body[data-experience] .sg-surface {
   background: var(--sg-surface);
 }
 
-.sg-header {
+body[data-experience] .sg-header {
   max-width: 760px;
   margin: 0 auto var(--sg-gap) auto;
   padding-bottom: var(--sg-gap);
   border-bottom: 1px solid var(--sg-border);
 }
 
-.sg-nav {
+body[data-experience] .sg-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,7 +33,7 @@ a {
   margin-bottom: var(--sg-gap);
 }
 
-.sg-nav-links {
+body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -41,7 +41,7 @@ a {
   gap: 12px;
 }
 
-.sg-nav-links a {
+body[data-experience] .sg-nav-links a {
   color: var(--sg-text);
   text-decoration: none;
   padding: 6px 10px;
@@ -49,13 +49,13 @@ a {
   transition: background 0.2s ease;
 }
 
-.sg-nav-links a:hover,
-.sg-nav-links a:focus-visible {
+body[data-experience] .sg-nav-links a:hover,
+body[data-experience] .sg-nav-links a:focus-visible {
   background: var(--sg-border);
   outline: none;
 }
 
-.sg-toggle {
+body[data-experience] .sg-toggle {
   background: var(--sg-panel);
   color: var(--sg-text);
   border: 1px solid var(--sg-border);
@@ -64,12 +64,12 @@ a {
   cursor: pointer;
 }
 
-.sg-toggle:focus-visible {
+body[data-experience] .sg-toggle:focus-visible {
   outline: 2px solid var(--sg-accent);
   outline-offset: 2px;
 }
 
-.sg-skip {
+body[data-experience] .sg-skip {
   position: absolute;
   left: -999px;
   top: auto;
@@ -78,7 +78,7 @@ a {
   overflow: hidden;
 }
 
-.sg-skip:focus {
+body[data-experience] .sg-skip:focus {
   position: static;
   width: auto;
   height: auto;
@@ -88,25 +88,25 @@ a {
   border-radius: var(--sg-radius);
 }
 
-.sg-eyebrow {
+body[data-experience] .sg-eyebrow {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--sg-muted);
   font-weight: 600;
 }
 
-.sg-lede {
+body[data-experience] .sg-lede {
   color: var(--sg-muted);
 }
 
-.sg-main {
+body[data-experience] .sg-main {
   max-width: 960px;
   margin: 0 auto;
   display: grid;
   gap: var(--sg-gap);
 }
 
-.sg-card {
+body[data-experience] .sg-card {
   list-style: none;
   padding: 20px;
   border: 1px solid var(--sg-border);
@@ -114,7 +114,7 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-list {
+body[data-experience] .sg-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -122,7 +122,7 @@ a {
   gap: var(--sg-gap);
 }
 
-.sg-article {
+body[data-experience] .sg-article {
   max-width: 760px;
   margin: 0 auto;
   padding: 24px;
@@ -131,17 +131,29 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-meta {
+body[data-experience] .sg-meta {
   margin-top: var(--sg-gap);
   color: var(--sg-muted);
   font-size: 14px;
 }
 
-.sg-footer {
+body[data-experience] .sg-footer {
   max-width: 960px;
   margin: var(--sg-gap) auto 0 auto;
   padding: 16px 0 var(--sg-gap) 0;
   border-top: 1px solid var(--sg-border);
   color: var(--sg-muted);
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-experience] {
+    scroll-behavior: auto;
+  }
+
+  body[data-experience] * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/experience_src/magazine/templates/detail.jinja
+++ b/experience_src/magazine/templates/detail.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>magazine | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
       <header class="sg-header">
         <p class="sg-eyebrow">Detail</p>

--- a/experience_src/magazine/templates/home.jinja
+++ b/experience_src/magazine/templates/home.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>{{ experience.name }} | Home</title>
-    <link rel="stylesheet" href="./assets/tokens.css">
-    <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav

--- a/experience_src/magazine/templates/list.jinja
+++ b/experience_src/magazine/templates/list.jinja
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>magazine | List</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
+    <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="{{ experience.key }}">
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>magazine コンテンツ一覧</h1>


### PR DESCRIPTION
## Summary
- copy experience assets during build and expose an asset_prefix for template rendering
- update generated templates to load CSS through the computed asset prefix and tag bodies with experience scope
- scope component styles to body[data-experience] and add a minimal prefers-reduced-motion fallback

## Testing
- python -m compileall sitegen


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c9d160488333a9dcf43fd7ddc74e)