### PR TITLE
Add shared feature bootstrap for detail pages

### DIFF
--- a/experience_src/hina/templates/detail.jinja
+++ b/experience_src/hina/templates/detail.jinja
@@ -5,10 +5,13 @@
     <title>hina | Detail</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if features_init_href %}
+    <script src="{{ features_init_href }}" defer></script>
+    {% endif %}
   </head>
   <body class="sg-surface" data-experience="{{ experience.key }}">
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>{{ content.title }}</h1>
         {% if content.summary %}
@@ -22,7 +25,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
         {% if content.render.kind == 'html' %}
         {{ content.render.html | safe }}
         {% endif %}

--- a/experience_src/immersive/templates/detail.jinja
+++ b/experience_src/immersive/templates/detail.jinja
@@ -5,10 +5,13 @@
     <title>immersive | Detail</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if features_init_href %}
+    <script src="{{ features_init_href }}" defer></script>
+    {% endif %}
   </head>
   <body class="sg-surface" data-experience="{{ experience.key }}">
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>{{ content.title }}</h1>
         {% if content.summary %}
@@ -22,7 +25,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
         {% if content.render.kind == 'html' %}
         {{ content.render.html | safe }}
         {% endif %}

--- a/experience_src/magazine/templates/detail.jinja
+++ b/experience_src/magazine/templates/detail.jinja
@@ -5,10 +5,13 @@
     <title>magazine | Detail</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if features_init_href %}
+    <script src="{{ features_init_href }}" defer></script>
+    {% endif %}
   </head>
   <body class="sg-surface" data-experience="{{ experience.key }}">
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>{{ content.title }}</h1>
         {% if content.summary %}
@@ -22,7 +25,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
         {% if content.render.kind == 'html' %}
         {{ content.render.html | safe }}
         {% endif %}

