### PR TITLE
Add route map generator and switcher for experiences

### DIFF
--- a/experience_src/hina/templates/detail.jinja
+++ b/experience_src/hina/templates/detail.jinja
@@ -5,11 +5,23 @@
     <title>hina | Detail</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
     {% if features_init_href %}
     <script src="{{ features_init_href }}" defer></script>
     {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+    data-content-id="{{ content.content_id }}"
+  >
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -19,10 +31,17 @@
         {% endif %}
         <nav>
           <ul class="sg-nav">
-            {% for link in nav_links %}
-            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
-            {% endfor %}
-          </ul>
+          {% for link in nav_links %}
+          <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+          {% endfor %}
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/experience_src/hina/templates/home.jinja
+++ b/experience_src/hina/templates/home.jinja
@@ -5,8 +5,19 @@
     <title>{{ experience.name }} | Home</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+  >
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav
@@ -20,7 +31,14 @@
           <li><a href="{{ link.href }}">{{ link.label }}</a></li>
           {% endfor %}
         </ul>
-        <button type="button" class="sg-toggle" aria-pressed="false">切替</button>
+        <button
+          type="button"
+          class="sg-toggle view-switcher"
+          aria-pressed="false"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
       <p class="sg-eyebrow">Experience</p>
       <h1>{{ experience.name }} ホーム</h1>

--- a/experience_src/hina/templates/list.jinja
+++ b/experience_src/hina/templates/list.jinja
@@ -5,8 +5,19 @@
     <title>hina | List</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+  >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>hina コンテンツ一覧</h1>
@@ -17,6 +28,13 @@
           <li><a href="{{ link.href }}">{{ link.label }}</a></li>
           {% endfor %}
         </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
     </header>
     <main class="sg-main" data-template="list" data-experience="{{ experience.key }}">

--- a/experience_src/immersive/templates/detail.jinja
+++ b/experience_src/immersive/templates/detail.jinja
@@ -5,11 +5,23 @@
     <title>immersive | Detail</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
     {% if features_init_href %}
     <script src="{{ features_init_href }}" defer></script>
     {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+    data-content-id="{{ content.content_id }}"
+  >
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -19,10 +31,17 @@
         {% endif %}
         <nav>
           <ul class="sg-nav">
-            {% for link in nav_links %}
-            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
-            {% endfor %}
-          </ul>
+          {% for link in nav_links %}
+          <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+          {% endfor %}
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/experience_src/immersive/templates/home.jinja
+++ b/experience_src/immersive/templates/home.jinja
@@ -5,8 +5,19 @@
     <title>{{ experience.name }} | Home</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+  >
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav
@@ -20,7 +31,14 @@
           <li><a href="{{ link.href }}">{{ link.label }}</a></li>
           {% endfor %}
         </ul>
-        <button type="button" class="sg-toggle" aria-pressed="false">切替</button>
+        <button
+          type="button"
+          class="sg-toggle view-switcher"
+          aria-pressed="false"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
       <p class="sg-eyebrow">Experience</p>
       <h1>{{ experience.name }} ホーム</h1>

--- a/experience_src/immersive/templates/list.jinja
+++ b/experience_src/immersive/templates/list.jinja
@@ -5,8 +5,19 @@
     <title>immersive | List</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+  >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>immersive コンテンツ一覧</h1>
@@ -17,6 +28,13 @@
           <li><a href="{{ link.href }}">{{ link.label }}</a></li>
           {% endfor %}
         </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
     </header>
     <main class="sg-main" data-template="list" data-experience="{{ experience.key }}">

--- a/experience_src/magazine/templates/detail.jinja
+++ b/experience_src/magazine/templates/detail.jinja
@@ -5,11 +5,23 @@
     <title>magazine | Detail</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
     {% if features_init_href %}
     <script src="{{ features_init_href }}" defer></script>
     {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+    data-content-id="{{ content.content_id }}"
+  >
     <article class="sg-article" data-template="detail" data-content-id="{{ content.content_id }}" data-routes-href="{{ routes_href }}">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -19,10 +31,17 @@
         {% endif %}
         <nav>
           <ul class="sg-nav">
-            {% for link in nav_links %}
-            <li><a href="{{ link.href }}">{{ link.label }}</a></li>
-            {% endfor %}
-          </ul>
+          {% for link in nav_links %}
+          <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+          {% endfor %}
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/experience_src/magazine/templates/home.jinja
+++ b/experience_src/magazine/templates/home.jinja
@@ -5,8 +5,19 @@
     <title>{{ experience.name }} | Home</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+  >
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav
@@ -20,7 +31,14 @@
           <li><a href="{{ link.href }}">{{ link.label }}</a></li>
           {% endfor %}
         </ul>
-        <button type="button" class="sg-toggle" aria-pressed="false">切替</button>
+        <button
+          type="button"
+          class="sg-toggle view-switcher"
+          aria-pressed="false"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
       <p class="sg-eyebrow">Experience</p>
       <h1>{{ experience.name }} ホーム</h1>

--- a/experience_src/magazine/templates/list.jinja
+++ b/experience_src/magazine/templates/list.jinja
@@ -5,8 +5,19 @@
     <title>magazine | List</title>
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/tokens.css">
     <link rel="stylesheet" href="{{ asset_prefix }}/assets/components.css">
+    {% if switcher_css_href %}
+    <link rel="stylesheet" href="{{ switcher_css_href }}">
+    {% endif %}
+    {% if switcher_js_href %}
+    <script src="{{ switcher_js_href }}" defer></script>
+    {% endif %}
   </head>
-  <body class="sg-surface" data-experience="{{ experience.key }}">
+  <body
+    class="sg-surface"
+    data-experience="{{ experience.key }}"
+    data-template="{{ template_key }}"
+    data-routes-href="{{ routes_href }}"
+  >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>magazine コンテンツ一覧</h1>
@@ -17,6 +28,13 @@
           <li><a href="{{ link.href }}">{{ link.label }}</a></li>
           {% endfor %}
         </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
     </header>
     <main class="sg-main" data-template="list" data-experience="{{ experience.key }}">

--- a/generated/hina/index.html
+++ b/generated/hina/index.html
@@ -5,8 +5,15 @@
     <title>Hina Generated Experience | Home</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="../shared/switcher.css">
+    <script src="../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="hina">
+  <body
+    class="sg-surface"
+    data-experience="hina"
+    data-template="home"
+    data-routes-href="routes.json"
+  >
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav
@@ -19,7 +26,14 @@
           <li><a href="/hina/">ホーム</a></li>
           <li><a href="/hina/list">一覧</a></li>
         </ul>
-        <button type="button" class="sg-toggle" aria-pressed="false">切替</button>
+        <button
+          type="button"
+          class="sg-toggle view-switcher"
+          aria-pressed="false"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
       <p class="sg-eyebrow">Experience</p>
       <h1>Hina Generated Experience ホーム</h1>

--- a/generated/hina/list.html
+++ b/generated/hina/list.html
@@ -5,8 +5,15 @@
     <title>hina | List</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="../shared/switcher.css">
+    <script src="../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="hina">
+  <body
+    class="sg-surface"
+    data-experience="hina"
+    data-template="list"
+    data-routes-href="routes.json"
+  >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>hina コンテンツ一覧</h1>
@@ -16,6 +23,13 @@
           <li><a href="/hina/">ホーム</a></li>
           <li><a href="/hina/list">一覧</a></li>
         </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
     </header>
     <main class="sg-main" data-template="list" data-experience="hina">

--- a/generated/hina/posts/ep01.html
+++ b/generated/hina/posts/ep01.html
@@ -5,9 +5,17 @@
     <title>hina | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
     <script src="../../shared/features/init-features.js" defer></script>
+    <script src="../../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="hina">
+  <body
+    class="sg-surface"
+    data-experience="hina"
+    data-template="detail"
+    data-routes-href="../routes.json"
+    data-content-id="ep01"
+  >
     <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -15,9 +23,16 @@
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
         <nav>
           <ul class="sg-nav">
-            <li><a href="/hina/">ホーム</a></li>
-            <li><a href="/hina/list">一覧</a></li>
-          </ul>
+          <li><a href="/hina/">ホーム</a></li>
+          <li><a href="/hina/list">一覧</a></li>
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/generated/hina/posts/welcome-post.html
+++ b/generated/hina/posts/welcome-post.html
@@ -5,9 +5,17 @@
     <title>hina | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
     <script src="../../shared/features/init-features.js" defer></script>
+    <script src="../../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="hina">
+  <body
+    class="sg-surface"
+    data-experience="hina"
+    data-template="detail"
+    data-routes-href="../routes.json"
+    data-content-id="welcome-post"
+  >
     <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -15,9 +23,16 @@
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
         <nav>
           <ul class="sg-nav">
-            <li><a href="/hina/">ホーム</a></li>
-            <li><a href="/hina/list">一覧</a></li>
-          </ul>
+          <li><a href="/hina/">ホーム</a></li>
+          <li><a href="/hina/list">一覧</a></li>
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/generated/hina/routes.json
+++ b/generated/hina/routes.json
@@ -1,0 +1,40 @@
+{
+  "order": [
+    "ruri",
+    "hina",
+    "immersive",
+    "magazine"
+  ],
+  "routes": {
+    "ruri": {
+      "home": "/index.html",
+      "content": {
+        "ep01": "/story1.html"
+      }
+    },
+    "hina": {
+      "home": "/hina/",
+      "list": "/hina/list",
+      "content": {
+        "ep01": "/hina/ep01",
+        "welcome-post": "/hina/welcome-post"
+      }
+    },
+    "immersive": {
+      "home": "/immersive/",
+      "list": "/immersive/list",
+      "content": {
+        "ep01": "/immersive/ep01",
+        "welcome-post": "/immersive/welcome-post"
+      }
+    },
+    "magazine": {
+      "home": "/magazine/",
+      "list": "/magazine/list",
+      "content": {
+        "ep01": "/magazine/ep01",
+        "welcome-post": "/magazine/welcome-post"
+      }
+    }
+  }
+}

--- a/generated/immersive/index.html
+++ b/generated/immersive/index.html
@@ -5,8 +5,15 @@
     <title>Immersive Generated Experience | Home</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="../shared/switcher.css">
+    <script src="../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="immersive">
+  <body
+    class="sg-surface"
+    data-experience="immersive"
+    data-template="home"
+    data-routes-href="routes.json"
+  >
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav
@@ -19,7 +26,14 @@
           <li><a href="/immersive/">ホーム</a></li>
           <li><a href="/immersive/list">一覧</a></li>
         </ul>
-        <button type="button" class="sg-toggle" aria-pressed="false">切替</button>
+        <button
+          type="button"
+          class="sg-toggle view-switcher"
+          aria-pressed="false"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
       <p class="sg-eyebrow">Experience</p>
       <h1>Immersive Generated Experience ホーム</h1>

--- a/generated/immersive/list.html
+++ b/generated/immersive/list.html
@@ -5,8 +5,15 @@
     <title>immersive | List</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="../shared/switcher.css">
+    <script src="../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="immersive">
+  <body
+    class="sg-surface"
+    data-experience="immersive"
+    data-template="list"
+    data-routes-href="routes.json"
+  >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>immersive コンテンツ一覧</h1>
@@ -16,6 +23,13 @@
           <li><a href="/immersive/">ホーム</a></li>
           <li><a href="/immersive/list">一覧</a></li>
         </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
     </header>
     <main class="sg-main" data-template="list" data-experience="immersive">

--- a/generated/immersive/posts/ep01.html
+++ b/generated/immersive/posts/ep01.html
@@ -5,9 +5,17 @@
     <title>immersive | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
     <script src="../../shared/features/init-features.js" defer></script>
+    <script src="../../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="immersive">
+  <body
+    class="sg-surface"
+    data-experience="immersive"
+    data-template="detail"
+    data-routes-href="../routes.json"
+    data-content-id="ep01"
+  >
     <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -15,9 +23,16 @@
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
         <nav>
           <ul class="sg-nav">
-            <li><a href="/immersive/">ホーム</a></li>
-            <li><a href="/immersive/list">一覧</a></li>
-          </ul>
+          <li><a href="/immersive/">ホーム</a></li>
+          <li><a href="/immersive/list">一覧</a></li>
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/generated/immersive/posts/welcome-post.html
+++ b/generated/immersive/posts/welcome-post.html
@@ -5,9 +5,17 @@
     <title>immersive | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
     <script src="../../shared/features/init-features.js" defer></script>
+    <script src="../../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="immersive">
+  <body
+    class="sg-surface"
+    data-experience="immersive"
+    data-template="detail"
+    data-routes-href="../routes.json"
+    data-content-id="welcome-post"
+  >
     <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -15,9 +23,16 @@
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
         <nav>
           <ul class="sg-nav">
-            <li><a href="/immersive/">ホーム</a></li>
-            <li><a href="/immersive/list">一覧</a></li>
-          </ul>
+          <li><a href="/immersive/">ホーム</a></li>
+          <li><a href="/immersive/list">一覧</a></li>
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/generated/immersive/routes.json
+++ b/generated/immersive/routes.json
@@ -1,0 +1,40 @@
+{
+  "order": [
+    "ruri",
+    "hina",
+    "immersive",
+    "magazine"
+  ],
+  "routes": {
+    "ruri": {
+      "home": "/index.html",
+      "content": {
+        "ep01": "/story1.html"
+      }
+    },
+    "hina": {
+      "home": "/hina/",
+      "list": "/hina/list",
+      "content": {
+        "ep01": "/hina/ep01",
+        "welcome-post": "/hina/welcome-post"
+      }
+    },
+    "immersive": {
+      "home": "/immersive/",
+      "list": "/immersive/list",
+      "content": {
+        "ep01": "/immersive/ep01",
+        "welcome-post": "/immersive/welcome-post"
+      }
+    },
+    "magazine": {
+      "home": "/magazine/",
+      "list": "/magazine/list",
+      "content": {
+        "ep01": "/magazine/ep01",
+        "welcome-post": "/magazine/welcome-post"
+      }
+    }
+  }
+}

--- a/generated/magazine/index.html
+++ b/generated/magazine/index.html
@@ -5,8 +5,15 @@
     <title>Magazine Generated Experience | Home</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="../shared/switcher.css">
+    <script src="../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="magazine">
+  <body
+    class="sg-surface"
+    data-experience="magazine"
+    data-template="home"
+    data-routes-href="routes.json"
+  >
     <a class="sg-skip" href="#content">メインコンテンツへスキップ</a>
     <header class="sg-header">
       <nav
@@ -19,7 +26,14 @@
           <li><a href="/magazine/">ホーム</a></li>
           <li><a href="/magazine/list">一覧</a></li>
         </ul>
-        <button type="button" class="sg-toggle" aria-pressed="false">切替</button>
+        <button
+          type="button"
+          class="sg-toggle view-switcher"
+          aria-pressed="false"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
       <p class="sg-eyebrow">Experience</p>
       <h1>Magazine Generated Experience ホーム</h1>

--- a/generated/magazine/list.html
+++ b/generated/magazine/list.html
@@ -5,8 +5,15 @@
     <title>magazine | List</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/components.css">
+    <link rel="stylesheet" href="../shared/switcher.css">
+    <script src="../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="magazine">
+  <body
+    class="sg-surface"
+    data-experience="magazine"
+    data-template="list"
+    data-routes-href="routes.json"
+  >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
       <h1>magazine コンテンツ一覧</h1>
@@ -16,6 +23,13 @@
           <li><a href="/magazine/">ホーム</a></li>
           <li><a href="/magazine/list">一覧</a></li>
         </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
       </nav>
     </header>
     <main class="sg-main" data-template="list" data-experience="magazine">

--- a/generated/magazine/posts/ep01.html
+++ b/generated/magazine/posts/ep01.html
@@ -5,9 +5,17 @@
     <title>magazine | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
     <script src="../../shared/features/init-features.js" defer></script>
+    <script src="../../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="magazine">
+  <body
+    class="sg-surface"
+    data-experience="magazine"
+    data-template="detail"
+    data-routes-href="../routes.json"
+    data-content-id="ep01"
+  >
     <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -15,9 +23,16 @@
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
         <nav>
           <ul class="sg-nav">
-            <li><a href="/magazine/">ホーム</a></li>
-            <li><a href="/magazine/list">一覧</a></li>
-          </ul>
+          <li><a href="/magazine/">ホーム</a></li>
+          <li><a href="/magazine/list">一覧</a></li>
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/generated/magazine/posts/welcome-post.html
+++ b/generated/magazine/posts/welcome-post.html
@@ -5,9 +5,17 @@
     <title>magazine | Detail</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
     <script src="../../shared/features/init-features.js" defer></script>
+    <script src="../../shared/switcher.js" defer></script>
   </head>
-  <body class="sg-surface" data-experience="magazine">
+  <body
+    class="sg-surface"
+    data-experience="magazine"
+    data-template="detail"
+    data-routes-href="../routes.json"
+    data-content-id="welcome-post"
+  >
     <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
@@ -15,9 +23,16 @@
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
         <nav>
           <ul class="sg-nav">
-            <li><a href="/magazine/">ホーム</a></li>
-            <li><a href="/magazine/list">一覧</a></li>
-          </ul>
+          <li><a href="/magazine/">ホーム</a></li>
+          <li><a href="/magazine/list">一覧</a></li>
+        </ul>
+        <button
+          type="button"
+          class="view-switcher"
+          data-action="switch-experience"
+        >
+          体験を切り替える
+        </button>
         </nav>
       </header>
       <section class="sg-main" data-content-body>

--- a/generated/magazine/routes.json
+++ b/generated/magazine/routes.json
@@ -1,0 +1,40 @@
+{
+  "order": [
+    "ruri",
+    "hina",
+    "immersive",
+    "magazine"
+  ],
+  "routes": {
+    "ruri": {
+      "home": "/index.html",
+      "content": {
+        "ep01": "/story1.html"
+      }
+    },
+    "hina": {
+      "home": "/hina/",
+      "list": "/hina/list",
+      "content": {
+        "ep01": "/hina/ep01",
+        "welcome-post": "/hina/welcome-post"
+      }
+    },
+    "immersive": {
+      "home": "/immersive/",
+      "list": "/immersive/list",
+      "content": {
+        "ep01": "/immersive/ep01",
+        "welcome-post": "/immersive/welcome-post"
+      }
+    },
+    "magazine": {
+      "home": "/magazine/",
+      "list": "/magazine/list",
+      "content": {
+        "ep01": "/magazine/ep01",
+        "welcome-post": "/magazine/welcome-post"
+      }
+    }
+  }
+}

--- a/generated/shared/switcher.css
+++ b/generated/shared/switcher.css
@@ -1,0 +1,17 @@
+.view-switcher {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  padding: 10px 12px;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+.view-switcher:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.26);
+}
+

--- a/generated/shared/switcher.js
+++ b/generated/shared/switcher.js
@@ -1,0 +1,47 @@
+(function experienceSwitcher() {
+  const button = document.querySelector('button.view-switcher[data-action="switch-experience"]');
+  const { experience: current, contentId, routesHref } = document.body.dataset || {};
+  if (!button || !routesHref || !current) return;
+
+  const routesUrl = new URL(routesHref, window.location.href);
+  let cache = null;
+
+  async function loadRoutes() {
+    if (cache) return cache;
+    const response = await fetch(routesUrl.href);
+    if (!response.ok) {
+      throw new Error(`Failed to load routes: ${response.status}`);
+    }
+    cache = await response.json();
+    return cache;
+  }
+
+  button.addEventListener('click', async () => {
+    try {
+      const payload = await loadRoutes();
+      const order = payload.order || [];
+      if (!order.length) return;
+
+      const currentIndex = order.indexOf(current);
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % order.length;
+      const nextKey = order[nextIndex];
+      const nextRoutes = payload.routes?.[nextKey];
+      if (!nextRoutes) return;
+
+      let target = null;
+      if (contentId && nextRoutes.content && nextRoutes.content[contentId]) {
+        target = nextRoutes.content[contentId];
+      }
+      if (!target) {
+        target = nextRoutes.home || null;
+      }
+      if (!target) return;
+
+      const resolved = new URL(target, routesUrl.href);
+      window.location.href = resolved.href;
+    } catch (error) {
+      console.warn("[switcher] navigation skipped", error);
+    }
+  });
+})();
+

--- a/index.html
+++ b/index.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
+
 <html lang="ja">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
-  <meta name="color-scheme" content="dark light" />
-  <title>結城ユイの成長物語｜瑠璃の宝石スタイル</title>
-  <meta name="description" content="サキュバスメイド喫茶《∞》を舞台に、結城ユイが“世界の見方”を磨いていく12話の成長物語。各話リンクとキャラクター紹介。" />
-  <meta property="og:title" content="結城ユイの成長物語｜瑠璃の宝石スタイル" />
-  <meta property="og:description" content="12話のリンクと、ネタバレしない紹介＆キャラクター紹介。" />
-  <meta property="og:type" content="website" />
-  <style>
+<meta charset="utf-8"/>
+<meta content="width=device-width,initial-scale=1,viewport-fit=cover" name="viewport"/>
+<meta content="dark light" name="color-scheme"/>
+<title>結城ユイの成長物語｜瑠璃の宝石スタイル</title>
+<meta content="サキュバスメイド喫茶《∞》を舞台に、結城ユイが“世界の見方”を磨いていく12話の成長物語。各話リンクとキャラクター紹介。" name="description"/>
+<meta content="結城ユイの成長物語｜瑠璃の宝石スタイル" property="og:title"/>
+<meta content="12話のリンクと、ネタバレしない紹介＆キャラクター紹介。" property="og:description"/>
+<meta content="website" property="og:type"/>
+<style>
     /* =========
        Theme: "Ruri Gem"
        ========= */
@@ -588,424 +589,381 @@
       .sparkles{ display:none; }
     }
   </style>
-</head>
-
-<body>
-  <a class="skip" href="#content">本文へスキップ</a>
-
-  <header class="topbar" role="banner">
-    <div class="topbar-inner">
-      <a class="brand" href="#" aria-label="トップへ">
-        <div class="mark" aria-hidden="true"></div>
-        <div class="brand-title">
-          <b>結城ユイの成長物語</b>
-          <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
-        </div>
-      </a>
-
-      <nav class="nav" aria-label="ページ内ナビゲーション">
-        <a href="#about">紹介</a>
-        <a href="#episodes">12話</a>
-        <a href="#characters">キャラクター</a>
-        <a class="cta" href="story1.html" aria-label="第1話を読む">第1話へ</a>
-      </nav>
-    </div>
-  </header>
-
-  <div class="hero" id="top">
-    <div class="panel hero-left reveal">
-      <div class="sparkles" aria-hidden="true" id="sparkles"></div>
-
-      <div class="hero-kicker">
-        <span class="dot" aria-hidden="true"></span>
-        <span>RURI GEM STORY • 12 EPISODES</span>
-      </div>
-
-      <h1>
+<link href="shared/switcher.css" rel="stylesheet" type="text/css"/><script defer="defer" src="shared/switcher.js"></script></head>
+<body data-experience="ruri" data-routes-href="routes.json" data-template="home">
+<a class="skip" href="#content">本文へスキップ</a>
+<header class="topbar" role="banner">
+<div class="topbar-inner">
+<a aria-label="トップへ" class="brand" href="#">
+<div aria-hidden="true" class="mark"></div>
+<div class="brand-title">
+<b>結城ユイの成長物語</b>
+<span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+</div>
+</a>
+<nav aria-label="ページ内ナビゲーション" class="nav">
+<a href="#about">紹介</a>
+<a href="#episodes">12話</a>
+<a href="#characters">キャラクター</a>
+<a aria-label="第1話を読む" class="cta" href="story1.html">第1話へ</a>
+<button class="view-switcher" data-action="switch-experience" type="button">体験を切り替える</button></nav>
+</div>
+</header>
+<div class="hero" id="top">
+<div class="panel hero-left reveal">
+<div aria-hidden="true" class="sparkles" id="sparkles"></div>
+<div class="hero-kicker">
+<span aria-hidden="true" class="dot"></span>
+<span>RURI GEM STORY • 12 EPISODES</span>
+</div>
+<h1>
         “世界の見方”は、拾い集めた小さな宝石で磨かれていく。
       </h1>
-
-      <p class="sub">
+<p class="sub">
         サキュバスメイド喫茶《∞》を舞台に、新人テストエンジニア・結城ユイが、
         伝説的な大先輩と出会い、迷いながらも視点を研いでいく成長物語。
         ここでは<strong>ネタバレなし</strong>で、12話への入口だけをきらめかせます。
       </p>
-
-      <div class="badge-row" aria-label="作品の雰囲気">
-        <div class="badge"><strong>舞台</strong>：喫茶《∞》の夜</div>
-        <div class="badge"><strong>テイスト</strong>：瑠璃 × 宝石 × ほの甘</div>
-        <div class="badge"><strong>読み味</strong>：1話1粒の気づき</div>
-      </div>
-
-      <div class="actions">
-        <a class="btn primary" href="story1.html">
+<div aria-label="作品の雰囲気" class="badge-row">
+<div class="badge"><strong>舞台</strong>：喫茶《∞》の夜</div>
+<div class="badge"><strong>テイスト</strong>：瑠璃 × 宝石 × ほの甘</div>
+<div class="badge"><strong>読み味</strong>：1話1粒の気づき</div>
+</div>
+<div class="actions">
+<a class="btn primary" href="story1.html">
           物語をひらく
-          <svg class="arrow" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-            <path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        </a>
-        <a class="btn" href="#episodes">12話を選ぶ</a>
-        <a class="btn" href="#characters">登場人物</a>
-      </div>
-    </div>
-
-    <div class="panel hero-right reveal" aria-label="瑠璃の宝石イラスト">
-      <div class="gem-wrap" role="img" aria-label="瑠璃色の宝石（装飾）">
-        <div class="glow" aria-hidden="true"></div>
-        <svg class="gem" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
-          <defs>
-            <linearGradient id="g0" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0" stop-color="#32e3d6" stop-opacity="0.95"/>
-              <stop offset="0.55" stop-color="#2d63ff" stop-opacity="0.95"/>
-              <stop offset="1" stop-color="#1f3bb5" stop-opacity="0.95"/>
-            </linearGradient>
-            <linearGradient id="g1" x1="1" y1="0" x2="0" y2="1">
-              <stop offset="0" stop-color="#ffd37a" stop-opacity="0.85"/>
-              <stop offset="0.5" stop-color="#ff4d8d" stop-opacity="0.65"/>
-              <stop offset="1" stop-color="#2d63ff" stop-opacity="0.85"/>
-            </linearGradient>
-            <filter id="softGlow" x="-40%" y="-40%" width="180%" height="180%">
-              <feGaussianBlur stdDeviation="6" result="blur"/>
-              <feColorMatrix in="blur" type="matrix"
-                values="1 0 0 0 0
+          <svg aria-hidden="true" class="arrow" fill="none" viewbox="0 0 24 24">
+<path d="M9 18l6-6-6-6" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.4"></path>
+</svg>
+</a>
+<a class="btn" href="#episodes">12話を選ぶ</a>
+<a class="btn" href="#characters">登場人物</a>
+</div>
+</div>
+<div aria-label="瑠璃の宝石イラスト" class="panel hero-right reveal">
+<div aria-label="瑠璃色の宝石（装飾）" class="gem-wrap" role="img">
+<div aria-hidden="true" class="glow"></div>
+<svg class="gem" viewbox="0 0 300 300" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<lineargradient id="g0" x1="0" x2="1" y1="0" y2="1">
+<stop offset="0" stop-color="#32e3d6" stop-opacity="0.95"></stop>
+<stop offset="0.55" stop-color="#2d63ff" stop-opacity="0.95"></stop>
+<stop offset="1" stop-color="#1f3bb5" stop-opacity="0.95"></stop>
+</lineargradient>
+<lineargradient id="g1" x1="1" x2="0" y1="0" y2="1">
+<stop offset="0" stop-color="#ffd37a" stop-opacity="0.85"></stop>
+<stop offset="0.5" stop-color="#ff4d8d" stop-opacity="0.65"></stop>
+<stop offset="1" stop-color="#2d63ff" stop-opacity="0.85"></stop>
+</lineargradient>
+<filter height="180%" id="softGlow" width="180%" x="-40%" y="-40%">
+<fegaussianblur result="blur" stddeviation="6"></fegaussianblur>
+<fecolormatrix in="blur" result="colored" type="matrix" values="1 0 0 0 0
                         0 1 0 0 0
                         0 0 1 0 0
-                        0 0 0 0.55 0" result="colored"/>
-              <feMerge>
-                <feMergeNode in="colored"/>
-                <feMergeNode in="SourceGraphic"/>
-              </feMerge>
-            </filter>
-          </defs>
-
-          <!-- Outer facet -->
-          <path d="M150 18
+                        0 0 0 0.55 0"></fecolormatrix>
+<femerge>
+<femergenode in="colored"></femergenode>
+<femergenode in="SourceGraphic"></femergenode>
+</femerge>
+</filter>
+</defs>
+<!-- Outer facet -->
+<path d="M150 18
                    L236 70
                    L278 160
                    L214 252
                    L150 282
                    L86 252
                    L22 160
-                   L64 70 Z"
-                fill="url(#g0)" filter="url(#softGlow)" opacity="0.98"/>
-
-          <!-- Inner facets -->
-          <path d="M150 28 L214 74 L246 154 L196 232 L150 258 L104 232 L54 154 L86 74 Z"
-                fill="rgba(255,255,255,.08)" />
-          <path d="M150 28 L214 74 L150 154 L86 74 Z" fill="rgba(255,255,255,.10)"/>
-          <path d="M86 74 L150 154 L54 154 Z" fill="rgba(255,255,255,.06)"/>
-          <path d="M214 74 L246 154 L150 154 Z" fill="rgba(255,255,255,.06)"/>
-          <path d="M150 154 L246 154 L196 232 Z" fill="rgba(255,255,255,.05)"/>
-          <path d="M54 154 L150 154 L104 232 Z" fill="rgba(255,255,255,.05)"/>
-
-          <!-- Highlight -->
-          <path d="M92 88 C120 62, 168 55, 204 78
+                   L64 70 Z" fill="url(#g0)" filter="url(#softGlow)" opacity="0.98"></path>
+<!-- Inner facets -->
+<path d="M150 28 L214 74 L246 154 L196 232 L150 258 L104 232 L54 154 L86 74 Z" fill="rgba(255,255,255,.08)"></path>
+<path d="M150 28 L214 74 L150 154 L86 74 Z" fill="rgba(255,255,255,.10)"></path>
+<path d="M86 74 L150 154 L54 154 Z" fill="rgba(255,255,255,.06)"></path>
+<path d="M214 74 L246 154 L150 154 Z" fill="rgba(255,255,255,.06)"></path>
+<path d="M150 154 L246 154 L196 232 Z" fill="rgba(255,255,255,.05)"></path>
+<path d="M54 154 L150 154 L104 232 Z" fill="rgba(255,255,255,.05)"></path>
+<!-- Highlight -->
+<path d="M92 88 C120 62, 168 55, 204 78
                    C168 92, 134 112, 118 142
-                   C106 118, 96 100, 92 88 Z"
-                fill="rgba(255,255,255,.18)"/>
-          <circle cx="98" cy="82" r="10" fill="rgba(255,255,255,.20)"/>
-          <circle cx="108" cy="74" r="6" fill="rgba(255,255,255,.22)"/>
-
-          <!-- Rim shimmer -->
-          <path d="M150 18
+                   C106 118, 96 100, 92 88 Z" fill="rgba(255,255,255,.18)"></path>
+<circle cx="98" cy="82" fill="rgba(255,255,255,.20)" r="10"></circle>
+<circle cx="108" cy="74" fill="rgba(255,255,255,.22)" r="6"></circle>
+<!-- Rim shimmer -->
+<path d="M150 18
                    L236 70
                    L278 160
                    L214 252
                    L150 282
                    L86 252
                    L22 160
-                   L64 70 Z"
-                fill="none" stroke="url(#g1)" stroke-width="3.2" opacity="0.85"/>
-        </svg>
-      </div>
-    </div>
-  </div>
-
-  <main id="content" role="main">
-    <!-- About -->
-    <section id="about" class="reveal">
-      <div class="section-title">
-        <h2>紹介（ネタバレなし）</h2>
-        <p>
+                   L64 70 Z" fill="none" opacity="0.85" stroke="url(#g1)" stroke-width="3.2"></path>
+</svg>
+</div>
+</div>
+</div>
+<main id="content" role="main">
+<!-- About -->
+<section class="reveal" id="about">
+<div class="section-title">
+<h2>紹介（ネタバレなし）</h2>
+<p>
           これは「正解を当てる話」ではなく、<strong>見え方が変わっていく話</strong>。
           失敗も、迷いも、誰かの言葉も、全部“瑠璃の欠片”みたいに光っていきます。
         </p>
-      </div>
-
-      <div class="two-col">
-        <article class="card">
-          <h3>
-            <span class="chip">世界観</span>
+</div>
+<div class="two-col">
+<article class="card">
+<h3>
+<span class="chip">世界観</span>
             サキュバスメイド喫茶《∞》の、きらめく現場
           </h3>
-          <p>
+<p>
             甘い匂いとネオンの間で、ユイは“なんとなく”から抜け出したいと思い始める。
             目の前の出来事に名前がつき、線が引けるようになったとき、世界は少しだけ優しくなる。
           </p>
-          <div class="meta" aria-label="キーワード">
-            <span class="tag">観察</span>
-            <span class="tag">分類</span>
-            <span class="tag">境界</span>
-            <span class="tag">地図</span>
-            <span class="tag">ログ</span>
-          </div>
-        </article>
-
-        <article class="card">
-          <h3>
-            <span class="chip">読みどころ</span>
+<div aria-label="キーワード" class="meta">
+<span class="tag">観察</span>
+<span class="tag">分類</span>
+<span class="tag">境界</span>
+<span class="tag">地図</span>
+<span class="tag">ログ</span>
+</div>
+</article>
+<article class="card">
+<h3>
+<span class="chip">読みどころ</span>
             1話1粒、“宝石みたいな気づき”
           </h3>
-          <p>
+<p>
             各話は短編のように読めて、でも繋がっている。
             何かを学ぶというより、<strong>見える範囲が広がる</strong>感覚を楽しむ物語です。
           </p>
-          <div class="meta" aria-label="雰囲気">
-            <span class="tag">成長</span>
-            <span class="tag">師弟</span>
-            <span class="tag">やさしい刺さり</span>
-            <span class="tag">夜の余韻</span>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <!-- Episodes -->
-    <section id="episodes" class="reveal">
-      <div class="section-title">
-        <h2>12話リンク</h2>
-        <p>気になる“石（テーマ）”から選んでもOK。もちろん第1話からでも。</p>
-      </div>
-
-      <div class="grid" role="list">
-        <!-- 1 -->
-        <article class="episode" role="listitem">
-          <a href="story1.html" aria-label="第1話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 01</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>はじまりの欠片</div>
-            </div>
-            <h3 class="ep-title">キラキラした背中と、ダメ出しの夜</h3>
-            <p class="ep-tease">同じ景色なのに、切り取り方が違う——その差に、胸が鳴る。</p>
-          </a>
-        </article>
-
-        <!-- 2 -->
-        <article class="episode" role="listitem">
-          <a href="story2.html" aria-label="第2話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 02</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>世界の輪郭</div>
-            </div>
-            <h3 class="ep-title">世界 W は、仕様書の外に広がってる</h3>
-            <p class="ep-tease">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
-          </a>
-        </article>
-
-        <!-- 3 -->
-        <article class="episode" role="listitem">
-          <a href="story3.html" aria-label="第3話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 03</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>束ねる石</div>
-            </div>
-            <h3 class="ep-title">同値クラスという、お守りの石</h3>
-            <p class="ep-tease">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
-          </a>
-        </article>
-
-        <!-- 4 -->
-        <article class="episode" role="listitem">
-          <a href="story4.html" aria-label="第4話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 04</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>境界の光</div>
-            </div>
-            <h3 class="ep-title">境界線を、一緒に歩いた夜</h3>
-            <p class="ep-tease">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
-          </a>
-        </article>
-
-        <!-- 5 -->
-        <article class="episode" role="listitem">
-          <a href="story5.html" aria-label="第5話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 05</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>分岐の地図</div>
-            </div>
-            <h3 class="ep-title">分岐の森と、先輩の地図</h3>
-            <p class="ep-tease">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
-          </a>
-        </article>
-
-        <!-- 6 -->
-        <article class="episode" role="listitem">
-          <a href="story6.html" aria-label="第6話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 06</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>変化の矢印</div>
-            </div>
-            <h3 class="ep-title">関係は、状態遷移で語れる</h3>
-            <p class="ep-tease">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
-          </a>
-        </article>
-
-        <!-- 7 -->
-        <article class="episode" role="listitem">
-          <a href="story7.html" aria-label="第7話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 07</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>選ぶ勇気</div>
-            </div>
-            <h3 class="ep-title">全部は試せない、という優しさ</h3>
-            <p class="ep-tease">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
-          </a>
-        </article>
-
-        <!-- 8 -->
-        <article class="episode" role="listitem">
-          <a href="story8.html" aria-label="第8話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 08</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>虹の目盛り</div>
-            </div>
-            <h3 class="ep-title">カバレッジの虹を見上げて</h3>
-            <p class="ep-tease">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
-          </a>
-        </article>
-
-        <!-- 9 -->
-        <article class="episode" role="listitem">
-          <a href="story9.html" aria-label="第9話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 09</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>手紙の音</div>
-            </div>
-            <h3 class="ep-title">ログは、システムからのラブレター</h3>
-            <p class="ep-tease">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
-          </a>
-        </article>
-
-        <!-- 10 -->
-        <article class="episode" role="listitem">
-          <a href="story10.html" aria-label="第10話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 10</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>魔導書と手</div>
-            </div>
-            <h3 class="ep-title">魔導書と職人の手、Fθと G</h3>
-            <p class="ep-tease">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
-          </a>
-        </article>
-
-        <!-- 11 -->
-        <article class="episode" role="listitem">
-          <a href="story11.html" aria-label="第11話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 11</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>迷いの証</div>
-            </div>
-            <h3 class="ep-title">先輩も、迷っていた</h3>
-            <p class="ep-tease">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
-          </a>
-        </article>
-
-        <!-- 12 -->
-        <article class="episode" role="listitem">
-          <a href="story12.html" aria-label="第12話へ">
-            <div class="ep-top">
-              <div class="ep-no">EP 12</div>
-              <div class="ep-gem"><span class="mini" aria-hidden="true"></span>地図を渡す</div>
-            </div>
-            <h3 class="ep-title">次の子に渡す、G の地図</h3>
-            <p class="ep-tease">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
-          </a>
-        </article>
-      </div>
-    </section>
-
-    <!-- Characters -->
-    <section id="characters" class="reveal">
-      <div class="section-title">
-        <h2>キャラクター紹介</h2>
-        <p>“誰が、どんな背中を見せるのか”。ここでは輪郭だけをそっと。</p>
-      </div>
-
-      <div class="two-col">
-        <article class="card">
-          <h3><span class="chip">主人公</span> 結城ユイ（ユイリア）</h3>
-          <p>
-            サキュバスメイド喫茶《∞》で働く新人テストエンジニア。<br />
+<div aria-label="雰囲気" class="meta">
+<span class="tag">成長</span>
+<span class="tag">師弟</span>
+<span class="tag">やさしい刺さり</span>
+<span class="tag">夜の余韻</span>
+</div>
+</article>
+</div>
+</section>
+<!-- Episodes -->
+<section class="reveal" id="episodes">
+<div class="section-title">
+<h2>12話リンク</h2>
+<p>気になる“石（テーマ）”から選んでもOK。もちろん第1話からでも。</p>
+</div>
+<div class="grid" role="list">
+<!-- 1 -->
+<article class="episode" role="listitem">
+<a aria-label="第1話へ" href="story1.html">
+<div class="ep-top">
+<div class="ep-no">EP 01</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>はじまりの欠片</div>
+</div>
+<h3 class="ep-title">キラキラした背中と、ダメ出しの夜</h3>
+<p class="ep-tease">同じ景色なのに、切り取り方が違う——その差に、胸が鳴る。</p>
+</a>
+</article>
+<!-- 2 -->
+<article class="episode" role="listitem">
+<a aria-label="第2話へ" href="story2.html">
+<div class="ep-top">
+<div class="ep-no">EP 02</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>世界の輪郭</div>
+</div>
+<h3 class="ep-title">世界 W は、仕様書の外に広がってる</h3>
+<p class="ep-tease">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+</a>
+</article>
+<!-- 3 -->
+<article class="episode" role="listitem">
+<a aria-label="第3話へ" href="story3.html">
+<div class="ep-top">
+<div class="ep-no">EP 03</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>束ねる石</div>
+</div>
+<h3 class="ep-title">同値クラスという、お守りの石</h3>
+<p class="ep-tease">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+</a>
+</article>
+<!-- 4 -->
+<article class="episode" role="listitem">
+<a aria-label="第4話へ" href="story4.html">
+<div class="ep-top">
+<div class="ep-no">EP 04</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>境界の光</div>
+</div>
+<h3 class="ep-title">境界線を、一緒に歩いた夜</h3>
+<p class="ep-tease">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+</a>
+</article>
+<!-- 5 -->
+<article class="episode" role="listitem">
+<a aria-label="第5話へ" href="story5.html">
+<div class="ep-top">
+<div class="ep-no">EP 05</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>分岐の地図</div>
+</div>
+<h3 class="ep-title">分岐の森と、先輩の地図</h3>
+<p class="ep-tease">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+</a>
+</article>
+<!-- 6 -->
+<article class="episode" role="listitem">
+<a aria-label="第6話へ" href="story6.html">
+<div class="ep-top">
+<div class="ep-no">EP 06</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>変化の矢印</div>
+</div>
+<h3 class="ep-title">関係は、状態遷移で語れる</h3>
+<p class="ep-tease">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+</a>
+</article>
+<!-- 7 -->
+<article class="episode" role="listitem">
+<a aria-label="第7話へ" href="story7.html">
+<div class="ep-top">
+<div class="ep-no">EP 07</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>選ぶ勇気</div>
+</div>
+<h3 class="ep-title">全部は試せない、という優しさ</h3>
+<p class="ep-tease">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+</a>
+</article>
+<!-- 8 -->
+<article class="episode" role="listitem">
+<a aria-label="第8話へ" href="story8.html">
+<div class="ep-top">
+<div class="ep-no">EP 08</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>虹の目盛り</div>
+</div>
+<h3 class="ep-title">カバレッジの虹を見上げて</h3>
+<p class="ep-tease">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+</a>
+</article>
+<!-- 9 -->
+<article class="episode" role="listitem">
+<a aria-label="第9話へ" href="story9.html">
+<div class="ep-top">
+<div class="ep-no">EP 09</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>手紙の音</div>
+</div>
+<h3 class="ep-title">ログは、システムからのラブレター</h3>
+<p class="ep-tease">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+</a>
+</article>
+<!-- 10 -->
+<article class="episode" role="listitem">
+<a aria-label="第10話へ" href="story10.html">
+<div class="ep-top">
+<div class="ep-no">EP 10</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>魔導書と手</div>
+</div>
+<h3 class="ep-title">魔導書と職人の手、Fθと G</h3>
+<p class="ep-tease">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+</a>
+</article>
+<!-- 11 -->
+<article class="episode" role="listitem">
+<a aria-label="第11話へ" href="story11.html">
+<div class="ep-top">
+<div class="ep-no">EP 11</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>迷いの証</div>
+</div>
+<h3 class="ep-title">先輩も、迷っていた</h3>
+<p class="ep-tease">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+</a>
+</article>
+<!-- 12 -->
+<article class="episode" role="listitem">
+<a aria-label="第12話へ" href="story12.html">
+<div class="ep-top">
+<div class="ep-no">EP 12</div>
+<div class="ep-gem"><span aria-hidden="true" class="mini"></span>地図を渡す</div>
+</div>
+<h3 class="ep-title">次の子に渡す、G の地図</h3>
+<p class="ep-tease">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+</a>
+</article>
+</div>
+</section>
+<!-- Characters -->
+<section class="reveal" id="characters">
+<div class="section-title">
+<h2>キャラクター紹介</h2>
+<p>“誰が、どんな背中を見せるのか”。ここでは輪郭だけをそっと。</p>
+</div>
+<div class="two-col">
+<article class="card">
+<h3><span class="chip">主人公</span> 結城ユイ（ユイリア）</h3>
+<p>
+            サキュバスメイド喫茶《∞》で働く新人テストエンジニア。<br/>
             知っているのは用語だけ。いつも場当たり的で、でも——だからこそ、伸びしろが眩しい。
           </p>
-          <div class="meta">
-            <span class="tag">新人</span>
-            <span class="tag">まっすぐ</span>
-            <span class="tag">学びが体温</span>
-          </div>
-        </article>
-
-        <article class="card">
-          <h3><span class="chip">大先輩</span> 神崎ナギ（かんざき・ナギ）</h3>
-          <p>
-            魔界テック界隈で伝説的なテストアーキテクト。<br />
+<div class="meta">
+<span class="tag">新人</span>
+<span class="tag">まっすぐ</span>
+<span class="tag">学びが体温</span>
+</div>
+</article>
+<article class="card">
+<h3><span class="chip">大先輩</span> 神崎ナギ（かんざき・ナギ）</h3>
+<p>
+            魔界テック界隈で伝説的なテストアーキテクト。<br/>
             落ち着いた笑顔で、核心をすっと差し出す。“こうなりたい”と思わせる背中。
           </p>
-          <div class="meta">
-            <span class="tag">静かな強さ</span>
-            <span class="tag">言葉が地図</span>
-            <span class="tag">穏やかに刺す</span>
-          </div>
-        </article>
-
-        <article class="card">
-          <h3><span class="chip">オーナー</span> バルハ</h3>
-          <p>
-            喫茶《∞》のオーナー。二人の成長を少し離れた場所から見つめる存在。<br />
+<div class="meta">
+<span class="tag">静かな強さ</span>
+<span class="tag">言葉が地図</span>
+<span class="tag">穏やかに刺す</span>
+</div>
+</article>
+<article class="card">
+<h3><span class="chip">オーナー</span> バルハ</h3>
+<p>
+            喫茶《∞》のオーナー。二人の成長を少し離れた場所から見つめる存在。<br/>
             舞台の空気を整え、物語の火種をそっと置く。
           </p>
-          <div class="meta">
-            <span class="tag">黒幕ポジ（やさしめ）</span>
-            <span class="tag">場を作る</span>
-          </div>
-        </article>
-
-        <article class="card">
-          <h3><span class="chip">舞台</span> サキュバスメイド喫茶《∞》</h3>
-          <p>
-            きらめく夜の“現場”。<br />
+<div class="meta">
+<span class="tag">黒幕ポジ（やさしめ）</span>
+<span class="tag">場を作る</span>
+</div>
+</article>
+<article class="card">
+<h3><span class="chip">舞台</span> サキュバスメイド喫茶《∞》</h3>
+<p>
+            きらめく夜の“現場”。<br/>
             人が集まり、気分が揺れ、選択が生まれる場所。ユイの学びは、いつもここから始まる。
           </p>
-          <div class="meta">
-            <span class="tag">夜のネオン</span>
-            <span class="tag">現場の温度</span>
-            <span class="tag">∞の余白</span>
-          </div>
-        </article>
-      </div>
-    </section>
-  </main>
-
-  <button class="topbtn" id="topbtn" type="button" aria-label="ページ上部へ戻る">
-    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="M12 5l-7 7m7-7l7 7M12 5v14" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-    <span>TOP</span>
-  </button>
-
-  <footer role="contentinfo">
-    <div>
-      © <span id="year"></span> サキュバスメイド喫茶《∞》｜瑠璃の宝石スタイル<br />
-      <span style="color:rgba(234,241,255,.58)">※このページはネタバレを避けた“入口”です。各話は story1.html〜story12.html に配置してください。</span>
-    </div>
-    <div class="foot-links">
-      <a href="#episodes">12話へ</a>
-      <a href="#characters">キャラクター</a>
-      <a href="story1.html">第1話を読む</a>
-    </div>
-  </footer>
-
-  <script>
+<div class="meta">
+<span class="tag">夜のネオン</span>
+<span class="tag">現場の温度</span>
+<span class="tag">∞の余白</span>
+</div>
+</article>
+</div>
+</section>
+</main>
+<button aria-label="ページ上部へ戻る" class="topbtn" id="topbtn" type="button">
+<svg aria-hidden="true" fill="none" viewbox="0 0 24 24">
+<path d="M12 5l-7 7m7-7l7 7M12 5v14" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.4"></path>
+</svg>
+<span>TOP</span>
+</button>
+<footer role="contentinfo">
+<div>
+      © <span id="year"></span> サキュバスメイド喫茶《∞》｜瑠璃の宝石スタイル<br/>
+<span style="color:rgba(234,241,255,.58)">※このページはネタバレを避けた“入口”です。各話は story1.html〜story12.html に配置してください。</span>
+</div>
+<div class="foot-links">
+<a href="#episodes">12話へ</a>
+<a href="#characters">キャラクター</a>
+<a href="story1.html">第1話を読む</a>
+</div>
+</footer>
+<script>
     // ---- sparkles placement (deterministic-ish) ----
     (function(){
       const root = document.getElementById("sparkles");

--- a/routes.json
+++ b/routes.json
@@ -1,0 +1,40 @@
+{
+  "order": [
+    "ruri",
+    "hina",
+    "immersive",
+    "magazine"
+  ],
+  "routes": {
+    "ruri": {
+      "home": "/index.html",
+      "content": {
+        "ep01": "/story1.html"
+      }
+    },
+    "hina": {
+      "home": "/hina/",
+      "list": "/hina/list",
+      "content": {
+        "ep01": "/hina/ep01",
+        "welcome-post": "/hina/welcome-post"
+      }
+    },
+    "immersive": {
+      "home": "/immersive/",
+      "list": "/immersive/list",
+      "content": {
+        "ep01": "/immersive/ep01",
+        "welcome-post": "/immersive/welcome-post"
+      }
+    },
+    "magazine": {
+      "home": "/magazine/",
+      "list": "/magazine/list",
+      "content": {
+        "ep01": "/magazine/ep01",
+        "welcome-post": "/magazine/welcome-post"
+      }
+    }
+  }
+}

--- a/shared/switcher.css
+++ b/shared/switcher.css
@@ -1,0 +1,17 @@
+.view-switcher {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  padding: 10px 12px;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+.view-switcher:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.26);
+}
+

--- a/shared/switcher.js
+++ b/shared/switcher.js
@@ -1,0 +1,47 @@
+(function experienceSwitcher() {
+  const button = document.querySelector('button.view-switcher[data-action="switch-experience"]');
+  const { experience: current, contentId, routesHref } = document.body.dataset || {};
+  if (!button || !routesHref || !current) return;
+
+  const routesUrl = new URL(routesHref, window.location.href);
+  let cache = null;
+
+  async function loadRoutes() {
+    if (cache) return cache;
+    const response = await fetch(routesUrl.href);
+    if (!response.ok) {
+      throw new Error(`Failed to load routes: ${response.status}`);
+    }
+    cache = await response.json();
+    return cache;
+  }
+
+  button.addEventListener('click', async () => {
+    try {
+      const payload = await loadRoutes();
+      const order = payload.order || [];
+      if (!order.length) return;
+
+      const currentIndex = order.indexOf(current);
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % order.length;
+      const nextKey = order[nextIndex];
+      const nextRoutes = payload.routes?.[nextKey];
+      if (!nextRoutes) return;
+
+      let target = null;
+      if (contentId && nextRoutes.content && nextRoutes.content[contentId]) {
+        target = nextRoutes.content[contentId];
+      }
+      if (!target) {
+        target = nextRoutes.home || null;
+      }
+      if (!target) return;
+
+      const resolved = new URL(target, routesUrl.href);
+      window.location.href = resolved.href;
+    } catch (error) {
+      console.warn("[switcher] navigation skipped", error);
+    }
+  });
+})();
+

--- a/sitegen/build.py
+++ b/sitegen/build.py
@@ -24,6 +24,7 @@ class BuildContext:
     out_root: Path
     routes_filename: str = "routes.json"
     shared_init_features: Path | None = None
+    shared_assets_dir: Path | None = None
     _copied_assets: set[str] = field(default_factory=set, init=False, repr=False)
 
     def templates_dir(self, experience: ExperienceSpec) -> Path:
@@ -61,6 +62,13 @@ class BuildContext:
         """Return the target path for the experience's routes.json."""
 
         return self.output_dir(experience) / self.routes_filename
+
+    def shared_asset_href(self, filename: str, base: Path) -> str | None:
+        """Compute a relative href to a shared asset if configured."""
+
+        if not self.shared_assets_dir:
+            return None
+        return _relative_href(self.shared_assets_dir / filename, base)
 
     def jinja_env(self, experience: ExperienceSpec) -> Environment:
         """Create a Jinja environment scoped to the experience templates."""
@@ -148,6 +156,9 @@ def build_home(experience: ExperienceSpec, ctx: BuildContext) -> List[Path]:
         experience=experience,
         routes_href=routes_href,
         asset_prefix=asset_prefix,
+        switcher_css_href=ctx.shared_asset_href("switcher.css", output_file.parent),
+        switcher_js_href=ctx.shared_asset_href("switcher.js", output_file.parent),
+        template_key="home",
         nav_links=[
             {"href": experience.route_patterns.home, "label": "ホーム"},
             {"href": experience.route_patterns.list, "label": "一覧"},
@@ -196,6 +207,9 @@ def build_list(
         experience=experience,
         routes_href=routes_href,
         asset_prefix=asset_prefix,
+        switcher_css_href=ctx.shared_asset_href("switcher.css", output_file.parent),
+        switcher_js_href=ctx.shared_asset_href("switcher.js", output_file.parent),
+        template_key="list",
         items=entries,
         nav_links=[
             {"href": experience.route_patterns.home, "label": "ホーム"},
@@ -243,6 +257,9 @@ def build_detail(
         routes_href=routes_href,
         asset_prefix=asset_prefix,
         features_init_href=features_init_href,
+        switcher_css_href=ctx.shared_asset_href("switcher.css", output_file.parent),
+        switcher_js_href=ctx.shared_asset_href("switcher.js", output_file.parent),
+        template_key="detail",
         nav_links=[
             {"href": experience.route_patterns.home, "label": "ホーム"},
             {"href": experience.route_patterns.list, "label": "一覧"},

--- a/sitegen/models.py
+++ b/sitegen/models.py
@@ -147,6 +147,14 @@ class ExperienceSpec(BaseModel):
     kind: Literal["legacy", "generated"] = Field(
         "legacy", description="Whether the experience is legacy or generated."
     )
+    home: Optional[str] = Field(
+        default=None,
+        description="Optional home href for legacy experiences.",
+    )
+    content: dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional map of contentId to href for legacy experiences.",
+    )
     description: Optional[str] = Field(
         None, description="Short description of the experience goal."
     )

--- a/sitegen/patch_legacy.py
+++ b/sitegen/patch_legacy.py
@@ -1,0 +1,121 @@
+"""Patch legacy HTML pages to support the experience switcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from bs4 import BeautifulSoup
+
+
+def _ensure_dataset(
+    body, *, routes_href: str, template: str, content_id: Optional[str]
+) -> None:
+    body["data-experience"] = "ruri"
+    body["data-template"] = template
+    body["data-routes-href"] = routes_href
+    if content_id:
+        body["data-content-id"] = content_id
+    elif "data-content-id" in body.attrs:
+        del body["data-content-id"]
+
+
+def _ensure_assets(soup: BeautifulSoup, css_href: str, js_href: str) -> None:
+    head = soup.head
+    if not head:
+        head = soup.new_tag("head")
+        soup.html.insert(0, head)
+
+    if not head.find("link", attrs={"href": css_href}):
+        link_tag = soup.new_tag(
+            "link", rel="stylesheet", href=css_href, type="text/css"
+        )
+        head.append(link_tag)
+
+    script_tag = head.find("script", attrs={"src": js_href})
+    if not script_tag:
+        script_tag = soup.new_tag("script", src=js_href)
+        head.append(script_tag)
+    script_tag["defer"] = "defer"
+
+
+def _insert_switcher_button(soup: BeautifulSoup) -> None:
+    nav = soup.find("nav", class_="nav") or soup.find("nav")
+    if not nav:
+        return
+
+    existing = nav.find("button", attrs={"data-action": "switch-experience"})
+    if existing:
+        return
+
+    button = soup.new_tag(
+        "button",
+        type="button",
+        attrs={"class": "view-switcher", "data-action": "switch-experience"},
+    )
+    button.string = "体験を切り替える"
+    nav.append(button)
+
+
+def _patch_file(
+    path: Path,
+    *,
+    template: str,
+    routes_href: str,
+    css_href: str,
+    js_href: str,
+    content_id: Optional[str] = None,
+) -> Path:
+    soup = BeautifulSoup(path.read_text(encoding="utf-8"), "html.parser")
+    body = soup.body
+    if not body:
+        raise ValueError(f"<body> not found in {path}")
+
+    _ensure_dataset(body, routes_href=routes_href, template=template, content_id=content_id)
+    _ensure_assets(soup, css_href=css_href, js_href=js_href)
+    _insert_switcher_button(soup)
+
+    path.write_text(str(soup), encoding="utf-8")
+    return path
+
+
+def patch_legacy_pages(
+    base_dir: Path,
+    *,
+    routes_href: str,
+    css_href: str,
+    js_href: str,
+) -> list[Path]:
+    """Apply switcher-friendly patches to legacy HTML pages."""
+
+    targets: list[Path] = []
+    index_path = base_dir / "index.html"
+    story1_path = base_dir / "story1.html"
+
+    if index_path.exists():
+        targets.append(
+            _patch_file(
+                index_path,
+                template="home",
+                routes_href=routes_href,
+                css_href=css_href,
+                js_href=js_href,
+            )
+        )
+
+    if story1_path.exists():
+        targets.append(
+            _patch_file(
+                story1_path,
+                template="detail",
+                routes_href=routes_href,
+                css_href=css_href,
+                js_href=js_href,
+                content_id="ep01",
+            )
+        )
+
+    return targets
+
+
+__all__ = ["patch_legacy_pages"]

--- a/sitegen/routes_gen.py
+++ b/sitegen/routes_gen.py
@@ -1,0 +1,84 @@
+"""Utilities for generating routes.json used by the experience switcher."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .models import ContentItem, ExperienceSpec
+from .util_fs import ensure_dir
+
+
+def _detail_href(experience: ExperienceSpec, slug: str) -> str:
+    """Build a detail href by substituting the slug into the pattern."""
+
+    return experience.route_patterns.detail.replace("{slug}", slug)
+
+
+def build_routes_payload(
+    experiences: list[ExperienceSpec], items: list[ContentItem]
+) -> dict:
+    """Create a merged payload describing available routes per experience.
+
+    The resulting structure is optimized for the client-side view switcher:
+    {
+      "order": ["ruri", "hina"],
+      "routes": {
+        "ruri": {"home": "/index.html", "content": {"ep01": "/story1.html"}},
+        "hina": {"home": "/hina/", "content": {"ep01": "/hina/ep01"}}
+      }
+    }
+    """
+
+    order = [exp.key for exp in experiences]
+    routes: dict[str, dict] = {}
+
+    for experience in experiences:
+        targeted = [item for item in items if item.experience == experience.key]
+        if not targeted:
+            targeted = items
+
+        if experience.kind == "legacy":
+            home = (
+                f"/{(experience.home or '').lstrip('/')}"
+                if experience.home
+                else experience.route_patterns.home
+            )
+            content_map = {
+                cid: f"/{href.lstrip('/')}" for cid, href in experience.content.items()
+            }
+            if not content_map:
+                for item in targeted:
+                    content_map[item.content_id] = _detail_href(experience, item.content_id)
+
+            routes[experience.key] = {"home": home, "content": content_map}
+            continue
+
+        content_map: dict[str, str] = {}
+        for item in items:
+            slug = item.content_id
+            content_map[slug] = _detail_href(experience, slug)
+
+        routes[experience.key] = {
+            "home": experience.route_patterns.home,
+            "list": experience.route_patterns.list,
+            "content": content_map,
+        }
+
+    return {"order": order, "routes": routes}
+
+
+def write_routes_payload(payload: dict, targets: Iterable[Path]) -> list[Path]:
+    """Write the JSON payload to each target path."""
+
+    serialized = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    written: list[Path] = []
+    for target in {Path(path) for path in targets}:
+        ensure_dir(target.parent)
+        target.write_text(serialized, encoding="utf-8")
+        written.append(target)
+    return written
+
+
+__all__ = ["build_routes_payload", "write_routes_payload"]

--- a/sitegen/shared_gen.py
+++ b/sitegen/shared_gen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Iterable
 
 from .util_fs import ensure_dir
 
@@ -35,4 +36,87 @@ def generate_init_features_js(out_dir: Path) -> Path:
     return target_path
 
 
-__all__ = ["generate_init_features_js"]
+SWITCHER_JS = """
+(function experienceSwitcher() {
+  const button = document.querySelector('button.view-switcher[data-action="switch-experience"]');
+  const { experience: current, contentId, routesHref } = document.body.dataset || {};
+  if (!button || !routesHref || !current) return;
+
+  const routesUrl = new URL(routesHref, window.location.href);
+  let cache = null;
+
+  async function loadRoutes() {
+    if (cache) return cache;
+    const response = await fetch(routesUrl.href);
+    if (!response.ok) {
+      throw new Error(`Failed to load routes: ${response.status}`);
+    }
+    cache = await response.json();
+    return cache;
+  }
+
+  button.addEventListener('click', async () => {
+    try {
+      const payload = await loadRoutes();
+      const order = payload.order || [];
+      if (!order.length) return;
+
+      const currentIndex = order.indexOf(current);
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % order.length;
+      const nextKey = order[nextIndex];
+      const nextRoutes = payload.routes?.[nextKey];
+      if (!nextRoutes) return;
+
+      let target = null;
+      if (contentId && nextRoutes.content && nextRoutes.content[contentId]) {
+        target = nextRoutes.content[contentId];
+      }
+      if (!target) {
+        target = nextRoutes.home || null;
+      }
+      if (!target) return;
+
+      const resolved = new URL(target, routesUrl.href);
+      window.location.href = resolved.href;
+    } catch (error) {
+      console.warn("[switcher] navigation skipped", error);
+    }
+  });
+})();
+"""
+
+SWITCHER_CSS = """
+.view-switcher {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  padding: 10px 12px;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+.view-switcher:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.26);
+}
+"""
+
+
+def generate_switcher_assets(target_roots: Iterable[Path]) -> list[Path]:
+    """Write shared switcher assets into each target root's shared directory."""
+
+    written: list[Path] = []
+    for root in {Path(path) for path in target_roots}:
+        shared_dir = ensure_dir(root / "shared")
+        js_path = shared_dir / "switcher.js"
+        css_path = shared_dir / "switcher.css"
+        js_path.write_text(SWITCHER_JS.lstrip() + "\n", encoding="utf-8")
+        css_path.write_text(SWITCHER_CSS.lstrip() + "\n", encoding="utf-8")
+        written.extend([js_path, css_path])
+    return written
+
+
+__all__ = ["generate_init_features_js", "generate_switcher_assets"]

--- a/story1.html
+++ b/story1.html
@@ -1,297 +1,241 @@
 <!DOCTYPE html>
+
 <html lang="ja">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>第1話「キラキラした背中と、ダメ出しの夜」</title>
-    <link rel="stylesheet" href="pop3_style.css">
-    <!-- KaTeX CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
-</head>
-<body>
-
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>第1話「キラキラした背中と、ダメ出しの夜」</title>
+<link href="pop3_style.css" rel="stylesheet"/>
+<!-- KaTeX CSS -->
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" rel="stylesheet"/>
+<link href="shared/switcher.css" rel="stylesheet" type="text/css"/><script defer="defer" src="shared/switcher.js"></script></head>
+<body data-content-id="ep01" data-experience="ruri" data-routes-href="routes.json" data-template="detail">
 <a class="skip" href="#content">本文へスキップ</a>
-<header class="topbar" role="banner" data-tts="ignore">
-  <div class="topbar-inner">
-    <a class="brand" href="index.html" aria-label="トップページへ">
-      <div class="mark" aria-hidden="true"></div>
-      <div class="brand-title">
-        <b>結城ユイの成長物語</b>
-        <span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
-      </div>
-    </a>
-    <nav class="nav" aria-label="関連ナビゲーション">
-      <a href="index.html#episodes">12話一覧</a>
-      <a href="index.html#about">紹介</a>
-      <a class="cta" href="index.html">トップへ戻る</a>
-    </nav>
-  </div>
+<header class="topbar" data-tts="ignore" role="banner">
+<div class="topbar-inner">
+<a aria-label="トップページへ" class="brand" href="index.html">
+<div aria-hidden="true" class="mark"></div>
+<div class="brand-title">
+<b>結城ユイの成長物語</b>
+<span>瑠璃の宝石スタイル｜サキュバスメイド喫茶《∞》</span>
+</div>
+</a>
+<nav aria-label="関連ナビゲーション" class="nav">
+<a href="index.html#episodes">12話一覧</a>
+<a href="index.html#about">紹介</a>
+<a class="cta" href="index.html">トップへ戻る</a>
+<button class="view-switcher" data-action="switch-experience" type="button">体験を切り替える</button></nav>
+</div>
 </header>
-  <main id="content">
-
-    <header>
+<main id="content">
+<header>
         第1話「キラキラした背中と、<span class="sparkle">ダメ出しの夜</span>」
     </header>
-
-    <section class="tts-controls" aria-label="読み上げコントロール" data-tts="ignore">
-        <div class="tts-row buttons">
-          <button type="button" id="speechToggle" aria-pressed="false">読み上げ OFF</button>
-          <button type="button" id="speechPause" disabled aria-pressed="false">一時停止</button>
-        </div>
-        <label for="voicePreset">音声プリセット
+<section aria-label="読み上げコントロール" class="tts-controls" data-tts="ignore">
+<div class="tts-row buttons">
+<button aria-pressed="false" id="speechToggle" type="button">読み上げ OFF</button>
+<button aria-pressed="false" disabled="" id="speechPause" type="button">一時停止</button>
+</div>
+<label for="voicePreset">音声プリセット
             <select id="voicePreset" name="voicePreset">
-                <option value="auto">自動（おすすめ）</option>
-            </select>
-        </label>
-        <label for="beatPreset">ビート
+<option value="auto">自動（おすすめ）</option>
+</select>
+</label>
+<label for="beatPreset">ビート
             <select id="beatPreset" name="beatPreset">
-                <option value="calm">明るい・落ち着く</option>
-                <option value="hype">テンション上げる</option>
-                <option value="neutral">当たり障りない（人ビート）</option>
-            </select>
-        </label>
-        <label for="masterVolume">音量 VOL
-            <input type="range" id="masterVolume" name="masterVolume" min="0" max="1" step="0.01" value="0.85">
-            <span id="masterVolumeValue">0.85</span>
-        </label>
-        <div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
-        <div class="tts-status">
-          <span id="speechStatus" role="status" aria-live="polite">準備中...</span>
-          <span id="tempoStatus" aria-live="polite"></span>
-          <span id="mixStatus" aria-live="polite"></span>
-          <span id="voiceSelectionStatus" aria-live="polite" class="voice-status"></span>
-        </div>
-    </section>
-    
-    <div class="container" id="story">
-        <div class="section">
-            <h2>◆前回までのあらすじ</h2>
-            <p>舞台は魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》。</p>
-            <p>新人サキュバスで"なんでも屋のダメダメテストエンジニア"結城ユイ（源氏名ユイリア）が、</p>
-            <p>伝説級テストアーキテクトの神崎ナギ、オーナーのバルハと共に成長していく物語です。</p>
-        </div>
-        
-        <div class="section">
-            <h2>◆本編</h2>
-            <p>魔界歓楽街の外れに、無限大マークのネオンサインが灯る。</p>
-            <p>サキュバスメイド喫茶《∞（インフィニティ）》――今夜がグランドオープンだ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">バルハ</span>
+<option value="calm">明るい・落ち着く</option>
+<option value="hype">テンション上げる</option>
+<option value="neutral">当たり障りない（人ビート）</option>
+</select>
+</label>
+<label for="masterVolume">音量 VOL
+            <input id="masterVolume" max="1" min="0" name="masterVolume" step="0.01" type="range" value="0.85"/>
+<span id="masterVolumeValue">0.85</span>
+</label>
+<div class="tts-note">読み上げを開始するとビートが同時に鳴り、停止すると止まります。</div>
+<div class="tts-status">
+<span aria-live="polite" id="speechStatus" role="status">準備中...</span>
+<span aria-live="polite" id="tempoStatus"></span>
+<span aria-live="polite" id="mixStatus"></span>
+<span aria-live="polite" class="voice-status" id="voiceSelectionStatus"></span>
+</div>
+</section>
+<div class="container" id="story">
+<div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>舞台は魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》。</p>
+<p>新人サキュバスで"なんでも屋のダメダメテストエンジニア"結城ユイ（源氏名ユイリア）が、</p>
+<p>伝説級テストアーキテクトの神崎ナギ、オーナーのバルハと共に成長していく物語です。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>魔界歓楽街の外れに、無限大マークのネオンサインが灯る。</p>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》――今夜がグランドオープンだ。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
                 「ユイリア！　フロア A、もう一回転いける？　"社畜応援ショット"がバカ売れよ！」
             </div>
-            
-            <p>カウンターからオーナーのバルハが翼をばさっと広げる。</p>
-            <p>私は結城ユイ、源氏名ユイリア。新人サキュバスにして、《∞》のなんでも屋テストエンジニアだ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
+<p>カウンターからオーナーのバルハが翼をばさっと広げる。</p>
+<p>私は結城ユイ、源氏名ユイリア。新人サキュバスにして、《∞》のなんでも屋テストエンジニアだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
                 「は、はいっ！　来た順で煽ってみます！」
             </div>
-            
-            <p>本当は「来た順」なんてテキトーなこと、言っちゃいけない。</p>
-            <p>でも今日の私は、朝からずっと場当たりだった。</p>
-            
-            <p>開店直前に突貫で詰め込んだキャンペーン。</p>
-            <p>SNS 限定割引、社畜救済ハグプラン、ワンドリンク無料クーポン……。</p>
-            <p>面白そうだからと全部オンにした結果、レジの魔導端末は何度もフリーズし、</p>
-            <p>ポイントは二重加算、席の予約は上書きされ、店内のあちこちからクレームが飛んだ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">客A</span>
+<p>本当は「来た順」なんてテキトーなこと、言っちゃいけない。</p>
+<p>でも今日の私は、朝からずっと場当たりだった。</p>
+<p>開店直前に突貫で詰め込んだキャンペーン。</p>
+<p>SNS 限定割引、社畜救済ハグプラン、ワンドリンク無料クーポン……。</p>
+<p>面白そうだからと全部オンにした結果、レジの魔導端末は何度もフリーズし、</p>
+<p>ポイントは二重加算、席の予約は上書きされ、店内のあちこちからクレームが飛んだ。</p>
+<div class="dialogue">
+<span class="character-name">客A</span>
                 「このクーポン、二重に効いてるんだけど？」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">客B</span>
+<div class="dialogue">
+<span class="character-name">客B</span>
                 「残業証明書なんて持ち歩かないよ！」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">客C</span>
+<div class="dialogue">
+<span class="character-name">客C</span>
                 「癒やされに来たのに、アンケートばっかりは違う！」
             </div>
-            
-            <p>謝って魔力でレシートを焼き直し、割引率を場当たりに変え、</p>
-            <p>私はなんとか炎上だけは避けた……つもりだった。</p>
-            
-            <div class="scene-break">＊　＊　＊</div>
-            
-            <p>――深夜。シャッターを下ろした店内に、ようやく静けさが降りる。</p>
-            
-            <p>テーブルにはアンケート用紙の山と、</p>
-            <p>魔導レジから吐き出されたログの束。</p>
-            <p>私は赤ペン片手に、うつぶせになっていた。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
+<p>謝って魔力でレシートを焼き直し、割引率を場当たりに変え、</p>
+<p>私はなんとか炎上だけは避けた……つもりだった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>――深夜。シャッターを下ろした店内に、ようやく静けさが降りる。</p>
+<p>テーブルにはアンケート用紙の山と、</p>
+<p>魔導レジから吐き出されたログの束。</p>
+<p>私は赤ペン片手に、うつぶせになっていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
                 「"クーポン二重適用"……"ショット提供遅延"……"強引なアンケート"……」
             </div>
-            
-            <p>バグみたいに列挙しても、ただの愚痴のリストだ。</p>
-            <p>どこから手をつければいいのか、さっぱり分からない。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<p>バグみたいに列挙しても、ただの愚痴のリストだ。</p>
+<p>どこから手をつければいいのか、さっぱり分からない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「ログ、見せてもらっていい？」
             </div>
-            
-            <p>不意に声がして、私は飛び上がった。</p>
-            <p>振り向くと、カウンター席に一人の女性が座っていた。</p>
-            
-            <p>黒髪をゆるく束ねた、シンプルなジャケット姿。</p>
-            <p>地味なのに、視線を吸い込むような琥珀色の瞳。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
+<p>不意に声がして、私は飛び上がった。</p>
+<p>振り向くと、カウンター席に一人の女性が座っていた。</p>
+<p>黒髪をゆるく束ねた、シンプルなジャケット姿。</p>
+<p>地味なのに、視線を吸い込むような琥珀色の瞳。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
                 「あ、あの、もう閉店で……」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「オーナーに合鍵、預かってるから」
             </div>
-            
-            <p>女性はマグカップを揺らしながら、ふわりと笑う。</p>
-            <p>カップから立ちのぼるのは湯気ではなく、細い魔力の糸だった。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<p>女性はマグカップを揺らしながら、ふわりと笑う。</p>
+<p>カップから立ちのぼるのは湯気ではなく、細い魔力の糸だった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「神崎ナギ。テストアーキテクト。今はフリーで、ちょっとだけこの店に関わってる」
             </div>
-            
-            <p>その名前に、私は思わず息を呑んだ。</p>
-            <p>魔界テック板で伝説みたいに語られる、大先輩の名前だ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
-                「き、今日のログ、一応全部出したんですけど……。<br>
+<p>その名前に、私は思わず息を呑んだ。</p>
+<p>魔界テック板で伝説みたいに語られる、大先輩の名前だ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「き、今日のログ、一応全部出したんですけど……。<br/>
                 クレームもメモったんですが、整理が全然できなくて」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「うん、ちょっと貸して」
             </div>
-            
-            <p>ナギさんはログとメモをぱらぱらとめくり、ホワイトボードの前に立つ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<p>ナギさんはログとメモをぱらぱらとめくり、ホワイトボードの前に立つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「客の種類は、ざっくりこの三パターンだね」
             </div>
-            
-            <p>縦に三本線を引き、左から順に「限界社畜」「癒やされたい勢」「冷やかし・観光客」と書く。</p>
-            <p>そこへ、さっきまで紙の海だったクレームが、迷いなく分類されていく。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
-                「"クーポン二重適用"で損したって怒ってたのは、ここ。<br>
-                "残業証明書なんて持ってない"って人も、こっち。<br>
+<p>縦に三本線を引き、左から順に「限界社畜」「癒やされたい勢」「冷やかし・観光客」と書く。</p>
+<p>そこへ、さっきまで紙の海だったクレームが、迷いなく分類されていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「"クーポン二重適用"で損したって怒ってたのは、ここ。<br/>
+                "残業証明書なんて持ってない"って人も、こっち。<br/>
                 アンケートにキレてたのは、たぶんこの列の人たち」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
                 「えっ、そんなにキレイに分かるものなんですか？」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「本当はもっと細かいけどね。まずはざっくりで十分」
             </div>
-            
-            <p>ナギさんは「限界社畜」の列を丸で囲んだ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<p>ナギさんは「限界社畜」の列を丸で囲んだ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「今日、いちばん大事にしたかったのは？」
             </div>
-            
-            <p>私の頭に、クマを作りながら笑っていたお客さんたちの顔が浮かぶ。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
+<p>私の頭に、クマを作りながら笑っていたお客さんたちの顔が浮かぶ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
                 「……社畜さん、たちです」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
-                「だよね。<br>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「だよね。<br/>
                 だったら、"社畜をどう見るか"っていうレンズから世界を切り分けたほうがいい」
             </div>
-            
-            <p>ペン先が、三つの列をぐるりとなぞる。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
-                「テストってさ、バグを片っ端から刺す仕事じゃない。<br>
+<p>ペン先が、三つの列をぐるりとなぞる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストってさ、バグを片っ端から刺す仕事じゃない。<br/>
                 "世界の見方"を設計する仕事なんだよ」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
                 「世界の、見方……」
             </div>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
-                「どんな種類の客がいて、何を期待して来て、<br>
-                何が壊れると一番つらいか。<br>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「どんな種類の客がいて、何を期待して来て、<br/>
+                何が壊れると一番つらいか。<br/>
                 その切り取り方を決めるのが、テストの最初の一歩」
             </div>
-            
-            <p>私は自分のメモ帳を見下ろす。</p>
-            <p>時系列に並んだクレームと、その場しのぎの対応が、</p>
-            <p>ただぎゅうぎゅうに詰め込まれているだけの紙切れ。</p>
-            
-            <p>同じ一日を見ているはずなのに――。</p>
-            
-            <p>顔を上げると、ホワイトボードには三つの列と矢印と丸だけの、</p>
-            <p>シンプルな地図ができあがっていた。</p>
-            <p>そこには、さっきまでカオスだったオープン初日の夜が、</p>
-            <p>嘘みたいに整然と並んでいる。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">ユイリア</span>
-                「同じ世界を見てるのに、<br>
+<p>私は自分のメモ帳を見下ろす。</p>
+<p>時系列に並んだクレームと、その場しのぎの対応が、</p>
+<p>ただぎゅうぎゅうに詰め込まれているだけの紙切れ。</p>
+<p>同じ一日を見ているはずなのに――。</p>
+<p>顔を上げると、ホワイトボードには三つの列と矢印と丸だけの、</p>
+<p>シンプルな地図ができあがっていた。</p>
+<p>そこには、さっきまでカオスだったオープン初日の夜が、</p>
+<p>嘘みたいに整然と並んでいる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「同じ世界を見てるのに、<br/>
                 先輩には、全然違う形に見えてる……」
             </div>
-            
-            <p>思わずこぼした言葉に、ナギさんは少しだけ目を細めた。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<p>思わずこぼした言葉に、ナギさんは少しだけ目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「その違いに気づけたなら、もう半分はテスト屋だよ」
             </div>
-            
-            <p>そう言って、ペンのキャップを閉め、私に放ってよこす。</p>
-            
-            <div class="dialogue">
-                <span class="character-name">神崎ナギ</span>
+<p>そう言って、ペンのキャップを閉め、私に放ってよこす。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
                 「ほら。次はユイちゃんが、世界の線を引いてみな？」
             </div>
-            
-            <p>ペンを握った指先が、じんわりと熱くなる。</p>
-            <p>胸の奥で、小さな灯りがぱっとともった気がした。</p>
-            
-            <p>いつか私も、この人みたいに、</p>
-            <p>世界をすっと三本の線で切り取れるようになりたい――。</p>
-            
-            <p>カウンターの影で、バルハがにやりと笑いながらこちらを見ていることに、</p>
-            <p>そのときの私はまだ気づいていなかった。</p>
-        </div>
-    </div>
-  </main>
-
-    <div class="footer">
+<p>ペンを握った指先が、じんわりと熱くなる。</p>
+<p>胸の奥で、小さな灯りがぱっとともった気がした。</p>
+<p>いつか私も、この人みたいに、</p>
+<p>世界をすっと三本の線で切り取れるようになりたい――。</p>
+<p>カウンターの影で、バルハがにやりと笑いながらこちらを見ていることに、</p>
+<p>そのときの私はまだ気づいていなかった。</p>
+</div>
+</div>
+</main>
+<div class="footer">
         © 魔界歓楽街 サキュバスメイド喫茶《∞（インフィニティ）》
     </div>
-
-    <!-- KaTeX JS -->
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js" integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
-    <script>
+<!-- KaTeX JS -->
+<script crossorigin="anonymous" defer="" integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+<script crossorigin="anonymous" defer="" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+<script>
         document.addEventListener("DOMContentLoaded", function() {
             renderMathInElement(document.body, {
                 delimiters: [
@@ -303,6 +247,6 @@
             });
         });
     </script>
-    <script type="module" src="./narration-init.js"></script>
+<script src="./narration-init.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a route map generator and CLI `--all` build path that writes routes.json copies and patches legacy pages
- generate shared switcher assets and wire them into generated experience templates
- regenerate outputs, including new routes manifests and updated legacy HTML with switcher controls

## Testing
- python -m sitegen build --all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ce608f308333a81f5671dc519aa5)