### PR TITLE
Render hina home content and enforce strict build inputs

### DIFF
--- a/config/experiences.yaml
+++ b/config/experiences.yaml
@@ -26,8 +26,8 @@
     renderKinds: ["markdown", "external"]
   routePatterns:
     home: "/hina/"
-    list: "/hina/list"
-    detail: "/hina/{slug}"
+    list: "/hina/list/"
+    detail: "/hina/posts/{slug}/"
 
 - key: immersive
   name: "Immersive Generated Experience"
@@ -40,8 +40,8 @@
     features: ["full-bleed"]
   routePatterns:
     home: "/immersive/"
-    list: "/immersive/list"
-    detail: "/immersive/{slug}"
+    list: "/immersive/list/"
+    detail: "/immersive/posts/{slug}/"
 
 - key: magazine
   name: "Magazine Generated Experience"
@@ -54,5 +54,5 @@
     features: ["grid-list"]
   routePatterns:
     home: "/magazine/"
-    list: "/magazine/list"
-    detail: "/magazine/{slug}"
+    list: "/magazine/list/"
+    detail: "/magazine/posts/{slug}/"

--- a/experience_src/hina/templates/home.jinja
+++ b/experience_src/hina/templates/home.jinja
@@ -51,7 +51,23 @@
     <main id="content" class="sg-main">
       <section class="sg-card">
         <h2>最新コンテンツ</h2>
-        <p>TODO: コンテンツ一覧をここにレンダリングします。</p>
+        <ul class="sg-list card-grid">
+          {% for entry in items %}
+          <li class="sg-card">
+            <p class="sg-eyebrow">Episode</p>
+            <h2><a href="{{ entry.detail_href }}">{{ entry.content.title }}</a></h2>
+            {% if entry.content.summary %}
+            <p class="sg-lede">{{ entry.content.summary }}</p>
+            {% elif entry.content.excerpt %}
+            <p class="sg-lede">{{ entry.content.excerpt }}</p>
+            {% endif %}
+            {% if entry.content.date %}
+            <p class="sg-meta">{{ entry.content.date }}</p>
+            {% endif %}
+            <p class="sg-meta">#{{ entry.content.content_id }}</p>
+          </li>
+          {% endfor %}
+        </ul>
       </section>
     </main>
     <footer class="sg-footer">

--- a/generated/hina/index.html
+++ b/generated/hina/index.html
@@ -24,7 +24,7 @@
       >
         <ul class="sg-nav-links">
           <li><a href="/hina/">ホーム</a></li>
-          <li><a href="/hina/list">一覧</a></li>
+          <li><a href="/hina/list/">一覧</a></li>
         </ul>
         <button
           type="button"
@@ -42,7 +42,14 @@
     <main id="content" class="sg-main">
       <section class="sg-card">
         <h2>最新コンテンツ</h2>
-        <p>TODO: コンテンツ一覧をここにレンダリングします。</p>
+        <ul class="sg-list card-grid">
+          <li class="sg-card">
+            <p class="sg-eyebrow">Episode</p>
+            <h2><a href="posts/ep01/index.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
+            <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
+            <p class="sg-meta">#ep01</p>
+          </li>
+        </ul>
       </section>
     </main>
     <footer class="sg-footer">

--- a/generated/hina/list/index.html
+++ b/generated/hina/list/index.html
@@ -3,16 +3,16 @@
   <head>
     <meta charset="utf-8">
     <title>hina | List</title>
-    <link rel="stylesheet" href="./assets/tokens.css">
-    <link rel="stylesheet" href="./assets/components.css">
-    <link rel="stylesheet" href="../shared/switcher.css">
-    <script src="../shared/switcher.js" defer></script>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
+    <script src="../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
     data-experience="hina"
     data-template="list"
-    data-routes-href="routes.json"
+    data-routes-href="../routes.json"
   >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
@@ -21,7 +21,7 @@
       <nav>
         <ul class="sg-nav">
           <li><a href="/hina/">ホーム</a></li>
-          <li><a href="/hina/list">一覧</a></li>
+          <li><a href="/hina/list/">一覧</a></li>
         </ul>
         <button
           type="button"