--- a/generated/hina/assets/components.css
+++ b/generated/hina/assets/components.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-body {
+body[data-experience] {
   margin: 0;
   padding: 32px;
   background: var(--sg-surface);
@@ -10,22 +10,22 @@ body {
   font-family: var(--sg-font);
 }
 
-a {
+body[data-experience] a {
   color: var(--sg-accent);
 }
 
-.sg-surface {
+body[data-experience] .sg-surface {
   background: var(--sg-surface);
 }
 
-.sg-header {
+body[data-experience] .sg-header {
   max-width: 760px;
   margin: 0 auto var(--sg-gap) auto;
   padding-bottom: var(--sg-gap);
   border-bottom: 1px solid var(--sg-border);
 }
 
-.sg-nav {
+body[data-experience] .sg-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,7 +33,7 @@ a {
   margin-bottom: var(--sg-gap);
 }
 
-.sg-nav-links {
+body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -41,7 +41,7 @@ a {
   gap: 12px;
 }
 
-.sg-nav-links a {
+body[data-experience] .sg-nav-links a {
   color: var(--sg-text);
   text-decoration: none;
   padding: 6px 10px;
@@ -49,13 +49,13 @@ a {
   transition: background 0.2s ease;
 }
 
-.sg-nav-links a:hover,
-.sg-nav-links a:focus-visible {
+body[data-experience] .sg-nav-links a:hover,
+body[data-experience] .sg-nav-links a:focus-visible {
   background: var(--sg-border);
   outline: none;
 }
 
-.sg-toggle {
+body[data-experience] .sg-toggle {
   background: var(--sg-panel);
   color: var(--sg-text);
   border: 1px solid var(--sg-border);
@@ -64,12 +64,12 @@ a {
   cursor: pointer;
 }
 
-.sg-toggle:focus-visible {
+body[data-experience] .sg-toggle:focus-visible {
   outline: 2px solid var(--sg-accent);
   outline-offset: 2px;
 }
 
-.sg-skip {
+body[data-experience] .sg-skip {
   position: absolute;
   left: -999px;
   top: auto;
@@ -78,7 +78,7 @@ a {
   overflow: hidden;
 }
 
-.sg-skip:focus {
+body[data-experience] .sg-skip:focus {
   position: static;
   width: auto;
   height: auto;
@@ -88,25 +88,25 @@ a {
   border-radius: var(--sg-radius);
 }
 
-.sg-eyebrow {
+body[data-experience] .sg-eyebrow {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--sg-muted);
   font-weight: 600;
 }
 
-.sg-lede {
+body[data-experience] .sg-lede {
   color: var(--sg-muted);
 }
 
-.sg-main {
+body[data-experience] .sg-main {
   max-width: 960px;
   margin: 0 auto;
   display: grid;
   gap: var(--sg-gap);
 }
 
-.sg-card {
+body[data-experience] .sg-card {
   list-style: none;
   padding: 20px;
   border: 1px solid var(--sg-border);
@@ -114,7 +114,7 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-list {
+body[data-experience] .sg-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -122,7 +122,7 @@ a {
   gap: var(--sg-gap);
 }
 
-.sg-article {
+body[data-experience] .sg-article {
   max-width: 760px;
   margin: 0 auto;
   padding: 24px;
@@ -131,17 +131,29 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-meta {
+body[data-experience] .sg-meta {
   margin-top: var(--sg-gap);
   color: var(--sg-muted);
   font-size: 14px;
 }
 
-.sg-footer {
+body[data-experience] .sg-footer {
   max-width: 960px;
   margin: var(--sg-gap) auto 0 auto;
   padding: 16px 0 var(--sg-gap) 0;
   border-top: 1px solid var(--sg-border);
   color: var(--sg-muted);
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-experience] {
+    scroll-behavior: auto;
+  }
+
+  body[data-experience] * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/generated/hina/index.html
+++ b/generated/hina/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="hina">
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav

--- a/generated/hina/list.html
+++ b/generated/hina/list.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>hina | List</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="./assets/tokens.css">
+    <link rel="stylesheet" href="./assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="hina">
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>hina コンテンツ一覧</h1>

--- a/generated/hina/posts/ep01.html
+++ b/generated/hina/posts/ep01.html
@@ -5,10 +5,11 @@
     <title>hina | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <script src="../../shared/features/init-features.js" defer></script>
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="hina">
     <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>EP01: 開幕、魔界喫茶《∞（インフィニティ）》</h1>
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
@@ -19,7 +20,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>舞台は魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》。</p>

--- a/generated/hina/posts/welcome-post.html
+++ b/generated/hina/posts/welcome-post.html
@@ -5,10 +5,11 @@
     <title>hina | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <script src="../../shared/features/init-features.js" defer></script>
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="hina">
     <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>ようこそ、魔界喫茶《∞》へ</h1>
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
@@ -19,7 +20,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
       </section>
       <footer class="sg-meta">
         <p>コンテンツ ID: welcome-post</p>

--- a/generated/immersive/assets/components.css
+++ b/generated/immersive/assets/components.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-body {
+body[data-experience] {
   margin: 0;
   padding: 32px;
   background: var(--sg-surface);
@@ -10,22 +10,22 @@ body {
   font-family: var(--sg-font);
 }
 
-a {
+body[data-experience] a {
   color: var(--sg-accent);
 }
 
-.sg-surface {
+body[data-experience] .sg-surface {
   background: var(--sg-surface);
 }
 
-.sg-header {
+body[data-experience] .sg-header {
   max-width: 760px;
   margin: 0 auto var(--sg-gap) auto;
   padding-bottom: var(--sg-gap);
   border-bottom: 1px solid var(--sg-border);
 }
 
-.sg-nav {
+body[data-experience] .sg-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,7 +33,7 @@ a {
   margin-bottom: var(--sg-gap);
 }
 
-.sg-nav-links {
+body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -41,7 +41,7 @@ a {
   gap: 12px;
 }
 
-.sg-nav-links a {
+body[data-experience] .sg-nav-links a {
   color: var(--sg-text);
   text-decoration: none;
   padding: 6px 10px;
@@ -49,13 +49,13 @@ a {
   transition: background 0.2s ease;
 }
 
-.sg-nav-links a:hover,
-.sg-nav-links a:focus-visible {
+body[data-experience] .sg-nav-links a:hover,
+body[data-experience] .sg-nav-links a:focus-visible {
   background: var(--sg-border);
   outline: none;
 }
 
-.sg-toggle {
+body[data-experience] .sg-toggle {
   background: var(--sg-panel);
   color: var(--sg-text);
   border: 1px solid var(--sg-border);
@@ -64,12 +64,12 @@ a {
   cursor: pointer;
 }
 
-.sg-toggle:focus-visible {
+body[data-experience] .sg-toggle:focus-visible {
   outline: 2px solid var(--sg-accent);
   outline-offset: 2px;
 }
 
-.sg-skip {
+body[data-experience] .sg-skip {
   position: absolute;
   left: -999px;
   top: auto;
@@ -78,7 +78,7 @@ a {
   overflow: hidden;
 }
 
-.sg-skip:focus {
+body[data-experience] .sg-skip:focus {
   position: static;
   width: auto;
   height: auto;
@@ -88,25 +88,25 @@ a {
   border-radius: var(--sg-radius);
 }
 
-.sg-eyebrow {
+body[data-experience] .sg-eyebrow {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--sg-muted);
   font-weight: 600;
 }
 
-.sg-lede {
+body[data-experience] .sg-lede {
   color: var(--sg-muted);
 }
 
-.sg-main {
+body[data-experience] .sg-main {
   max-width: 960px;
   margin: 0 auto;
   display: grid;
   gap: var(--sg-gap);
 }
 
-.sg-card {
+body[data-experience] .sg-card {
   list-style: none;
   padding: 20px;
   border: 1px solid var(--sg-border);
@@ -114,7 +114,7 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-list {
+body[data-experience] .sg-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -122,7 +122,7 @@ a {
   gap: var(--sg-gap);
 }
 
-.sg-article {
+body[data-experience] .sg-article {
   max-width: 760px;
   margin: 0 auto;
   padding: 24px;
@@ -131,17 +131,29 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-meta {
+body[data-experience] .sg-meta {
   margin-top: var(--sg-gap);
   color: var(--sg-muted);
   font-size: 14px;
 }
 
-.sg-footer {
+body[data-experience] .sg-footer {
   max-width: 960px;
   margin: var(--sg-gap) auto 0 auto;
   padding: 16px 0 var(--sg-gap) 0;
   border-top: 1px solid var(--sg-border);
   color: var(--sg-muted);
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-experience] {
+    scroll-behavior: auto;
+  }
+
+  body[data-experience] * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/generated/immersive/index.html
+++ b/generated/immersive/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="immersive">
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav

--- a/generated/immersive/list.html
+++ b/generated/immersive/list.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>immersive | List</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="./assets/tokens.css">
+    <link rel="stylesheet" href="./assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="immersive">
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>immersive コンテンツ一覧</h1>

--- a/generated/immersive/posts/ep01.html
+++ b/generated/immersive/posts/ep01.html
@@ -5,10 +5,11 @@
     <title>immersive | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <script src="../../shared/features/init-features.js" defer></script>
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="immersive">
     <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>EP01: 開幕、魔界喫茶《∞（インフィニティ）》</h1>
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
@@ -19,7 +20,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>舞台は魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》。</p>

--- a/generated/immersive/posts/welcome-post.html
+++ b/generated/immersive/posts/welcome-post.html
@@ -5,10 +5,11 @@
     <title>immersive | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <script src="../../shared/features/init-features.js" defer></script>
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="immersive">
     <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>ようこそ、魔界喫茶《∞》へ</h1>
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
@@ -19,7 +20,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
       </section>
       <footer class="sg-meta">
         <p>コンテンツ ID: welcome-post</p>

--- a/generated/magazine/assets/components.css
+++ b/generated/magazine/assets/components.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
 }
 
-body {
+body[data-experience] {
   margin: 0;
   padding: 32px;
   background: var(--sg-surface);
@@ -10,22 +10,22 @@ body {
   font-family: var(--sg-font);
 }
 
-a {
+body[data-experience] a {
   color: var(--sg-accent);
 }
 
-.sg-surface {
+body[data-experience] .sg-surface {
   background: var(--sg-surface);
 }
 
-.sg-header {
+body[data-experience] .sg-header {
   max-width: 760px;
   margin: 0 auto var(--sg-gap) auto;
   padding-bottom: var(--sg-gap);
   border-bottom: 1px solid var(--sg-border);
 }
 
-.sg-nav {
+body[data-experience] .sg-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -33,7 +33,7 @@ a {
   margin-bottom: var(--sg-gap);
 }
 
-.sg-nav-links {
+body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -41,7 +41,7 @@ a {
   gap: 12px;
 }
 
-.sg-nav-links a {
+body[data-experience] .sg-nav-links a {
   color: var(--sg-text);
   text-decoration: none;
   padding: 6px 10px;
@@ -49,13 +49,13 @@ a {
   transition: background 0.2s ease;
 }
 
-.sg-nav-links a:hover,
-.sg-nav-links a:focus-visible {
+body[data-experience] .sg-nav-links a:hover,
+body[data-experience] .sg-nav-links a:focus-visible {
   background: var(--sg-border);
   outline: none;
 }
 
-.sg-toggle {
+body[data-experience] .sg-toggle {
   background: var(--sg-panel);
   color: var(--sg-text);
   border: 1px solid var(--sg-border);
@@ -64,12 +64,12 @@ a {
   cursor: pointer;
 }
 
-.sg-toggle:focus-visible {
+body[data-experience] .sg-toggle:focus-visible {
   outline: 2px solid var(--sg-accent);
   outline-offset: 2px;
 }
 
-.sg-skip {
+body[data-experience] .sg-skip {
   position: absolute;
   left: -999px;
   top: auto;
@@ -78,7 +78,7 @@ a {
   overflow: hidden;
 }
 
-.sg-skip:focus {
+body[data-experience] .sg-skip:focus {
   position: static;
   width: auto;
   height: auto;
@@ -88,25 +88,25 @@ a {
   border-radius: var(--sg-radius);
 }
 
-.sg-eyebrow {
+body[data-experience] .sg-eyebrow {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--sg-muted);
   font-weight: 600;
 }
 
-.sg-lede {
+body[data-experience] .sg-lede {
   color: var(--sg-muted);
 }
 
-.sg-main {
+body[data-experience] .sg-main {
   max-width: 960px;
   margin: 0 auto;
   display: grid;
   gap: var(--sg-gap);
 }
 
-.sg-card {
+body[data-experience] .sg-card {
   list-style: none;
   padding: 20px;
   border: 1px solid var(--sg-border);
@@ -114,7 +114,7 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-list {
+body[data-experience] .sg-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -122,7 +122,7 @@ a {
   gap: var(--sg-gap);
 }
 
-.sg-article {
+body[data-experience] .sg-article {
   max-width: 760px;
   margin: 0 auto;
   padding: 24px;
@@ -131,17 +131,29 @@ a {
   background: var(--sg-panel);
 }
 
-.sg-meta {
+body[data-experience] .sg-meta {
   margin-top: var(--sg-gap);
   color: var(--sg-muted);
   font-size: 14px;
 }
 
-.sg-footer {
+body[data-experience] .sg-footer {
   max-width: 960px;
   margin: var(--sg-gap) auto 0 auto;
   padding: 16px 0 var(--sg-gap) 0;
   border-top: 1px solid var(--sg-border);
   color: var(--sg-muted);
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-experience] {
+    scroll-behavior: auto;
+  }
+
+  body[data-experience] * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/generated/magazine/index.html
+++ b/generated/magazine/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="magazine">
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav

--- a/generated/magazine/list.html
+++ b/generated/magazine/list.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>magazine | List</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="./assets/tokens.css">
+    <link rel="stylesheet" href="./assets/components.css">
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="magazine">
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>magazine コンテンツ一覧</h1>

--- a/generated/magazine/posts/ep01.html
+++ b/generated/magazine/posts/ep01.html
@@ -5,10 +5,11 @@
     <title>magazine | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <script src="../../shared/features/init-features.js" defer></script>
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="magazine">
     <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>EP01: 開幕、魔界喫茶《∞（インフィニティ）》</h1>
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
@@ -19,7 +20,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
         <div class="section">
             <h2>◆前回までのあらすじ</h2>
             <p>舞台は魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》。</p>

--- a/generated/magazine/posts/welcome-post.html
+++ b/generated/magazine/posts/welcome-post.html
@@ -5,10 +5,11 @@
     <title>magazine | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <script src="../../shared/features/init-features.js" defer></script>
   </head>
-  <body class="sg-surface">
+  <body class="sg-surface" data-experience="magazine">
     <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
-      <header class="sg-header">
+      <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>ようこそ、魔界喫茶《∞》へ</h1>
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
@@ -19,7 +20,7 @@
           </ul>
         </nav>
       </header>
-      <section class="sg-main">
+      <section class="sg-main" data-content-body>
       </section>
       <footer class="sg-meta">
         <p>コンテンツ ID: welcome-post</p>

--- a/generated/shared/features/init-features.js
+++ b/generated/shared/features/init-features.js
@@ -1,0 +1,13 @@
+(function initFeatures() {
+  try {
+    const contentBody = document.querySelector('[data-content-body]');
+    if (!contentBody) return;
+
+    const features = contentBody.getAttribute('data-features') || '';
+    if (features) {
+      console.info('[features:init]', features);
+    }
+  } catch (error) {
+    console.info('[features:init] skipped due to error', error);
+  }
+})();

--- a/sitegen/build.py
+++ b/sitegen/build.py
@@ -23,6 +23,7 @@ class BuildContext:
     src_root: Path
     out_root: Path
     routes_filename: str = "routes.json"
+    shared_init_features: Path | None = None
     _copied_assets: set[str] = field(default_factory=set, init=False, repr=False)
 
     def templates_dir(self, experience: ExperienceSpec) -> Path:
@@ -228,6 +229,11 @@ def build_detail(
     routes_href = _relative_href(ctx.routes_path(experience), output_file.parent)
     ctx.copy_assets(experience)
     asset_prefix = _relative_href(output_dir, output_file.parent)
+    features_init_href = (
+        _relative_href(ctx.shared_init_features, output_file.parent)
+        if ctx.shared_init_features
+        else None
+    )
 
     env = ctx.jinja_env(experience)
     template = env.get_template("detail.jinja")
@@ -236,6 +242,7 @@ def build_detail(
         content=item,
         routes_href=routes_href,
         asset_prefix=asset_prefix,
+        features_init_href=features_init_href,
         nav_links=[
             {"href": experience.route_patterns.home, "label": "ホーム"},
             {"href": experience.route_patterns.list, "label": "一覧"},

--- a/sitegen/cli.py
+++ b/sitegen/cli.py
@@ -16,6 +16,7 @@ from .build import (
     build_list,
     load_content_items,
 )
+from .shared_gen import generate_init_features_js
 from .models import (
     ContentItem,
     ExperienceSpec,
@@ -474,10 +475,14 @@ def _handle_build(args: argparse.Namespace) -> None:
     src_root = Path(args.src)
     out_root = Path(args.out)
     content_dir = Path(args.content)
+    shared_init_features = (
+        generate_init_features_js(out_root) if args.shared else None
+    )
     ctx = BuildContext(
         src_root=src_root,
         out_root=out_root,
         routes_filename=args.routes_filename,
+        shared_init_features=shared_init_features,
     )
 
     items = load_content_items(content_dir)
@@ -687,6 +692,11 @@ def build_parser() -> argparse.ArgumentParser:
         dest="routes_filename",
         default="routes.json",
         help="Filename for routes JSON used to compute data-routes-href.",
+    )
+    build_parser.add_argument(
+        "--shared",
+        action="store_true",
+        help="Generate shared assets (e.g., feature bootstrap scripts).",
     )
     build_parser.set_defaults(func=_handle_build)
 

--- a/sitegen/shared_gen.py
+++ b/sitegen/shared_gen.py
@@ -1,0 +1,38 @@
+"""Generators for shared assets used across experiences."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .util_fs import ensure_dir
+
+
+def generate_init_features_js(out_dir: Path) -> Path:
+    """Write a defensive bootstrap for feature detection.
+
+    The script lightly inspects the content body and logs any declared features
+    without interrupting page rendering when errors occur.
+    """
+
+    target_dir = ensure_dir(out_dir / "shared" / "features")
+    target_path = target_dir / "init-features.js"
+    script = """
+(function initFeatures() {
+  try {
+    const contentBody = document.querySelector('[data-content-body]');
+    if (!contentBody) return;
+
+    const features = contentBody.getAttribute('data-features') || '';
+    if (features) {
+      console.info('[features:init]', features);
+    }
+  } catch (error) {
+    console.info('[features:init] skipped due to error', error);
+  }
+})();
+"""
+    target_path.write_text(script.lstrip(), encoding="utf-8")
+    return target_path
+
+
+__all__ = ["generate_init_features_js"]


### PR DESCRIPTION
## Summary
- add shared generator for the shared/features init-features.js bootstrap
- wire detail templates to include tts and content body data attributes plus the shared script
- rebuild generated outputs, including the new shared asset

## Testing
- python -m sitegen build --shared

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cc28f7a88333afe66e1540282530)