@@ -36,7 +36,7 @@
       <ul class="sg-list card-grid">
         <li class="sg-card">
           <p class="sg-eyebrow">Episode</p>
-          <h2><a href="posts/ep01.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
+          <h2><a href="../posts/ep01/index.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
           <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
           <p class="sg-meta">#ep01</p>
         </li>

--- a/generated/hina/posts/ep01/index.html
+++ b/generated/hina/posts/ep01/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="utf-8">
     <title>hina | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
-    <link rel="stylesheet" href="../../shared/switcher.css">
-    <script src="../../shared/features/init-features.js" defer></script>
-    <script src="../../shared/switcher.js" defer></script>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
     data-experience="hina"
     data-template="detail"
-    data-routes-href="../routes.json"
+    data-routes-href="../../routes.json"
     data-content-id="ep01"
   >
-    <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
+    <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>EP01: 開幕、魔界喫茶《∞（インフィニティ）》</h1>
@@ -24,7 +24,7 @@
         <nav>
           <ul class="sg-nav">
           <li><a href="/hina/">ホーム</a></li>
-          <li><a href="/hina/list">一覧</a></li>
+          <li><a href="/hina/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/hina/posts/welcome-post/index.html
+++ b/generated/hina/posts/welcome-post/index.html
@@ -2,29 +2,29 @@
 <html lang="ja">
   <head>
     <meta charset="utf-8">
-    <title>immersive | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
-    <link rel="stylesheet" href="../../shared/switcher.css">
-    <script src="../../shared/features/init-features.js" defer></script>
-    <script src="../../shared/switcher.js" defer></script>
+    <title>hina | Detail</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
-    data-experience="immersive"
+    data-experience="hina"
     data-template="detail"
-    data-routes-href="../routes.json"
+    data-routes-href="../../routes.json"
     data-content-id="welcome-post"
   >
-    <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
+    <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>ようこそ、魔界喫茶《∞》へ</h1>
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
         <nav>
           <ul class="sg-nav">
-          <li><a href="/immersive/">ホーム</a></li>
-          <li><a href="/immersive/list">一覧</a></li>
+          <li><a href="/hina/">ホーム</a></li>
+          <li><a href="/hina/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/hina/routes.json
+++ b/generated/hina/routes.json
@@ -14,26 +14,26 @@
     },
     "hina": {
       "home": "/hina/",
-      "list": "/hina/list",
+      "list": "/hina/list/",
       "content": {
-        "ep01": "/hina/ep01",
-        "welcome-post": "/hina/welcome-post"
+        "ep01": "/hina/posts/ep01/",
+        "welcome-post": "/hina/posts/welcome-post/"
       }
     },
     "immersive": {
       "home": "/immersive/",
-      "list": "/immersive/list",
+      "list": "/immersive/list/",
       "content": {
-        "ep01": "/immersive/ep01",
-        "welcome-post": "/immersive/welcome-post"
+        "ep01": "/immersive/posts/ep01/",
+        "welcome-post": "/immersive/posts/welcome-post/"
       }
     },
     "magazine": {
       "home": "/magazine/",
-      "list": "/magazine/list",
+      "list": "/magazine/list/",
       "content": {
-        "ep01": "/magazine/ep01",
-        "welcome-post": "/magazine/welcome-post"
+        "ep01": "/magazine/posts/ep01/",
+        "welcome-post": "/magazine/posts/welcome-post/"
       }
     }
   }

--- a/generated/immersive/index.html
+++ b/generated/immersive/index.html
@@ -24,7 +24,7 @@
       >
         <ul class="sg-nav-links">
           <li><a href="/immersive/">ホーム</a></li>
-          <li><a href="/immersive/list">一覧</a></li>
+          <li><a href="/immersive/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/immersive/list/index.html
+++ b/generated/immersive/list/index.html
@@ -3,16 +3,16 @@
   <head>
     <meta charset="utf-8">
     <title>immersive | List</title>
-    <link rel="stylesheet" href="./assets/tokens.css">
-    <link rel="stylesheet" href="./assets/components.css">
-    <link rel="stylesheet" href="../shared/switcher.css">
-    <script src="../shared/switcher.js" defer></script>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
+    <script src="../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
     data-experience="immersive"
     data-template="list"
-    data-routes-href="routes.json"
+    data-routes-href="../routes.json"
   >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
@@ -21,7 +21,7 @@
       <nav>
         <ul class="sg-nav">
           <li><a href="/immersive/">ホーム</a></li>
-          <li><a href="/immersive/list">一覧</a></li>
+          <li><a href="/immersive/list/">一覧</a></li>
         </ul>
         <button
           type="button"
@@ -36,13 +36,13 @@
       <section class="immersive-stack">
         <article class="sg-card immersive-card">
           <p class="sg-eyebrow">Featured</p>
-          <h2><a href="posts/ep01.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
+          <h2><a href="../posts/ep01/index.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
           <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
           <div class="sg-meta">読む →</div>
         </article>
         <article class="sg-card immersive-card">
           <p class="sg-eyebrow">Featured</p>
-          <h2><a href="posts/welcome-post.html">ようこそ、魔界喫茶《∞》へ</a></h2>
+          <h2><a href="../posts/welcome-post/index.html">ようこそ、魔界喫茶《∞》へ</a></h2>
           <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
           <div class="sg-meta">読む →</div>
         </article>

--- a/generated/immersive/posts/ep01/index.html
+++ b/generated/immersive/posts/ep01/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="utf-8">
     <title>immersive | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
-    <link rel="stylesheet" href="../../shared/switcher.css">
-    <script src="../../shared/features/init-features.js" defer></script>
-    <script src="../../shared/switcher.js" defer></script>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
     data-experience="immersive"
     data-template="detail"
-    data-routes-href="../routes.json"
+    data-routes-href="../../routes.json"
     data-content-id="ep01"
   >
-    <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
+    <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>EP01: 開幕、魔界喫茶《∞（インフィニティ）》</h1>
@@ -24,7 +24,7 @@
         <nav>
           <ul class="sg-nav">
           <li><a href="/immersive/">ホーム</a></li>
-          <li><a href="/immersive/list">一覧</a></li>
+          <li><a href="/immersive/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/immersive/posts/welcome-post/index.html
+++ b/generated/immersive/posts/welcome-post/index.html
@@ -2,29 +2,29 @@
 <html lang="ja">
   <head>
     <meta charset="utf-8">
-    <title>magazine | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
-    <link rel="stylesheet" href="../../shared/switcher.css">
-    <script src="../../shared/features/init-features.js" defer></script>
-    <script src="../../shared/switcher.js" defer></script>
+    <title>immersive | Detail</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
-    data-experience="magazine"
+    data-experience="immersive"
     data-template="detail"
-    data-routes-href="../routes.json"
+    data-routes-href="../../routes.json"
     data-content-id="welcome-post"
   >
-    <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
+    <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>ようこそ、魔界喫茶《∞》へ</h1>
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
         <nav>
           <ul class="sg-nav">
-          <li><a href="/magazine/">ホーム</a></li>
-          <li><a href="/magazine/list">一覧</a></li>
+          <li><a href="/immersive/">ホーム</a></li>
+          <li><a href="/immersive/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/immersive/routes.json
+++ b/generated/immersive/routes.json
@@ -14,26 +14,26 @@
     },
     "hina": {
       "home": "/hina/",
-      "list": "/hina/list",
+      "list": "/hina/list/",
       "content": {
-        "ep01": "/hina/ep01",
-        "welcome-post": "/hina/welcome-post"
+        "ep01": "/hina/posts/ep01/",
+        "welcome-post": "/hina/posts/welcome-post/"
       }
     },
     "immersive": {
       "home": "/immersive/",
-      "list": "/immersive/list",
+      "list": "/immersive/list/",
       "content": {
-        "ep01": "/immersive/ep01",
-        "welcome-post": "/immersive/welcome-post"
+        "ep01": "/immersive/posts/ep01/",
+        "welcome-post": "/immersive/posts/welcome-post/"
       }
     },
     "magazine": {
       "home": "/magazine/",
-      "list": "/magazine/list",
+      "list": "/magazine/list/",
       "content": {
-        "ep01": "/magazine/ep01",
-        "welcome-post": "/magazine/welcome-post"
+        "ep01": "/magazine/posts/ep01/",
+        "welcome-post": "/magazine/posts/welcome-post/"
       }
     }
   }

--- a/generated/magazine/index.html
+++ b/generated/magazine/index.html
@@ -24,7 +24,7 @@
       >
         <ul class="sg-nav-links">
           <li><a href="/magazine/">ホーム</a></li>
-          <li><a href="/magazine/list">一覧</a></li>
+          <li><a href="/magazine/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/magazine/list/index.html
+++ b/generated/magazine/list/index.html
@@ -3,16 +3,16 @@
   <head>
     <meta charset="utf-8">
     <title>magazine | List</title>
-    <link rel="stylesheet" href="./assets/tokens.css">
-    <link rel="stylesheet" href="./assets/components.css">
-    <link rel="stylesheet" href="../shared/switcher.css">
-    <script src="../shared/switcher.js" defer></script>
+    <link rel="stylesheet" href="../assets/tokens.css">
+    <link rel="stylesheet" href="../assets/components.css">
+    <link rel="stylesheet" href="../../shared/switcher.css">
+    <script src="../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
     data-experience="magazine"
     data-template="list"
-    data-routes-href="routes.json"
+    data-routes-href="../routes.json"
   >
     <header class="sg-header">
       <p class="sg-eyebrow">Listing</p>
@@ -21,7 +21,7 @@
       <nav>
         <ul class="sg-nav">
           <li><a href="/magazine/">ホーム</a></li>
-          <li><a href="/magazine/list">一覧</a></li>
+          <li><a href="/magazine/list/">一覧</a></li>
         </ul>
         <button
           type="button"
@@ -35,12 +35,12 @@
     <main class="sg-main" data-template="list" data-experience="magazine">
       <div class="magazine-shelf">
         <article class="sg-card magazine-tile">
-          <h2><a href="posts/ep01.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
+          <h2><a href="../posts/ep01/index.html">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
           <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
           <p class="sg-meta">タグ: story, episode, 魔界喫茶</p>
         </article>
         <article class="sg-card magazine-tile">
-          <h2><a href="posts/welcome-post.html">ようこそ、魔界喫茶《∞》へ</a></h2>
+          <h2><a href="../posts/welcome-post/index.html">ようこそ、魔界喫茶《∞》へ</a></h2>
           <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
           <p class="sg-meta">タグ: sample, intro</p>
         </article>

--- a/generated/magazine/posts/ep01/index.html
+++ b/generated/magazine/posts/ep01/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="utf-8">
     <title>magazine | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
-    <link rel="stylesheet" href="../../shared/switcher.css">
-    <script src="../../shared/features/init-features.js" defer></script>
-    <script src="../../shared/switcher.js" defer></script>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
     data-experience="magazine"
     data-template="detail"
-    data-routes-href="../routes.json"
+    data-routes-href="../../routes.json"
     data-content-id="ep01"
   >
-    <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../routes.json">
+    <article class="sg-article" data-template="detail" data-content-id="ep01" data-routes-href="../../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>EP01: 開幕、魔界喫茶《∞（インフィニティ）》</h1>
@@ -24,7 +24,7 @@
         <nav>
           <ul class="sg-nav">
           <li><a href="/magazine/">ホーム</a></li>
-          <li><a href="/magazine/list">一覧</a></li>
+          <li><a href="/magazine/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/magazine/posts/welcome-post/index.html
+++ b/generated/magazine/posts/welcome-post/index.html
@@ -2,29 +2,29 @@
 <html lang="ja">
   <head>
     <meta charset="utf-8">
-    <title>hina | Detail</title>
-    <link rel="stylesheet" href="../assets/tokens.css">
-    <link rel="stylesheet" href="../assets/components.css">
-    <link rel="stylesheet" href="../../shared/switcher.css">
-    <script src="../../shared/features/init-features.js" defer></script>
-    <script src="../../shared/switcher.js" defer></script>
+    <title>magazine | Detail</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
   </head>
   <body
     class="sg-surface"
-    data-experience="hina"
+    data-experience="magazine"
     data-template="detail"
-    data-routes-href="../routes.json"
+    data-routes-href="../../routes.json"
     data-content-id="welcome-post"
   >
-    <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../routes.json">
+    <article class="sg-article" data-template="detail" data-content-id="welcome-post" data-routes-href="../../routes.json">
       <header class="sg-header" data-tts="ignore">
         <p class="sg-eyebrow">Detail</p>
         <h1>ようこそ、魔界喫茶《∞》へ</h1>
         <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
         <nav>
           <ul class="sg-nav">
-          <li><a href="/hina/">ホーム</a></li>
-          <li><a href="/hina/list">一覧</a></li>
+          <li><a href="/magazine/">ホーム</a></li>
+          <li><a href="/magazine/list/">一覧</a></li>
         </ul>
         <button
           type="button"

--- a/generated/magazine/routes.json
+++ b/generated/magazine/routes.json
@@ -14,26 +14,26 @@
     },
     "hina": {
       "home": "/hina/",
-      "list": "/hina/list",
+      "list": "/hina/list/",
       "content": {
-        "ep01": "/hina/ep01",
-        "welcome-post": "/hina/welcome-post"
+        "ep01": "/hina/posts/ep01/",
+        "welcome-post": "/hina/posts/welcome-post/"
       }
     },
     "immersive": {
       "home": "/immersive/",
-      "list": "/immersive/list",
+      "list": "/immersive/list/",
       "content": {
-        "ep01": "/immersive/ep01",
-        "welcome-post": "/immersive/welcome-post"
+        "ep01": "/immersive/posts/ep01/",
+        "welcome-post": "/immersive/posts/welcome-post/"
       }
     },
     "magazine": {
       "home": "/magazine/",
-      "list": "/magazine/list",
+      "list": "/magazine/list/",
       "content": {
-        "ep01": "/magazine/ep01",
-        "welcome-post": "/magazine/welcome-post"
+        "ep01": "/magazine/posts/ep01/",
+        "welcome-post": "/magazine/posts/welcome-post/"
       }
     }
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydantic
 PyYAML
 jinja2
 beautifulsoup4
+pytest

--- a/routes.json
+++ b/routes.json
@@ -14,26 +14,26 @@
     },
     "hina": {
       "home": "/hina/",
-      "list": "/hina/list",
+      "list": "/hina/list/",
       "content": {
-        "ep01": "/hina/ep01",
-        "welcome-post": "/hina/welcome-post"
+        "ep01": "/hina/posts/ep01/",
+        "welcome-post": "/hina/posts/welcome-post/"
       }
     },
     "immersive": {
       "home": "/immersive/",
-      "list": "/immersive/list",
+      "list": "/immersive/list/",
       "content": {
-        "ep01": "/immersive/ep01",
-        "welcome-post": "/immersive/welcome-post"
+        "ep01": "/immersive/posts/ep01/",
+        "welcome-post": "/immersive/posts/welcome-post/"
       }
     },
     "magazine": {
       "home": "/magazine/",
-      "list": "/magazine/list",
+      "list": "/magazine/list/",
       "content": {
-        "ep01": "/magazine/ep01",
-        "welcome-post": "/magazine/welcome-post"
+        "ep01": "/magazine/posts/ep01/",
+        "welcome-post": "/magazine/posts/welcome-post/"
       }
     }
   }

--- a/sitegen/cli.py
+++ b/sitegen/cli.py
@@ -499,7 +499,7 @@ def _handle_build(args: argparse.Namespace) -> None:
 
     written: list[Path] = []
     for exp in generated:
-        written.extend(build_home(exp, ctx))
+        written.extend(build_home(exp, ctx, items))
         written.extend(build_list(exp, ctx, items))
         for item in items:
             written.extend(build_detail(exp, ctx, item))

--- a/sitegen/models.py
+++ b/sitegen/models.py
@@ -212,6 +212,18 @@ class ContentItem(BaseModel):
     page_type: str = Field(..., alias="pageType", description="Page type for routing.")
     title: str = Field(..., description="Display title.")
     summary: Optional[str] = Field(None, description="Short teaser or deck.")
+    excerpt: Optional[str] = Field(
+        None,
+        description="Optional short teaser used when summary is absent.",
+    )
+    date: Optional[str] = Field(
+        None, description="Published date in ISO format or human friendly string."
+    )
+    body_html: Optional[str] = Field(
+        None,
+        alias="bodyHtml",
+        description="Rendered HTML body for list or detail views.",
+    )
     render: RenderContract = Field(..., description="How the content should render.")
     data_href: Optional[str] = Field(
         None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_content_loader.py
+++ b/tests/test_content_loader.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from sitegen.build import load_content_items
+
+
+def test_load_content_items_success():
+    items = load_content_items(Path("content/posts"))
+
+    assert items, "Content loader should return at least one item"
+    first = items[0]
+    assert first.content_id
+    assert first.title
+    assert first.render
+
+
+def test_load_content_items_empty_dir(tmp_path: Path):
+    empty_dir = tmp_path / "posts"
+    empty_dir.mkdir()
+
+    with pytest.raises(SystemExit):
+        load_content_items(empty_dir)

--- a/tests/test_hina_home_generation.py
+++ b/tests/test_hina_home_generation.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from bs4 import BeautifulSoup
+
+from sitegen.build import BuildContext, build_detail, build_home, build_list, load_content_items
+from sitegen.models import ExperienceSpec
+
+
+def _load_experiences() -> list[ExperienceSpec]:
+    data = yaml.safe_load(Path("config/experiences.yaml").read_text(encoding="utf-8"))
+    return [ExperienceSpec.model_validate(item) for item in data]
+
+
+@pytest.fixture()
+def hina_spec() -> ExperienceSpec:
+    return next(exp for exp in _load_experiences() if exp.key == "hina")
+
+
+def test_hina_home_is_rendered(tmp_path: Path, hina_spec: ExperienceSpec):
+    out_root = tmp_path / "generated"
+    ctx = BuildContext(src_root=Path("experience_src"), out_root=out_root)
+    items = load_content_items(Path("content/posts"))
+
+    build_home(hina_spec, ctx, items)
+    build_list(hina_spec, ctx, items)
+    for item in items:
+        build_detail(hina_spec, ctx, item)
+
+    output_dir = out_root / (hina_spec.output_dir or hina_spec.key)
+    home_path = output_dir / "index.html"
+    assert home_path.exists(), "Home page should be generated"
+
+    html = home_path.read_text(encoding="utf-8")
+    assert "TODO:" not in html
+
+    soup = BeautifulSoup(html, "html.parser")
+    cards = soup.select("li.sg-card")
+    assert cards, "At least one content card should be rendered"
+
+    first_slug = items[0].content_id
+    link = soup.select_one(f"a[href*='{first_slug}']")
+    assert link, "Detail link for the first post should be present"

--- a/tests/test_jinja_strictundefined.py
+++ b/tests/test_jinja_strictundefined.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+from jinja2 import UndefinedError
+
+from sitegen.build import BuildContext
+from sitegen.models import ExperienceSpec, RoutePatterns, Supports
+
+
+def _fake_experience(tmp_path: Path) -> ExperienceSpec:
+    return ExperienceSpec(
+        key="tmp",
+        name="Tmp",
+        kind="generated",
+        output_dir="tmp",
+        supports=Supports(),
+        route_patterns=RoutePatterns(
+            home="/tmp/",
+            list="/tmp/list/",
+            detail="/tmp/posts/{slug}/",
+        ),
+    )
+
+
+def test_jinja_strictundefined(tmp_path: Path):
+    templates_dir = tmp_path / "src" / "tmp" / "templates"
+    templates_dir.mkdir(parents=True)
+    (templates_dir / "strict.jinja").write_text("{{ missing_value }}", encoding="utf-8")
+
+    ctx = BuildContext(src_root=tmp_path / "src", out_root=tmp_path / "out")
+    exp = _fake_experience(tmp_path)
+    env = ctx.jinja_env(exp)
+    template = env.get_template("strict.jinja")
+
+    with pytest.raises(UndefinedError):
+        template.render()


### PR DESCRIPTION
## Summary
- enforce stricter content typing and fail-fast loading with new metadata fields and StrictUndefined Jinja environments
- render the Hina home template with real posts, aligned pretty URLs, and updated routes/output structure
- add pytest coverage for content loading, home generation, and template strictness; refresh generated assets to match

## Testing
- python -m pip install -r requirements.txt
- pytest -q
- python -m sitegen build --experiences config/experiences.yaml --src experience_src --out generated --content content/posts --routes-filename routes.json --all

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532eef02f08333bf78891e08913177)