### PR TITLE
fix(sitegen): generated experiences home becomes full-spec (about/episodes/characters)

### DIFF
--- a/config/experiences.yaml
+++ b/config/experiences.yaml
@@ -35,7 +35,7 @@
   output_dir: "hina"
   supports:
     locales: ["ja-JP"]
-    pageTypes: ["story", "about", "character"]
+    pageTypes: ["story", "about", "character", "siteMeta"]
     features: ["story-hero"]
     renderKinds: ["markdown", "external", "html"]
   routePatterns:
@@ -50,7 +50,7 @@
   output_dir: "immersive"
   supports:
     locales: ["ja-JP"]
-    pageTypes: ["story", "about", "character"]
+    pageTypes: ["story", "about", "character", "siteMeta"]
     features: ["full-bleed"]
     renderKinds: ["markdown", "external", "html"]
   routePatterns:
@@ -65,7 +65,7 @@
   output_dir: "magazine"
   supports:
     locales: ["ja-JP"]
-    pageTypes: ["story", "about", "character"]
+    pageTypes: ["story", "about", "character", "siteMeta"]
     features: ["grid-list"]
     renderKinds: ["markdown", "external", "html"]
   routePatterns:

--- a/content/posts/site-meta.json
+++ b/content/posts/site-meta.json
@@ -1,0 +1,19 @@
+{
+  "contentId": "site-meta",
+  "experience": "hina",
+  "pageType": "siteMeta",
+  "title": "Hina Generated Experience",
+  "summary": "Hina バリエーション用のジェネレート体験。",
+  "profile": "全エクスペリエンスで共有するヒーロー情報。12話とキャラクター紹介を揃えた“フルスペック”のホームを生成するためのメタデータ。",
+  "role": "Experience",
+  "ctaLabel": "一覧を見る",
+  "ctaHref": "list/",
+  "render": {
+    "kind": "html",
+    "html": "<p>Site metadata entry used to populate home hero blocks.</p>"
+  },
+  "tags": [
+    "site",
+    "meta"
+  ]
+}

--- a/generated/_buildinfo.json
+++ b/generated/_buildinfo.json
@@ -1,0 +1,109 @@
+{
+  "timestamp": "2025-12-30T09:24:01.652280+00:00",
+  "git": {
+    "sha": "650ad45f381242f987b751219c21b53a1069fec8"
+  },
+  "out": "generated",
+  "content": {
+    "total": 20,
+    "pageTypes": {
+      "about": 3,
+      "character": 4,
+      "story": 12,
+      "siteMeta": 1
+    }
+  },
+  "experiences": [
+    {
+      "key": "hina",
+      "outputDir": "generated/hina",
+      "content": {
+        "total": 20,
+        "pageTypes": {
+          "about": 3,
+          "character": 4,
+          "story": 12,
+          "siteMeta": 1
+        }
+      }
+    },
+    {
+      "key": "immersive",
+      "outputDir": "generated/immersive",
+      "content": {
+        "total": 20,
+        "pageTypes": {
+          "about": 3,
+          "character": 4,
+          "story": 12,
+          "siteMeta": 1
+        }
+      }
+    },
+    {
+      "key": "magazine",
+      "outputDir": "generated/magazine",
+      "content": {
+        "total": 20,
+        "pageTypes": {
+          "about": 3,
+          "character": 4,
+          "story": 12,
+          "siteMeta": 1
+        }
+      }
+    }
+  ],
+  "routesFilename": "routes.json",
+  "writtenFiles": [
+    "hina/index.html",
+    "hina/list/index.html",
+    "hina/posts/ep01/index.html",
+    "hina/posts/ep02/index.html",
+    "hina/posts/ep03/index.html",
+    "hina/posts/ep04/index.html",
+    "hina/posts/ep05/index.html",
+    "hina/posts/ep06/index.html",
+    "hina/posts/ep07/index.html",
+    "hina/posts/ep08/index.html",
+    "hina/posts/ep09/index.html",
+    "hina/posts/ep10/index.html",
+    "hina/posts/ep11/index.html",
+    "hina/posts/ep12/index.html",
+    "immersive/index.html",
+    "immersive/list/index.html",
+    "immersive/posts/ep01/index.html",
+    "immersive/posts/ep02/index.html",
+    "immersive/posts/ep03/index.html",
+    "immersive/posts/ep04/index.html",
+    "immersive/posts/ep05/index.html",
+    "immersive/posts/ep06/index.html",
+    "immersive/posts/ep07/index.html",
+    "immersive/posts/ep08/index.html",
+    "immersive/posts/ep09/index.html",
+    "immersive/posts/ep10/index.html",
+    "immersive/posts/ep11/index.html",
+    "immersive/posts/ep12/index.html",
+    "magazine/index.html",
+    "magazine/list/index.html",
+    "magazine/posts/ep01/index.html",
+    "magazine/posts/ep02/index.html",
+    "magazine/posts/ep03/index.html",
+    "magazine/posts/ep04/index.html",
+    "magazine/posts/ep05/index.html",
+    "magazine/posts/ep06/index.html",
+    "magazine/posts/ep07/index.html",
+    "magazine/posts/ep08/index.html",
+    "magazine/posts/ep09/index.html",
+    "magazine/posts/ep10/index.html",
+    "magazine/posts/ep11/index.html",
+    "magazine/posts/ep12/index.html",
+    "routes.json",
+    "shared/switcher.css",
+    "shared/switcher.js",
+    "index.html",
+    "shared/switcher.css",
+    "shared/switcher.js",
+    "story1.html"
+  ]
+}

--- a/generated/hina/assets/base.css
+++ b/generated/hina/assets/base.css
@@ -91,6 +91,33 @@ body[data-experience] .sg-nav {
   flex-wrap: wrap;
 }
 
+body[data-experience] .sg-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+body[data-experience] .sg-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--sg-border);
+  background: var(--sg-panel);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+body[data-experience] .sg-button:hover,
+body[data-experience] .sg-button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+  outline: none;
+}
+
 body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
@@ -196,6 +223,11 @@ body[data-experience] .magazine-shelf {
 body[data-experience] .magazine-tile {
   display: grid;
   gap: 8px;
+}
+
+body[data-experience] .sg-markdown {
+  display: grid;
+  gap: 10px;
 }
 
 @media (max-width: 640px) {

--- a/generated/hina/index.html
+++ b/generated/hina/index.html
@@ -8,6 +8,9 @@
     <link rel="stylesheet" href="./assets/base.css">
     <link rel="stylesheet" href="./assets/components.css">
     <link rel="stylesheet" href="../shared/switcher.css">
+    <meta name="description" content="Hina バリエーション用のジェネレート体験。">
+    <meta property="og:title" content="Hina Generated Experience">
+    <meta property="og:description" content="Hina バリエーション用のジェネレート体験。">
     <script src="../shared/switcher.js" defer></script>
   </head>
   <body class="sg-surface" data-experience="hina" data-template="home" data-routes-href="../routes.json">
@@ -22,6 +25,9 @@
       <ul class="sg-nav-links">
         <li><a href="./">ホーム</a></li>
         <li><a href="list/">一覧</a></li>
+        <li><a href="./#about">紹介</a></li>
+        <li><a href="./#episodes">12話</a></li>
+        <li><a href="./#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -33,20 +39,143 @@
       </button>
     </nav>
     <p class="sg-eyebrow">Experience</p>
-    <h1>Hina Generated Experience ホーム</h1>
+    <h1>Hina Generated Experience</h1>
     <p class="sg-lede">Hina バリエーション用のジェネレート体験。</p>
+    <div class="sg-actions">
+      <a class="sg-button" href="list/">一覧を見る</a>
+    </div>
   </header>
   <main id="content" class="sg-main">
-    <section class="sg-card">
-      <h2>最新コンテンツ</h2>
+    <section class="sg-card" id="about">
+      <h2>紹介</h2>
+      <div class="sg-list card-grid">
+        <article class="sg-card" data-about-id="about-世界観">
+          <p class="sg-eyebrow">世界観</p>
+          <h3>サキュバスメイド喫茶《∞》の、きらめく現場</h3>
+          <p class="sg-lede">甘い匂いとネオンの間で、ユイは“なんとなく”から抜け出したいと思い始める。
+            目の前の出来事に名前がつき、線が引けるようになったとき、世界は少しだけ優しくなる。</p>
+          <p class="sg-meta">観察 / 分類 / 境界 / 地図 / ログ</p>
+        </article>
+        <article class="sg-card" data-about-id="about-読みどころ">
+          <p class="sg-eyebrow">読みどころ</p>
+          <h3>1話1粒、“宝石みたいな気づき”</h3>
+          <p class="sg-lede">各話は短編のように読めて、でも繋がっている。
+            何かを学ぶというより、 見える範囲が広がる 感覚を楽しむ物語です。</p>
+          <p class="sg-meta">成長 / 師弟 / やさしい刺さり / 夜の余韻</p>
+        </article>
+        <article class="sg-card" data-about-id="welcome-post">
+          <p class="sg-eyebrow">イントロ</p>
+          <h3>ようこそ、魔界喫茶《∞》へ</h3>
+          <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
+          <p class="sg-meta">sample / intro</p>
+        </article>
+      </div>
+    </section>
+    <section class="sg-card" id="episodes">
+      <h2>エピソード</h2>
       <ul class="sg-list card-grid">
-        <li class="sg-card">
-          <p class="sg-eyebrow">Episode</p>
-          <h2><a href="posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
+        <li class="sg-card" data-episode-id="ep01">
+          <p class="sg-eyebrow">Episode 01</p>
+          <h3><a href="posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h3>
           <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
-          <p class="sg-meta">#ep01</p>
+          <p class="sg-meta">story / episode / 魔界喫茶</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep02">
+          <p class="sg-eyebrow">Episode 02</p>
+          <h3><a href="posts/ep02/">EP02: 世界 W は、仕様書の外に広がってる</a></h3>
+          <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep03">
+          <p class="sg-eyebrow">Episode 03</p>
+          <h3><a href="posts/ep03/">EP03: 同値クラスという、お守りの石</a></h3>
+          <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep04">
+          <p class="sg-eyebrow">Episode 04</p>
+          <h3><a href="posts/ep04/">EP04: 境界線を、一緒に歩いた夜</a></h3>
+          <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep05">
+          <p class="sg-eyebrow">Episode 05</p>
+          <h3><a href="posts/ep05/">EP05: 分岐の森と、先輩の地図</a></h3>
+          <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep06">
+          <p class="sg-eyebrow">Episode 06</p>
+          <h3><a href="posts/ep06/">EP06: 関係は、状態遷移で語れる</a></h3>
+          <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep07">
+          <p class="sg-eyebrow">Episode 07</p>
+          <h3><a href="posts/ep07/">EP07: 全部は試せない、という優しさ</a></h3>
+          <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep08">
+          <p class="sg-eyebrow">Episode 08</p>
+          <h3><a href="posts/ep08/">EP08: カバレッジの虹を見上げて</a></h3>
+          <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep09">
+          <p class="sg-eyebrow">Episode 09</p>
+          <h3><a href="posts/ep09/">EP09: ログは、システムからのラブレター</a></h3>
+          <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep10">
+          <p class="sg-eyebrow">Episode 10</p>
+          <h3><a href="posts/ep10/">EP10: 魔導書と職人の手、Fθと G</a></h3>
+          <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep11">
+          <p class="sg-eyebrow">Episode 11</p>
+          <h3><a href="posts/ep11/">EP11: 先輩も、迷っていた</a></h3>
+          <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+          <p class="sg-meta">story / episode</p>
+        </li>
+        <li class="sg-card" data-episode-id="ep12">
+          <p class="sg-eyebrow">Episode 12</p>
+          <h3><a href="posts/ep12/">EP12: 次の子に渡す、G の地図</a></h3>
+          <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+          <p class="sg-meta">story / episode</p>
         </li>
       </ul>
+    </section>
+    <section class="sg-card" id="characters">
+      <h2>キャラクター</h2>
+      <div class="sg-list card-grid">
+        <article class="sg-card" data-character-id="character-サキュバスメイド喫茶∞">
+          <p class="sg-eyebrow">舞台</p>
+          <h3>サキュバスメイド喫茶《∞》</h3>
+          <p class="sg-lede">きらめく夜の“現場”。 人が集まり、気分が揺れ、選択が生まれる場所。ユイの学びは、いつもここから始まる。</p>
+          <p class="sg-meta">夜のネオン / 現場の温度 / ∞の余白</p>
+        </article>
+        <article class="sg-card" data-character-id="character-バルハ">
+          <p class="sg-eyebrow">オーナー</p>
+          <h3>バルハ</h3>
+          <p class="sg-lede">喫茶《∞》のオーナー。二人の成長を少し離れた場所から見つめる存在。 舞台の空気を整え、物語の火種をそっと置く。</p>
+          <p class="sg-meta">黒幕ポジ（やさしめ） / 場を作る</p>
+        </article>
+        <article class="sg-card" data-character-id="character-神崎ナギ">
+          <p class="sg-eyebrow">大先輩</p>
+          <h3>神崎ナギ（かんざき・ナギ）</h3>
+          <p class="sg-lede">魔界テック界隈で伝説的なテストアーキテクト。 落ち着いた笑顔で、核心をすっと差し出す。“こうなりたい”と思わせる背中。</p>
+          <p class="sg-meta">静かな強さ / 言葉が地図 / 穏やかに刺す</p>
+        </article>
+        <article class="sg-card" data-character-id="character-結城ユイ">
+          <p class="sg-eyebrow">主人公</p>
+          <h3>結城ユイ（ユイリア）</h3>
+          <p class="sg-lede">サキュバスメイド喫茶《∞》で働く新人テストエンジニア。 知っているのは用語だけ。いつも場当たり的で、でも——だからこそ、伸びしろが眩しい。</p>
+          <p class="sg-meta">新人 / まっすぐ / 学びが体温</p>
+        </article>
+      </div>
     </section>
   </main>
   <footer class="sg-footer">
@@ -54,3 +183,4 @@
   </footer>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/list/index.html
+++ b/generated/hina/list/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>hina | List</title>
+    <title>Hina Generated Experience | List</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/base.css">
     <link rel="stylesheet" href="../assets/components.css">
@@ -13,12 +13,15 @@
   <body class="sg-surface" data-experience="hina" data-template="list" data-routes-href="../../routes.json">
   <header class="sg-header">
     <p class="sg-eyebrow">Listing</p>
-    <h1>hina コンテンツ一覧</h1>
-    <p class="sg-lede">カード型でタイトルと要約をざっくり眺められるシンプルなリスト。</p>
+    <h1>Hina Generated Experience コンテンツ一覧</h1>
+    <p class="sg-lede">Hina バリエーション用のジェネレート体験。</p>
     <nav class="sg-nav">
       <ul class="sg-nav-links">
         <li><a href="../">ホーム</a></li>
         <li><a href="./">一覧</a></li>
+        <li><a href="../#about">紹介</a></li>
+        <li><a href="../#episodes">12話</a></li>
+        <li><a href="../#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -31,13 +34,80 @@
   </header>
   <main class="sg-main" data-template="list" data-experience="hina">
     <ul class="sg-list card-grid">
-      <li class="sg-card">
-        <p class="sg-eyebrow">Episode</p>
+      <li class="sg-card" data-episode-id="ep01">
+        <p class="sg-eyebrow">Episode 01</p>
         <h2><a href="../posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
         <p class="sg-meta">#ep01</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep02">
+        <p class="sg-eyebrow">Episode 02</p>
+        <h2><a href="../posts/ep02/">EP02: 世界 W は、仕様書の外に広がってる</a></h2>
+        <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+        <p class="sg-meta">#ep02</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep03">
+        <p class="sg-eyebrow">Episode 03</p>
+        <h2><a href="../posts/ep03/">EP03: 同値クラスという、お守りの石</a></h2>
+        <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+        <p class="sg-meta">#ep03</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep04">
+        <p class="sg-eyebrow">Episode 04</p>
+        <h2><a href="../posts/ep04/">EP04: 境界線を、一緒に歩いた夜</a></h2>
+        <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+        <p class="sg-meta">#ep04</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep05">
+        <p class="sg-eyebrow">Episode 05</p>
+        <h2><a href="../posts/ep05/">EP05: 分岐の森と、先輩の地図</a></h2>
+        <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+        <p class="sg-meta">#ep05</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep06">
+        <p class="sg-eyebrow">Episode 06</p>
+        <h2><a href="../posts/ep06/">EP06: 関係は、状態遷移で語れる</a></h2>
+        <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+        <p class="sg-meta">#ep06</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep07">
+        <p class="sg-eyebrow">Episode 07</p>
+        <h2><a href="../posts/ep07/">EP07: 全部は試せない、という優しさ</a></h2>
+        <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+        <p class="sg-meta">#ep07</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep08">
+        <p class="sg-eyebrow">Episode 08</p>
+        <h2><a href="../posts/ep08/">EP08: カバレッジの虹を見上げて</a></h2>
+        <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+        <p class="sg-meta">#ep08</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep09">
+        <p class="sg-eyebrow">Episode 09</p>
+        <h2><a href="../posts/ep09/">EP09: ログは、システムからのラブレター</a></h2>
+        <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+        <p class="sg-meta">#ep09</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep10">
+        <p class="sg-eyebrow">Episode 10</p>
+        <h2><a href="../posts/ep10/">EP10: 魔導書と職人の手、Fθと G</a></h2>
+        <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+        <p class="sg-meta">#ep10</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep11">
+        <p class="sg-eyebrow">Episode 11</p>
+        <h2><a href="../posts/ep11/">EP11: 先輩も、迷っていた</a></h2>
+        <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+        <p class="sg-meta">#ep11</p>
+      </li>
+      <li class="sg-card" data-episode-id="ep12">
+        <p class="sg-eyebrow">Episode 12</p>
+        <h2><a href="../posts/ep12/">EP12: 次の子に渡す、G の地図</a></h2>
+        <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+        <p class="sg-meta">#ep12</p>
       </li>
     </ul>
   </main>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep01/index.html
+++ b/generated/hina/posts/ep01/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>hina | Detail</title>
+    <title>EP01: 開幕、魔界喫茶《∞（インフィニティ）》 | Hina Generated Experience</title>
     <link rel="stylesheet" href="../../assets/tokens.css">
     <link rel="stylesheet" href="../../assets/base.css">
     <link rel="stylesheet" href="../../assets/components.css">
     <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。">
+    <meta property="og:title" content="EP01: 開幕、魔界喫茶《∞（インフィニティ）》">
+    <meta property="og:description" content="新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。">
     <script src="../../../shared/features/init-features.js" defer></script>
     <script src="../../../shared/switcher.js" defer></script>
   </head>
@@ -21,6 +24,9 @@
         <ul class="sg-nav-links">
         <li><a href="../../">ホーム</a></li>
         <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -256,3 +262,4 @@
   </article>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep02/index.html
+++ b/generated/hina/posts/ep02/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP02: 世界 W は、仕様書の外に広がってる | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="画面の外へ。現場と人の温度が、物語の色を変えていく。">
+    <meta property="og:title" content="EP02: 世界 W は、仕様書の外に広がってる">
+    <meta property="og:description" content="画面の外へ。現場と人の温度が、物語の色を変えていく。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep02">
+  <article class="sg-article" data-template="detail" data-content-id="ep02" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP02: 世界 W は、仕様書の外に広がってる</h1>
+      <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》オープン初夜、新人サキュバスで“なんでも屋のダメダメテストエンジニア”結城ユイ（源氏名ユイリア）は感覚だけでイベントを回し、店を炎上寸前にしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームのログとメモを一瞥しただけで「客のパターン」を整理し、あっという間に状況を見える化。ユイは同じ世界を見ているはずなのに全く違う景色を切り取る先輩の背中に、強く憧れ始める。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>翌日の昼、《∞》はまだ開店前だった。昨夜の喧騒が嘘みたいに静かで、店内にはバルハがグラスを磨く音だけが響いている。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイリア、ちょっと外、付き合ってくれる？」
+            </div>
+<p>カウンター越しに顔を出した神崎ナギが、軽く手を振った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「テスト、ですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストの前に、“世界を見る練習”」
+            </div>
+<p>二人は店の前に並んで立った。昼の魔界歓楽街は、夜とは別人のようだ。ネオンは落ち着き、魔法水晶の看板が淡く光り、隣のインキュバス喫茶からコーヒーの香りが流れてくる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「質問。誰がこの店に入りそう？　誰は絶対入らなさそう？」
+            </div>
+<p>ナギが通りを指さす。黒ローブの魔法使い。ショッピング袋を下げたギャルサキュバスたち。ため息まじりにスマホをいじる人間界のサラリーマン。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと、あのギャルサキュバスたちは絶対来ます！　《∞》のパフェ、昨日SNSでバズってましたし」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ふむ。それで、あのスーツの彼は？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“社畜”っぽい人は来ないと思います。時間なさそうだし、メイド喫茶に寄る余裕なんて――」
+            </div>
+<p>ユイが言い終える前に、ギャルサキュバスたちは《∞》の前を素通りして、向かいのカラオケ魔城に吸い込まれていった。代わりに、クマのできたサラリーマンが店の前で立ち止まる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……え？」
+            </div>
+<p>ユイが固まっていると、男はおずおずと扉を覗き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「すみません、昨日の夜すごく楽しくて……昼もやってるかと思って」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「あ、今は準備中で……」
+            </div>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「ですよね。じゃあメニューの写真だけ撮らせてください。仕事の励みにしたくて」
+            </div>
+<p>入口のメニュー立てをスマホで撮りながら、彼はほっとしたように笑った。その背中を見送りながら、ユイは自分の予想が気持ちいいくらい外れたことを実感する。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「予想、外れちゃったね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ですよね。仕様書では“ターゲットは疲れた社畜”って書いてあったから、てっきり、ああいう人はむしろ来ないんだと思ってて」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「仕様書、昨日渡したやつ？」
+            </div>
+<p>ナギはポケットから折りたたまれた紙を取り出す。ターゲット像、営業時間、コンセプト。昨夜、ふたりで書いたメモだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい。わたし、こういう紙に書いてあることが“世界の全部”だと思ってました」
+            </div>
+<p>ユイが俯くと、ナギは紙の裏に大きな丸を描き、その中に「W」と書き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Wっていうのはね、“この店に関わる世界全部”のこと」
+            </div>
+<p>丸の外側へ矢印を伸ばしながら、ナギは通りを指す。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「時間帯、天気、この通りの空気、さっきの彼の残業状況、SNSの評判、その人の今日の気分……ここ“現場”を歩く人間ぜんぶ。仕様書に書いてないものほど、テストでは効いてくるんだよ」
+            </div>
+<p>ユイはごくりと喉を鳴らした。ナギは丸の中に小さな四角を描き、「仕様書」と書き込む。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「こうやって見ると、仕様書って、W の中のこのくらいの箱にしかすぎない」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……じゃあ、わたし、W のほんの一部しか見てなかったんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「“しか”って言うと、ちょっともったいないかな」
+            </div>
+<p>ナギは首を横に振る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「昨日の君は“仕様書の中だけの世界”を必死に見ていた。でも今はこうして、仕様書の外を見ようとしている」
+            </div>
+<p>通りに向けられたユイの視線を確かめてから、静かに続けた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「見ようとした瞬間から、もうテスターなんだよ」
+            </div>
+<p>胸の奥が、ぽっと温かくなる。ユイはポケットからメモ帳を取り出し、ページの端に「世界W観察ログ」と書き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「じゃあ……さっきのサラリーマンさんは、“昼でもメニューを眺めたいくらい昨日の体験が刺さった客”ってことで……世界 W の中の、ひとつの点？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。仕様書には“疲れた社畜”としか書いてなかった。でも実際の W には、“昨日楽しんでくれた人が、今日も何かを求めてくる”って状態があった」
+            </div>
+<p>ナギは丸の中に小さな点を打つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「その点に気づいたのは、ユイリアだよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……わたし、ちゃんと見れてましたか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。“外した”って落ち込んでたけど、外れたってことは、“こうだろう”って仮説を立ててたってこと。何も考えずに眺めてたら、そもそも外れないからね」
+            </div>
+<p>ユイはきょとんとし、それからふにゃりと笑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「なんか……失敗ログにも、意味がある気がしてきました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「あるよ。世界 W を知るための、立派な観測データ」
+            </div>
+<p>店に戻ると、バルハがカウンターから顔を上げた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「外の空気はどうだった？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……世界、思ったよりずっと広かったです」
+            </div>
+<p>ユイが答えると、バルハはにやりと笑う。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ふたりとも、ちゃんと外を見て帰ってきた顔してるよ」
+            </div>
+<p>夕方、街にネオンが灯り始める。開店準備を終えたユイは扉の前に立ち、通りを見上げた。仕様書の外側に広がる、揺れるような世界 W。その中からどんな瞬間をすくい上げられるだろう――そんなことを思いながら、彼女は「本日開店」のプレートをそっと裏返した。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep02</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep03/index.html
+++ b/generated/hina/posts/ep03/index.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP03: 同値クラスという、お守りの石 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。">
+    <meta property="og:title" content="EP03: 同値クラスという、お守りの石">
+    <meta property="og:description" content="ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep03">
+  <article class="sg-article" data-template="detail" data-content-id="ep03" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP03: 同値クラスという、お守りの石</h1>
+      <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街にオープンしたサキュバスメイド喫茶《∞（インフィニティ）》。新人メイド・ユイリアこと結城ユイは、“なんでも屋のダメダメテストエンジニア”として場当たりでイベントを回し、オープン初夜にクレーム祭りを引き起こしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、山のようなクレームログを一瞥しただけで客を三つのパターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
+<p>翌日、店の前で通行人を観察したユイは、誰が店に入るかを外し続け、世界 <span class="katex">W</span> が仕様書の外側――時間や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」と笑うナギに励まされ、世界を少しずつ切り取る力を育て始める。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「社畜客」「観光客」「カップル」「ぼっち」――ホワイトボード一面の付箋を前に、ユイは頭を抱えていた。</p>
+<p>イベント仕様：残業明け社畜救済ナイト。対象客層が多すぎると感じながら、バルハからのミッションである「どんな客にも癒やされたと言わせる設計」を考えている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「社畜にもブラックとホワイトがいて、観光客も陽キャと陰キャがいて……これ全部別々にテストしてたら、一生終わらないんだけど…」
+            </div>
+<p>カウンターの上では、オーナー・バルハが黄金の瞳でその様子を眺めている。助け舟は期待できそうにない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「行き詰まった顔してるね」
+            </div>
+<p>背後から聞き慣れた声。振り向けば、神崎ナギが立っていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「せ、先輩！　このカオス見ないでください…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ううん、いいカオスだよ」
+            </div>
+<p>ナギはくすりと笑い、ポケットから小さなガラス瓶を取り出した。中には色も形も違う小さな鉱石がぎゅっと詰まっている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「綺麗ですけど？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部、石英（クォーツ）だよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え、全部同じなんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。見た目は違っても、“この観点から見ると同じ”ってことはよくある」
+            </div>
+<p>ナギは瓶を軽く振ってから、ホワイトボードの前に立つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今ユイが困ってるのは、“全部違って見えるお客さん”でしょ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい…。バリエーション多すぎて、テストパターンが宇宙の端まで増えそうで…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、“お守りの石”を信じてみようか」
+            </div>
+<p>ナギはマーカーを手に取った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今日のイベントで一番守りたい観点 <span class="katex">S</span> は？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと…『ここに来てよかった』…ですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「その中でも、残業明け社畜救済なんだから？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「――“限界の社畜さんが、少しでも呼吸を取り戻せるか”」
+            </div>
+<p>ナギは真ん中に大きな丸を描き、「<span class="katex">S</span>：限界社畜の呼吸ポイント」と書き込む。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、この <span class="katex">S</span> から見て“同じ扱いでよさそうな人たち”を探そう」
+            </div>
+<p>ナギは付箋を二枚はがす。《社畜：三日徹夜、今にも倒れそう》《社畜：残業続き、今日は上司に怒鳴られてきた》。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「この二人にとって一番大事なのは？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「体力ゼロと、心がズタボロ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「どっちも“今すぐ難しい話を聞かされると死ぬ”って意味では同じだよね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「あ、たしかに」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあこの二人は、<span class="katex">S</span> の観点では同じ“限界社畜クラス”」
+            </div>
+<p>ナギは二枚を丸で囲み、「<span class="katex">A_1</span>：限界社畜」とラベルをつけた。</p>
+<p>次にナギがつまんだのは、《社畜：普段は激務だが今日は奇跡の有給》《観光客：魔界出張のついでに寄った》の二枚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「一見違うけど、“今日の気分”は似てない？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どっちも、ちょっと浮かれてる感じ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。“今日は特別な一日”クラスだね」
+            </div>
+<p>新しい丸に「<span class="katex">A_2</span>：特別デー満喫」と書き込む。さっきまでバラバラだった客たちが、観点 <span class="katex">S</span> を通してふわっと集まり始める。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え、じゃあ…このカップルと、このぼっちさんも…」
+            </div>
+<p>ユイは自分で付箋を動かし、ラブラブ観光カップルと、スマホを握りしめてそわそわしている青年を同じ丸に入れた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どっちも“誰かに見せたい特別な夜”クラス…かも」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん、その分け方はユイの <span class="katex">W</span> の見方から出てきたものだよ」
+            </div>
+<p>ナギはホワイトボードの端に小さく書き添える。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「世界 <span class="katex">W</span> のお客さんを、観点 <span class="katex">S</span> から見て“同じ息の仕方かどうか”で分けたグループ。それがテストでいう同値クラス <span class="katex">A(S)</span>」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「同値クラス…用語としてしか知らなかったです」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「名前だけ知ってても、こうやって <span class="katex">W</span> の上に描いてみると、ちょっと身近になるでしょ？」
+            </div>
+<p>ユイはうなずき、ノートを開いた。丸と矢印が増えるたび、混沌だった世界が少しだけ整っていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、それぞれのクラスから代表を一人決めて、その人の一晩を徹底的にシミュレーションしよう」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「<span class="katex">A_1</span> は三日徹夜さん。寝落ちさせない導線と、脳に優しいメニューを…」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「<span class="katex">A_2</span> は有給社畜さん。“頑張ってる自分”を労えるサプライズを入れたいです」
+            </div>
+<p>客の名前の代わりに、「<span class="katex">A_1</span>」「<span class="katex">A_2</span>」の記号がノートの上を跳ね回る。さっきまで怖かったバリエーションが、「塊」として手のひらに乗る感覚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ね、全部バラバラに見えてた世界が、“同じ扱いでよくなる塊”に見えてきたでしょ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい…。世界がちょっと優しくなった気がします」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「それが、同値クラスのお守り効果」
+            </div>
+<p>ナギは瓶から小さな透明な石を一つ取り出した。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今日からユイのお守り。困ったら、この石を見て考えてみて。“この子と同じように扱える仲間、いないかな？”って」
+            </div>
+<p>ユイはそっと石を握りしめる。冷たい感触が、少しずつ手の中で温度を帯びていく。</p>
+<p>――いつか自分も、ナギみたいに。バラバラな世界を、やさしい丸で包んであげられる先輩になれたら。</p>
+<p>石英のかすかなきらめきが、ホワイトボードに映る。そこにはもう、“なんでも屋のダメダメテストエンジニア”ではなく、同値クラスという小さな石を手に入れた、一人のテスト屋の地図が描かれ始めていた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep03</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep04/index.html
+++ b/generated/hina/posts/ep04/index.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP04: 境界線を、一緒に歩いた夜 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。">
+    <meta property="og:title" content="EP04: 境界線を、一緒に歩いた夜">
+    <meta property="og:description" content="近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep04">
+  <article class="sg-article" data-template="detail" data-content-id="ep04" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP04: 境界線を、一緒に歩いた夜</h1>
+      <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で働く新人メイド兼テストエンジニア・結城ユイ（ユイリア）は、場当たり運営でオープン初夜を炎上させてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、クレームログを一瞬で三つの客パターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
+<p>翌日、店の前で通行人を観察したユイは、誰が店に入るかを外し続け、世界 <span class="katex">W</span> が仕様書の外側──時間や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」と笑うナギに励まされ、さらにイベント準備では、小さな鉱石を例に「観点しだいで同じ扱いにできる塊＝同値クラス」を学び、世界を少し整理して見られるようになってきていた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「社畜救済ナイト、本日かぎり〜！」サキュバスメイド喫茶《∞》のネオンが青く瞬く。スーツ客限定ドリンク無料、残業時間を申告すると「おつかれさまマッサージ」付き──そのイベントを企画したのは、昨日「同値クラス」を教わったばかりのユイだ。</p>
+<p>胸元で、ナギにもらった鉱石の小瓶が揺れる。カラン、と扉の鈴。最初の客はネクタイを緩めた中年の男。目の下のクマが深い。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「いらっしゃいませ。今月の残業時間、よろしければ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">社畜客</span>
+                「百二十時間だ」
+            </div>
+<p>想定テーブルの最大値を軽く超えた数字に、ユイの笑顔が固まる。動揺をごまかそうとして、軽口が滑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「そんな会社、やめちゃえばいいのに！」
+            </div>
+<p>冗談のつもりでウインクした瞬間、男の肩がびくりと震える。</p>
+<div class="dialogue">
+<span class="character-name">社畜客</span>
+                「…やめられたら、とっくにやめてるよ」
+            </div>
+<p>ぽたり、とテーブルに落ちる雫。涙だと気づいたときには遅かった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>休憩に入ると、フィードバックカードが一枚置かれていた。</p>
+<div class="feedback-card">「励ましがきつかったです。そっとしておいてほしかった」</div>
+<p>短い文字が、胸を刺す。そこへまた鈴の音。ユイはカードを握りしめたままホールへ戻った。</p>
+<p>今度は若いサラリーマン風の男。スーツも表情もまだ余裕がある。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「いらっしゃいませ。ドリンクは？」
+            </div>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「おすすめで。…大変そうだね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「まあ、ぼちぼちです」
+            </div>
+<p>仕事の話題を避け、マニュアル通りの笑顔で受け流す。沈黙が増えるたびに、ユイは一歩ずつ下がっていくみたいな気持ちになる。帰り際、その客もカードを書いていった。</p>
+<div class="feedback-card">「可愛いけど、今日はなんか遠くてさみしかった」</div>
+<p>二枚のカード。踏み込みすぎた自分と、引きすぎた自分。どちらも正解に見えなくて、ユイはスタッフルームの椅子に崩れ落ちた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私、どこまで行っていいか、全然分かんない」
+            </div>
+<p>ぽつりと言ったとき、背後から穏やかな声が落ちてくる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、境界線を見に行こっか」
+            </div>
+<p>振り返ると、ナギが白いコートの裾を揺らして立っていた。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>店を出て少し歩くと、歓楽街の端に細い川がある。ネオンを映した黒い水面と石畳。その境目には、濡れて黒い石と乾いて白い石のくっきりした帯ができていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ここ、分かりやすいでしょ。『濡れて滑りやすい世界』と『乾いて歩きやすい世界』の境界」
+            </div>
+<p>ナギは境目の少し色の違う石をつま先でつつく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ここまではセーフ、ここから先はアウト。その“ちょうど変わるところ”を何度も行き来して確かめるのが、境界値分析」
+            </div>
+<p>ユイはおそるおそる境界の上に片足を置く。靴底がかすかにぐにゃっと滑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「…こわ」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でも、テスト屋が一番知りたいのって、この感触なんだよ」
+            </div>
+<p>ナギは境目の石を拾い、ユイの手に乗せた。ひんやり冷たい。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「さっきの二人も、境界線のそばにいたんだと思う。『会社やめちゃえば』って一言で、“うれしい共感”から“一気につらい現実”側に落ちちゃうラインとか」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私、完全に踏み抜いたやつだ」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。でも、その場所が分かったのは大きい。テストで言えば、『ここが 59→60 分で結果が変わるポイントでした』ってログが取れた状態」
+            </div>
+<p>ナギは石に小さく「B」と書く。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Boundary の B。今日のカードは、『このクラスの人はここまで来ると泣いちゃう』『ここまで下がるとさみしい』っていう境界値データ。ダメな自分の証拠じゃなくて、世界 <span class="katex">W</span> からのメモだよ」
+            </div>
+<p>ユイは、ラブレターにしては刺さり方がエグいなと思いながらも、少し笑った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「境界って、人の心が変わるラインでもある。だから、一歩目でつまずくのは普通。大事なのは『ここが危ない』って印をつけて、次は一歩手前から試すこと」
+            </div>
+<p>夜風が川面をわたる。ユイは石と小瓶を握りしめた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「…じゃあ、もう一回だけ、やってみてもいい？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「もちろん。境界値分析って、“もう一度踏み出す勇気”のためのおまじないだから」
+            </div>
+<p>《∞》のネオンが遠くで瞬く。ユイはその光を見つめ、小さくうなずいた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「明日、社畜さん向けのトークを、『天気ゾーン』『仕事ぼやきゾーン』『人生ゾーン』ってライン引いて考えてみる。どこで世界が変わるか、自分でもちゃんと見に行く」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いいね。それ、次の『地図作り』にもつながるよ」
+            </div>
+<p>境界線を一緒に歩いた夜。ユイの中で「失敗」というラベルが、そっと「発見」に書き換わっていった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep04</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep05/index.html
+++ b/generated/hina/posts/ep05/index.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP05: 分岐の森と、先輩の地図 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="増え続ける条件の森。迷いを“見える形”にしていく一歩。">
+    <meta property="og:title" content="EP05: 分岐の森と、先輩の地図">
+    <meta property="og:description" content="増え続ける条件の森。迷いを“見える形”にしていく一歩。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep05">
+  <article class="sg-article" data-template="detail" data-content-id="ep05" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP05: 分岐の森と、先輩の地図</h1>
+      <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、テストエンジニア見習いとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させてしまう。しかし現れた伝説級テストアーキテクト・神崎ナギが、クレームログを三つの客パターンに整理して見せ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
+<p>翌日、店先で通行人を観察したユイは「誰が店に入るか」を外し続け、世界 <span class="katex">W</span> は仕様書だけでなく、時間帯や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」とナギに言われ、世界をちゃんと見る一歩を踏み出した。</p>
+<p>イベント準備では、属性が増えすぎて混乱するユイに、ナギが小さな鉱石を見せながら「観点しだいで同じ扱いにできる塊＝同値クラス」を説明。見た目は違っても、テストしたい観点 <span class="katex">S</span> から見れば同じグループにできる客たちがいると知り、ユイは世界を少し整理して見られるようになっていく。</p>
+<p>社畜救済イベント本番では、ある客には踏み込みすぎて泣かせ、別の客には距離を取りすぎて「冷たい」と言われてしまう。落ち込むユイに、ナギは夜の河川敷で「どこまで踏み込んだらうれしくて、どこから先は苦しくなるか。人にもテストにも境界がある」と境界値分析を重ねて語る。ユイは、失敗が「境界を探すための一歩」だったと受け止め、もう一度やってみようと顔を上げた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>その夜の《∞》は、レジ前だけ小さな地獄だった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと……平日社畜割でドリンク半額で、雨の日カウンター席 10％オフで、ペア来店＋SNS 投稿でデザートサービスで……」
+            </div>
+<p>ユイはレジ画面と手書きメモを交互ににらみ、指を折っては戻す。バルハオーナーが導入した新ロジックは、社畜証明や天気、席種、SNS 投稿、滞在時間など条件が重なるほど複雑だった。頭の中で IF と AND と OR が枝分かれし、思考は白煙を上げ始める。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「お、お待たせしてしまってすみませんっ！」
+            </div>
+<p>目の前の社畜スーツ客に、とりあえず一番お得そうな割引を全部乗せしてしまった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業終了後。客席が暗くなり、カウンターだけが照明に浮かぶ。ユイは割引条件を書き散らしたノートを前にうなっていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ここで社畜フラグが立って……ここで雨フラグで分岐して、席種でまた分岐して、SNS で……木が増えすぎて根っこが分かんない……」
+            </div>
+<p>ノートには IF 文の断片と矢印が蜘蛛の巣のように広がり、自分でも読めない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「分岐の森で遭難してる顔だね」
+            </div>
+<p>エプロンを外した神崎ナギが立っていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギ先輩……。頭の中で全部追おうとしたら、ぜんぶ混ざって……今日、絶対どこかでミスりました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「分岐が増えるほどね、頭の中だけで持ちきれないものは外に出してあげたほうがいい」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「外に？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。“地図”にしちゃうの」
+            </div>
+<p>ナギが小さなホワイトボードにシンプルな表の枠を引く。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「割引に効いてきそうな条件だけ並べよう。これは決定表。IF 文を文章で追う代わりに、マス目で分岐を見るやり方」
+            </div>
+<p>左端に「社畜証明」「雨の日」「カウンター席」「ペア来店」「SNS 投稿」「〜19:00」「滞在 60 分」、上には「パターン1」「パターン2」……と書き込まれていく。ナギは「パターン1」の列に◯と×を書き込み始めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「たとえば、よく来る黒スーツの社畜さん。証明あり、雨の日に来ることが多くて、カウンター席好きで、仕事仲間と二人で来るけど SNS 投稿はしない。時間は 18:30 ごろ、滞在は 60 分前後」
+            </div>
+<p>ユイの頭に、毎回「おつかれ」と笑う常連の顔が浮かぶ。</p>
+<div class="decision-table">
+<table>
+<tr>
+<th>条件</th>
+<th>パターン1</th>
+<th>パターン2</th>
+</tr>
+<tr><td>社畜証明</td><td>◯</td><td>◯</td></tr>
+<tr><td>雨の日</td><td>◯</td><td>×</td></tr>
+<tr><td>カウンター席</td><td>◯</td><td>×</td></tr>
+<tr><td>ペア来店</td><td>◯</td><td>×</td></tr>
+<tr><td>SNS 投稿</td><td>×</td><td>◯</td></tr>
+<tr><td>〜19:00</td><td>◯</td><td>◯</td></tr>
+<tr><td>滞在 60 分</td><td>◯</td><td>×</td></tr>
+<tr><td>結果</td><td>ドリンク半額＋会計10％オフ＋デザート＋ポイント二倍</td><td>ドリンク半額＋デザート</td></tr>
+</table>
+</div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあパターン2 は？　一人でふらっと来た社畜さん。証明はあるけど、雨じゃなくて、テーブル席で、SNS 投稿はしてくれる」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと……社畜証明＝◯、雨の日＝×、カウンター席＝×、ペア来店＝×、SNS 投稿＝◯、〜19:00＝◯、滞在 60 分＝×……結果は、ドリンク半額とデザートだけ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。雨じゃないから 10％オフは付かないし、滞在も 60 分から外れてる。こうやって一行ずつ見ていけば、迷わない」
+            </div>
+<p>自分のペンで◯と×を書き込みながら、ユイは思う。 同じ森の中にいるはずなのに、地図があるだけで足元がくっきりする。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……さっきまでのぐちゃぐちゃが、ちゃんと“道”に見えてきました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でしょ。人の脳はそんなに分岐を同時には扱えない。だから、地図に肩代わりさせればいい」
+            </div>
+<p>ナギはボードの端に小さな山の絵を描いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「鉱物採集するときも、地形図なしで山に突っ込むと遭難する。“危ない分岐”は最初から赤で印を付けておく」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“売上が吹き飛ぶやばい組合せ”も、赤で囲んでおける……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そうそう。『全部覚えておく』って、実は一番危ない考え方なんだよ」
+            </div>
+<p>ユイは笑いながら、パターン3、4 と常連たちを思い浮かべてマス目を埋めていく。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「これ、明日からレジ横に貼りませんか？　みんなで同じ地図を見られるように」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いいね。分岐の森は、一人で歩かなくていい」
+            </div>
+<p>ナギがふっと目を細める。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「それとね。今日、分岐に呑まれて苦しくなった感覚も、ちゃんと覚えておいて」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え？　忘れたいんですけど……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いつか、もっと迷子になってる新人が現れたときに、『ここに地図があるよ』って渡すために」
+            </div>
+<p>その言葉に、胸の奥が少し熱くなる。手作りの決定表は、まだ粗い線だらけの地図だ。けれどユイには、その端っこから、遠くの“先輩の背中”へ伸びる細い道が続いているように見えた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep05</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep06/index.html
+++ b/generated/hina/posts/ep06/index.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP06: 関係は、状態遷移で語れる | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="時間で変わるものには、ちゃんと“状態”と“遷移”がある。">
+    <meta property="og:title" content="EP06: 関係は、状態遷移で語れる">
+    <meta property="og:description" content="時間で変わるものには、ちゃんと“状態”と“遷移”がある。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep06">
+  <article class="sg-article" data-template="detail" data-content-id="ep06" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP06: 関係は、状態遷移で語れる</h1>
+      <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で見習いテストエンジニアとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させかける。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームを三つの客パターンに整理してみせ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
+<p>翌日、店先で通行人を観察したユイは、誰が店に入るかをことごとく外し、世界 <span class="katex">W</span> が仕様書の外側──時間帯や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」とナギに認められ、世界をちゃんと見る一歩を踏み出す。</p>
+<p>イベント準備では、増え続ける客の属性に溺れかけるが、ナギから同値クラスの考え方を教わり、「観点しだいで同じ扱いにできる塊」が見えるようになる。社畜救済イベント本番では、踏み込みすぎたり距離を取りすぎたりして失敗するものの、「人にもテストにも境界がある」と境界値分析を重ねて聞かされ、失敗を境界探しの一歩として受け止め直す。</p>
+<p>第5話では、割引条件や時間帯などの分岐が爆発し、頭の中の IF 文で迷子になったユイに、ナギが決定表という「分岐の地図」を描いてみせた。ユイは複雑さを外に出して整理する感覚を掴みかけている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>夕方の《∞》に、見慣れた背広が入ってくる。社畜救済イベント以来の常連客カズマだ。ユイリアはいつものノリでしっぽを振った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「おかえりなさいませ〜社畜さま♡　今日も残業コンボ決めてきました？」
+            </div>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……ああ」
+            </div>
+<p>返事は短く、声は平坦。いつもなら「やめろ」と笑うのに、今日は視線がテーブルから上がってこない。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ご褒美ドリンク、今日は強めにしときます？　魂までとろけるやつ！」
+            </div>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……悪い。今日は、あんまりいじらないでくれると助かる」
+            </div>
+<p>ユイはあわてて頭を下げ、マニュアルどおりの笑顔で注文だけを取る。会話はそれ以上広がらず、彼は一杯飲むと、いつもより早く帰ってしまった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業後、裏口の階段。ユイは膝を抱え、横で缶コーヒーを開けるナギをちらりと見る。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……やっぱり、やらかしましたよね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「カズマくんのこと？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい。前は“社畜さま”っていじると笑ってくれたのに、今日は明らかに刺さってて……。決定表まで作ったのに、“関係の気分”みたいなのは表にできなくて」
+            </div>
+<p>ナギは少し考え、ユイのノートを開いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「決定表は、その瞬間の条件と結果を見るには便利なんだ。でも、人や関係みたいに、時間でじわじわ変わるものは、別の見方がいい」
+            </div>
+<p>ナギが丸をひとつ描き、矢印を伸ばす。</p>
+<p class="diagram">『初来店』 → 『リピーター』 → 『常連』 → 『VIP』<br/>　　　　　　　　　　　　　↘<br/>　　　　　　　　　　　　　『離脱』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これが関係の“状態遷移図”。丸が“今どんな状態か”。矢印が“そこからどこに行きうるか”。ログイン前→ログイン中→ログアウト、みたいな変化も、同じように描けるよ」
+            </div>
+<p>さらに小さな丸が増える。</p>
+<p class="diagram">『限界社畜』 → 『ちょっと回復した常連』 → 『心が折れかけ常連』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「カズマくん、今日はたぶんここだね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“心が折れかけ常連”……」
+            </div>
+<p>言葉になった途端、さっきの沈んだ目が、ただ怖いものじゃなく「そういう状態」として見え直る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「同じ“常連”でも、状態が違えば、かけていい言葉も変わる。今日ユイが投げたのは、“ちょっと回復した常連”向けのいじり方だった」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「うわ……決定表、雑にまとめすぎたかもです……」
+            </div>
+<p>ユイは自分の表のマスを思い出し、うなだれる。ナギは『心が折れかけ常連』から別の丸へ矢印を足した。</p>
+<p class="diagram">『心が折れかけ常連』 → 『静かに休めた常連』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「次に会ったとき、“今日は静かに過ごすコースもありますよ”ってそっと出してみる。もし少しでも休めたら、状態はこっちに遷移する。そこからまた、ゆっくり別の矢印を考えればいい」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……一回ミスったら“離脱”に直行ってわけじゃないんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「人はバージョン固定じゃないからね。何度でもアップデートできる。『今どの状態にいて、どこに行きうるか』が見えると、テストしたい場面も、声のかけ方も見えてくるよ」
+            </div>
+<div class="scene-break">＊　＊　＊</div>
+<p>翌晩。ドアベルが鳴り、またカズマが入ってきた。昨日と同じように疲れた顔。それでも足がここを選んでくれたことが、少しうれしい。エプロンのポケットには、自分で描いた小さな状態遷移メモが入っている。</p>
+<p>（今は“心が折れかけ常連”。ここから、“静かに休めた常連”へ、矢印を伸ばす）</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「おかえりなさいませ、カズマさん。今日は──いじられたい日ですか？　それとも、“そっとしておいてほしい日”ですか？」
+            </div>
+<p>カズマがきょとんとし、やがてふっと笑う。</p>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……後者で、お願いします」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「かしこまりました。“静かに休めた常連”コースですね」
+            </div>
+<p>小声でそう確認しながら、ユイは余計な台詞を挟まず、そっとカップを置く。人の心は仕様書みたいにきれいには並ばない。それでも、丸と矢印で輪郭を描いてみると、モヤモヤが少しだけ形になる。</p>
+<p>立ちのぼる湯気の向こうで、ユイリアの小さな決意が、静かに新しい状態へと遷移していった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep06</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep07/index.html
+++ b/generated/hina/posts/ep07/index.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP07: 全部は試せない、という優しさ | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="全部を抱えない。“守るために選ぶ”という、やさしい決断。">
+    <meta property="og:title" content="EP07: 全部は試せない、という優しさ">
+    <meta property="og:description" content="全部を抱えない。“守るために選ぶ”という、やさしい決断。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep07">
+  <article class="sg-article" data-template="detail" data-content-id="ep07" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP07: 全部は試せない、という優しさ</h1>
+      <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働き始めた結城ユイ──ユイリアは、炎上しかけたオープン初夜を伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」と教わる。その後、世界 <span class="katex">W</span> が仕様書の外側まで広がること、同値クラスでばらばらの客をまとめられること、境界値分析で踏み込み方を調整できること、決定表で分岐を地図にできること、状態遷移図で関係の変化を見通せることを少しずつ身に付け、図で世界を扱う感覚を育てている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「――じゃ、今度の《魔界横断オールナイトフェス》のテスト計画、ユイリアちゃんに任せたわよん♪」</p>
+<p>オーナーのバルハが、ぎっしり書き込みだらけの企画書を置いた。BGM３種、コスチューム３種、限定メニュー３種、席配置３パターン、客層４パターン。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……多くないですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「魔界の夜は盛りだくさんが正義よ☆　じゃ、よろしく～」
+            </div>
+<p>カウンターの端で、ユイはノートを開く。BGM × コスチューム × メニュー × 席配置 × 客層……。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「全部試そうとすると、3×3×3×3×4で……」
+            </div>
+<p>数字を書きかけたペン先が止まる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「私、こんなにテストケース作る時間、ない……」
+            </div>
+<p>前に教わった決定表を真似してみるが、マス目はすぐ真っ黒になり、頭の中の IF 文も一緒に爆発した。気づけば、ノートに額をつけていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイ、寝落ち？」
+            </div>
+<p>ふわりと影が差し、聞き慣れた声がした。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「な、ナギ先輩……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストケースに轢かれた顔してるね」
+            </div>
+<p>ナギはノートを覗き込み、びっしりの×印を見る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部の組合せを、全部試そうとしてる？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「だって……どれか取りこぼしたところでバグったら、私のせいでイベントが壊れるかもって思ったら……全部やらなきゃって」
+            </div>
+<p>自分でも情けなくて、声が小さくなる。ナギは少しだけ考える顔をしてから、ペンを取った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイ、山で鉱物採集したことある？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ないです」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「山って、全部の石を拾うんじゃなくて、“ここらへんに石英が多い層がある”とか“ここの斜面は崩れやすい”ってポイントを押さえるの。テストも同じ。全部は試せないからこそ、『代表』に絞る」
+            </div>
+<p>ナギは紙に小さな表を描く。BGM・コスチューム・メニュー・席配置・客層。それぞれの組み合わせを均等に拾う直交表ができあがっていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これはペアワイズとか直交表って呼ぶやり方。二つずつの組合せが漏れなく入るように、最小限のケースを選ぶんだ」
+            </div>
+<p>並んだ数字が、さっきまでの 3×3×3×3×4 の暴力から一気に少なくなる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ほんとだ。全部じゃないのに、ちゃんと“組み合わせを見る”って感じが残ってる」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部を試せないって、諦めじゃなくて優しさなんだよ。限られた時間で、壊れやすいところをちゃんと見るための優先順位付け」
+            </div>
+<p>ナギは最後に、空欄にいくつかのリスクメモを書き込む。「深夜帯×ハイヒール→滑りリスク」「辛メニュー×未成年→要注意」。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「直交表は“平均的な組合せ”を見るのが得意。でも、人が滑りやすいところ、燃えやすいところは意識的に足しておくといい」
+            </div>
+<p>ユイは深呼吸し、重かった肩が少し軽くなるのを感じた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……全部はできない、って決めるのって怖かったけど、ちゃんと理由があれば、むしろ守りになるんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。“優しく選ぶ”ってこと。ユイが選んだケースで、当日のお客さんが安全に楽しめるようにしよう」
+            </div>
+<p>フェス当日、ユイは直交表で選んだ組み合わせを丁寧に試し、リスクメモのケースを重点的に確認した。終電を逃した社畜がハイヒールのサキュバスに絡みそうになる場面も、事前に想定していた導線チェックのおかげで大きな事故にはならなかった。</p>
+<p>閉店後、バルハが冷蔵庫のドアに直交表を貼りながら笑う。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「全部は試せない、けど、この表があればみんなで迷子にならないね」
+            </div>
+<p>ユイも笑う。全部を抱え込まなくてもいい。優しく選んだ少ないケースが、確かに世界 <span class="katex">W</span> の安全を守っている手応えがあった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep07</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep08/index.html
+++ b/generated/hina/posts/ep08/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP08: カバレッジの虹を見上げて | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="足りないより、届いたところを見ていい——色を塗り分ける夜。">
+    <meta property="og:title" content="EP08: カバレッジの虹を見上げて">
+    <meta property="og:description" content="足りないより、届いたところを見ていい——色を塗り分ける夜。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep08">
+  <article class="sg-article" data-template="detail" data-content-id="ep08" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP08: カバレッジの虹を見上げて</h1>
+      <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働く結城ユイ──源氏名ユイリア。場当たり運営で炎上しかけたオープン初夜、伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」だと知る。</p>
+<p>店の前を行き交う人々を観察し、仕様書の外側まで含めた世界 <span class="katex">W</span> を意識するようになったユイは、ばらばらに見える客たちを同値クラスとしてまとめ、境界値分析で踏み込み方を整え、決定表で分岐の森を地図にし、状態遷移図で関係の変化を見通す力を磨いてきた。大イベント前にはペアワイズで「筋のいい組合せ」だけを選び、「全部は試せない」という賢いあきらめ方も学びつつある。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>イベント閉店後の《∞》は、嘘みたいに静かだった。さっきまで魔界 EDM が鳴り響き、社畜も観光客もカップルもごちゃまぜだったフロアが、今は片付いたテーブルとほのかな魔灯の明かりだけを残している。</p>
+<p>ユイリアはカウンター席で大きくため息をついた。目の前には今日のイベント用に自分で書いたテストケースノート。ページの端には「ペアワイズ OK」「境界△」「カズマさん来たら追加観察」と走り書きのメモが乱れている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「一応、事故はなかったし……みんな楽しそうだった、よね」
+            </div>
+<p>つぶやきながらも、胸のあたりがざわざわして落ち着かない。何かを忘れている気がする。どこかに穴があって、明日突然そこから炎が噴き出すんじゃないか、みたいな感覚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「顔に“テスト不安”って書いてあるよ」
+            </div>
+<p>振り向くと、いつの間にか神崎ナギがグラスに水を入れて座っていた。奥の厨房では、オーナーのバルハがしっぽで鍋を器用に運びながらこちらをちらりと見てニヤリと笑っている。</p>
+<p>ユイは観念して、ノートをぐるっと回してナギのほうに押し出した。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「今日、ペアワイズで組合せはかなり削れて……決定表も一応作って……境界っぽいところも、前に怒られたやつは踏み直して。でも、どこまでやれてるのか、全然わかんなくて。“まだ足りない気がする”って感覚だけが、ずっと残っちゃうんです」
+            </div>
+<p>ナギはノートをぱらぱらとめくり、ページの端に描かれた小さな丸や矢印を眺めながら、ふっと目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。いい顔してるよ、ユイ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっ、今にも泣きそうなんですけど」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「『ここまではやった。でも、どこまで守れてるんだろう？』って、カバレッジを気にし始めた目だもん」
+            </div>
+<p>ナギはナプキンの裏に小さな七色の弧を描いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストで『どのくらい試せてる？』を考えるとき、私はよく虹を描く。網羅したいものを色で塗っていくイメージね」
+            </div>
+<p>弧には「機能」「組合せ」「境界」「役割」「時間帯」「デバイス」などのラベルが並ぶ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部を同じ濃さで塗るのは無理。だから、今日みたいに組合せはペアワイズで薄めに、でも境界と役割は濃く塗る、とか、塗り分けを決める」
+            </div>
+<p>ユイは虹の欠けたところを指でなぞった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「私、時間帯とデバイス、ほぼ塗ってないかも……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ次の改善ポイントが見えたね。『虹のこの色は薄いけど、今回は許容する』『この色だけは濃く塗る』って自分で決めると、不安はだいぶ形になるよ」
+            </div>
+<p>ユイはノートの隅に、小さな虹を描き写す。「機能：濃」「境界：濃」「組合せ：中」「役割：中」「時間帯：薄」「デバイス：薄」。</p>
+<p>バルハが厨房から顔を出し、鍋をかき混ぜながら笑った。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「虹、いいじゃない。うちの店も七色に光ってるんだし」
+            </div>
+<p>ユイはふっと笑う。不安は消えない。けれど、どの色をどこまで塗ったかを自分で説明できると思うと、胸のざわつきが少しだけ静まった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「次のイベントでは、時間帯の色もちゃんと塗ってみます」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。虹は一晩じゃ完成しないからね。少しずつ重ねていこう」
+            </div>
+<p>虹色のメモをポケットにしまいながら、ユイは静かなフロアを見渡した。テストは終わらない。それでも、どの色を濃く塗るかを選べる自分が、少しだけ誇らしかった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep08</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep09/index.html
+++ b/generated/hina/posts/ep09/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP09: ログは、システムからのラブレター | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="沈黙のデータが、ふいに語りはじめる。気づきはそこにある。">
+    <meta property="og:title" content="EP09: ログは、システムからのラブレター">
+    <meta property="og:description" content="沈黙のデータが、ふいに語りはじめる。気づきはそこにある。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep09">
+  <article class="sg-article" data-template="detail" data-content-id="ep09" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP09: ログは、システムからのラブレター</h1>
+      <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>新人テストエンジニア・結城ユイ（源氏名ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれながら、サキュバスメイド喫茶《∞（インフィニティ）》で世界 <span class="katex">W</span> の見方を学び続けている。客を同値クラスで捉え、境界値で踏み込み方を調整し、決定表で分岐を地図にし、状態遷移図で関係の揺れを眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹で自分のテストの濃淡を確かめるようになった。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>金曜の夜。《∞》は社畜救済ナイトとハーフアニバーサリー割引が重なり、開店直後から満席だった。</p>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「ユイリアさーん！　会計が通りません！」
+            </div>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「ドリンクだけ永遠に『処理中』です！」
+            </div>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「レシート、古代語みたいになってるんですけど！」
+            </div>
+<p>新人メイドたちの悲鳴が一斉に飛んできて、ユイは固まる。頭の中で IF 文が暴走し始めたそのとき、カウンターの端から落ち着いた声がした。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「深呼吸、ユイリア。まずは、世界で何が起きてるかを見よっか」
+            </div>
+<p>ナギはバックヤードの端末を指さす。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギ先輩！？」「カズマくんが『今日は地獄だ』って騒いでたからね」
+            </div>
+<p>画面にはタイムスタンプやエラーコードの並んだログがびっしりと流れていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「うっ……ログって、やっぱり怖いです。怒られてるみたいで」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「怒ってるんじゃなくて、“苦しかった場所”を教えてくれてるだけだよ」
+            </div>
+<p>ナギはスクロールを止め、一行を指でなぞる。</p>
+<pre>WARN discount-rule-07 condition overflow for pattern[社畜救済×ハーフアニバ×深夜延長]</pre>
+<p>それはユイが決定表の空いていたマスに勢いで書き足した新コンボだった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「WARN は『ここ、ちょっとしんどかったよ』っていう弱めの悲鳴。世界 <span class="katex">W</span> から届いた、“ここが痛い”っていうラブレターだね」
+            </div>
+<p>客席を振り返ると、奥のボックス席でスーツ姿のグループが会計を待ちながら伝票の山とにらめっこしていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「このコンボのときだけ、料金計算を何度もやり直してる。だから端末がタイムアウトして、レシートもぐちゃぐちゃになる」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「じゃあ、このコンボだけ一時的に止めれば……？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。世界 <span class="katex">W</span> 全体を止める必要はない。“痛がってる同値クラス”だけをそっと保護する」
+            </div>
+<p>二人でオーナーのバルハに状況を説明すると、バルハは肩をすくめて笑った。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「OK。そのコンボは今夜だけ封印ね。『悪魔的負荷のため、社畜救済とハーフアニバの同時適用は停止中』ってポップ書いとくわ」
+            </div>
+<p>対応後、ラッシュは戻ってきたが、端末の悲鳴はぴたりと止んだ。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業終了後。ユイはバックヤードで改めてログを眺める。イベントの時間帯、席の組み合わせ、特定のメニュー。赤い文字が集まる場所は、今日の世界 <span class="katex">W</span> が痛んでいた場所そのものだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ラブレター、ですね。本当に」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でしょ？　『ここ、もっと優しくして』『この組合せ、重すぎる』って、システムがちゃんと教えてくれる」
+            </div>
+<p>ユイはラブレターを丁寧にノートへ貼り付け、次のテスト計画のページに矢印を引いた。ログの文字列が、少しだけ温かく見えた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep09</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep10/index.html
+++ b/generated/hina/posts/ep10/index.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP10: 魔導書と職人の手、Fθと G | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="便利さの向こう側。最後に“触る一点”を決めるのは誰？">
+    <meta property="og:title" content="EP10: 魔導書と職人の手、Fθと G">
+    <meta property="og:description" content="便利さの向こう側。最後に“触る一点”を決めるのは誰？">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep10">
+  <article class="sg-article" data-template="detail" data-content-id="ep10" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP10: 魔導書と職人の手、Fθと G</h1>
+      <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》の新人テストエンジニア・結城ユイ（ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれ、世界 <span class="katex">W</span> の見方を育ててきた。客を同値クラスでまとめ、心の境界値にぶつかり、決定表で分岐を地図にし、状態遷移図で関係を眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹でテストの濃淡を確かめ、ログを「システムからのラブレター」と読むようになった。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>営業後のカウンターで、バルハが分厚い黒い本を置いた。表紙には銀色で《汎用魔導書 Fθ》とある。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ねえユイリア。“頭数勝負”じゃないやり方、試してみない？」
+            </div>
+<p>不安を飲み込みつつ、ユイはナギと三人で実験することになった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「この前の社畜救済イベントの仕様とログ、流してみようか」
+            </div>
+<p>ナギが端末から魔導書へ魔力ケーブルを繋ぐと、黒いページが勝手にめくれ、光る文字が浮かぶ。</p>
+<pre>&lt;テスト案候補：
+ 1. 残業時間 0〜100 時間の全範囲で割引率が正しいこと
+ 2. 客の職種ごとに専用セリフが表示されること
+ 3. ログイン失敗時に励ましメッセージが表示されること
+ ……（以下 120 件）&gt;</pre>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ひゃ、百二十件！？」
+            </div>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ね、量では私たち敵わないでしょ？」
+            </div>
+<p>ユイは喉を鳴らす。魔導書が吐き出すテスト案の量と速度は、今まで自分が夜通しひねり出してきたものを軽々と超えていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……じゃあ、私の仕事、なくなっちゃうんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そうはならないよ。Fθは“材料”はたくさんくれる。でも、それをどう選ぶか、どう世界 <span class="katex">W</span> に合わせて磨くかは、職人の手がいる」
+            </div>
+<p>ナギは手元の紙に小さな記号を書いた。「Fθ → G」。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Fθ は魔導書の提案関数。G は私たちが持つ“現場の眼”。Fθ(G(x)) で初めて、店のテストケースになる」
+            </div>
+<p>ユイは試しに、魔導書の案から今日のイベントに関係しそうなものを三つ選び、決定表や状態遷移図と突き合わせていく。バルハはキッチン側の制約やコストを口にし、ユイはカバレッジの虹を思い浮かべながら優先度を塗り分けていった。</p>
+<p>深夜、テーブルには魔導書からの 120 件と、ユイが選んだ 12 件が並ぶ。後者は丸や矢印や色で塗られ、具体的な手順が添えられていた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「同じ“テスト案”でも、仕上がりが全然違うね。後ろの 12 件は、店の匂いがする」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Fθ がくれた素材を、G で整える。それが職人の手仕事」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……よかった。じゃあ、私、まだここでやることあるんだ」
+            </div>
+<p>魔導書は便利だ。それでも、店の匂いと温度を知っている手が要る。その手を、もっと確かにしていきたい。ユイはそう思いながら、魔導書の光るページをそっと閉じた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep10</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep11/index.html
+++ b/generated/hina/posts/ep11/index.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP11: 先輩も、迷っていた | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="憧れの背中にも、消しては書いた線がある。その温度を知る。">
+    <meta property="og:title" content="EP11: 先輩も、迷っていた">
+    <meta property="og:description" content="憧れの背中にも、消しては書いた線がある。その温度を知る。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep11">
+  <article class="sg-article" data-template="detail" data-content-id="ep11" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP11: 先輩も、迷っていた</h1>
+      <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞》の新人テストエンジニア・ユイ（ユイリア）は、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という神崎ナギの言葉に導かれ、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジの虹、ログ解析、そして魔導書 Fθ と現場写像 G といった道具を手にしてきた。いつかナギのように <span class="katex">W</span> と制約 <span class="katex">E</span> から観点 <span class="katex">S</span> を選び取りたいと願い始めている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>閉店後の《∞》は、ネオンの名残だけがテーブルを染めていた。ユイはホワイトボードの前で固まっている。世界 <span class="katex">W</span>、制約 <span class="katex">E</span>、観点 <span class="katex">S</span>──書いたはずの図は、行き止まりの矢印と二重線で消された丸の墓場だ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「最終イベントの設計、ぜんぜん <span class="katex">G</span> が引けない……」
+            </div>
+<p>カラン、と裏口の鈴が鳴いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「派手に迷子ってるね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギさん……！」
+            </div>
+<p>神崎ナギは、魔界ブレンドコーヒーを二つ持って現れた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「バルハから、“ユイが世界の端でフリーズしてる”って連絡きたよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「監視社会だ……」
+            </div>
+<p>ナギはユイの隣に並び、ボードを一瞥する。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ふむ。ちゃんと <span class="katex">W</span> も <span class="katex">E</span> も <span class="katex">S</span> も書き出してる。いい迷子だ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どこがですか！　そこから先がぐちゃぐちゃで……。ナギさんみたいに、一本スッと <span class="katex">G</span> を引けないんです。私、相変わらず“なんでも屋のダメテストエンジニア”のままな気がして……」
+            </div>
+<p>ナギは何も言わず、くるりと背を向けた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ちょっと待ってて。昔の私を連れてくる」
+            </div>
+<div class="scene-break">＊　＊　＊</div>
+<p>しばらくして戻ってきたナギの腕には、分厚いノートが抱えられていた。角がすり切れ、コーヒーの染みが地図のように広がっている。端には小さく「テストアーキテクチャーの頭脳」と走り書きされていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これ、私がまだ“迷子のなんでも屋”だった頃のノート」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……見ていいですか」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「覚悟があるなら」
+            </div>
+<p>ユイがそっと開くと、中身は線でぐちゃぐちゃに消されたテスト案、観点が二重線で潰されたメモ、途中で放り出された決定表。今のユイのボードと瓜二つだった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ナギさんも、迷ってたんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。迷うよ。世界 <span class="katex">W</span> を丸ごと扱おうとしたら、毎回ね。一本で <span class="katex">G</span> を引けるのは、何度も迷子になったからだと思う」
+            </div>
+<p>ナギはノートの端に描かれた薄い矢印を指さす。そこには「ここで諦めた」「ここから <span class="katex">S</span> を減らした」と小さな字が添えられていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「迷った跡も、仕事の一部。『ここで詰まった』『ここは捨てた』ってログを残すと、次に <span class="katex">G</span> を引くときの支えになるよ」
+            </div>
+<p>ユイは自分のボードに「ここで迷った」「ここは捨てた」と赤ペンで書き込んだ。線で塗りつぶされた丸が、少しだけ愛おしく見えてくる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私も、この迷子ログ、残しておきます」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。そのログを渡せる後輩が来たら、ユイはもう“魅力ある大先輩”になってるよ」
+            </div>
+<p>ネオンの残光がホワイトボードを照らす。迷路のような線と赤いメモが、少しずつ「道」に見えてきた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep11</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/hina/posts/ep12/index.html
+++ b/generated/hina/posts/ep12/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP12: 次の子に渡す、G の地図 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。">
+    <meta property="og:title" content="EP12: 次の子に渡す、G の地図">
+    <meta property="og:description" content="最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="hina" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep12">
+  <article class="sg-article" data-template="detail" data-content-id="ep12" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP12: 次の子に渡す、G の地図</h1>
+      <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》で新人テストエンジニアとして働き始めたユイリア。場当たり運営でオープン初夜を炎上させかけた彼女は、伝説のテストアーキテクト神崎ナギと出会い、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という言葉に導かれる。仕様書の外に広がる世界 <span class="katex">W</span> と制約 <span class="katex">E</span> を意識し、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジ、ログ解析、魔導書 Fθ と写像 <span class="katex">G</span> などの道具を手にしてきた。</p>
+<p>最終イベント設計では再び迷子になるが、ナギのボロボロの昔のノートに自分と同じぐちゃぐちゃの図を見つけ、憧れの先輩もかつては迷っていたと知る。ユイは「自分もあの背中に向かって歩いていい」と胸の奥でそっと決めた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>最終イベントの朝、まだ客のいない《∞》は、壁一面のホワイトボードで白く光っていた。同値クラスで色分けされた客の分類、境界値の付箋、決定表、状態遷移図、ログのグラフ。十一話分の失敗と発見が層になって張りついている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……すごいカオス。でも、今日はここから一本の線を引く日」
+            </div>
+<p>ユイはマーカーを握り、中央に縦線を引いた。その左に大きく「<span class="katex">W</span>」。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「この店の世界 <span class="katex">W</span> は、ここに来る人たちの人生全部」
+            </div>
+<p>右側には「<span class="katex">E</span>」。営業時間、スタッフの体力、厨房のキャパシティ。制約が並ぶ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「今日守りたい観点 <span class="katex">S</span> は、“常連も初見さんも『ここが居場所だ』と思えるか”」
+            </div>
+<p>矢印が伸び、同値クラスが丸で囲まれ、境界値のメモが配置される。ペアワイズで選んだ組合せ、虹で塗ったカバレッジの濃淡、ログから拾った痛みのポイント。全部が一本の地図に重なる。</p>
+<p>ドアが開き、オーナーのバルハと神崎ナギが入ってくる。壁いっぱいの図を見て、ふたりは目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「おお……店の歴史が壁に詰まってる」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイの <span class="katex">G</span> だね。どう引いたの？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「全部はできないから、今日の <span class="katex">S</span> に合わせて濃く塗る色を決めました。失敗ログも残しておきたくて」
+            </div>
+<p>ナギはうなずき、ポケットから小さな空ノートを取り出した。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これ、次に入る新人用に。今日の地図、写しておいて」
+            </div>
+<p>ユイは驚きながらノートを受け取る。白紙のページがまぶしい。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私が、書いていいんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。君が迷って見つけた道は、きっと次の子の助けになる」
+            </div>
+<p>開店のベルが鳴る。ユイはマーカーを置き、胸ポケットに小さなノートをしまった。G の地図は、もう自分だけのものじゃない。次の誰かに渡すためのものだ。</p>
+<p>「いらっしゃいませ！」――新人の声が、まぶしいほど真っ直ぐに響いた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep12</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/assets/base.css
+++ b/generated/immersive/assets/base.css
@@ -91,6 +91,33 @@ body[data-experience] .sg-nav {
   flex-wrap: wrap;
 }
 
+body[data-experience] .sg-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+body[data-experience] .sg-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--sg-border);
+  background: var(--sg-panel);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+body[data-experience] .sg-button:hover,
+body[data-experience] .sg-button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+  outline: none;
+}
+
 body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
@@ -196,6 +223,11 @@ body[data-experience] .magazine-shelf {
 body[data-experience] .magazine-tile {
   display: grid;
   gap: 8px;
+}
+
+body[data-experience] .sg-markdown {
+  display: grid;
+  gap: 10px;
 }
 
 @media (max-width: 640px) {

--- a/generated/immersive/index.html
+++ b/generated/immersive/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>Immersive Generated Experience | Home</title>
+    <title>Hina Generated Experience | Home</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/base.css">
     <link rel="stylesheet" href="./assets/components.css">
     <link rel="stylesheet" href="../shared/switcher.css">
+    <meta name="description" content="Hina バリエーション用のジェネレート体験。">
+    <meta property="og:title" content="Hina Generated Experience">
+    <meta property="og:description" content="Hina バリエーション用のジェネレート体験。">
     <script src="../shared/switcher.js" defer></script>
   </head>
   <body class="sg-surface" data-experience="immersive" data-template="home" data-routes-href="../routes.json">
@@ -22,6 +25,9 @@
       <ul class="sg-nav-links">
         <li><a href="./">ホーム</a></li>
         <li><a href="list/">一覧</a></li>
+        <li><a href="./#about">紹介</a></li>
+        <li><a href="./#episodes">12話</a></li>
+        <li><a href="./#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -33,30 +39,148 @@
       </button>
     </nav>
     <p class="sg-eyebrow">Experience</p>
-    <h1>Immersive Generated Experience ホーム</h1>
-    <p class="sg-lede">全画面で没入感を高めるジェネレート体験。</p>
+    <h1>Hina Generated Experience</h1>
+    <p class="sg-lede">Hina バリエーション用のジェネレート体験。</p>
+    <div class="sg-actions">
+      <a class="sg-button" href="list/">一覧を見る</a>
+    </div>
   </header>
   <main id="content" class="sg-main">
-    <section class="sg-card">
-      <h2>最新コンテンツ</h2>
+    <section class="sg-card" id="about">
+      <h2>紹介</h2>
       <div class="immersive-stack">
-        <article class="sg-card immersive-card">
-          <p class="sg-eyebrow">Featured</p>
+        <article class="sg-card immersive-card" data-about-id="about-世界観">
+          <p class="sg-eyebrow">世界観</p>
+          <h2>サキュバスメイド喫茶《∞》の、きらめく現場</h2>
+          <p class="sg-lede">甘い匂いとネオンの間で、ユイは“なんとなく”から抜け出したいと思い始める。
+            目の前の出来事に名前がつき、線が引けるようになったとき、世界は少しだけ優しくなる。</p>
+          <p class="sg-meta">観察 / 分類 / 境界 / 地図 / ログ</p>
+        </article>
+        <article class="sg-card immersive-card" data-about-id="about-読みどころ">
+          <p class="sg-eyebrow">読みどころ</p>
+          <h2>1話1粒、“宝石みたいな気づき”</h2>
+          <p class="sg-lede">各話は短編のように読めて、でも繋がっている。
+            何かを学ぶというより、 見える範囲が広がる 感覚を楽しむ物語です。</p>
+          <p class="sg-meta">成長 / 師弟 / やさしい刺さり / 夜の余韻</p>
+        </article>
+        <article class="sg-card immersive-card" data-about-id="welcome-post">
+          <p class="sg-eyebrow">イントロ</p>
+          <h2>ようこそ、魔界喫茶《∞》へ</h2>
+          <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
+          <p class="sg-meta">sample / intro</p>
+        </article>
+      </div>
+    </section>
+    <section class="sg-card" id="episodes">
+      <h2>エピソード</h2>
+      <div class="immersive-stack">
+        <article class="sg-card immersive-card" data-episode-id="ep01">
+          <p class="sg-eyebrow">Episode 01</p>
           <h2><a href="posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
           <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
-          <p class="sg-meta">読む →</p>
+          <p class="sg-meta">続きを読む →</p>
         </article>
-        <article class="sg-card immersive-card">
-          <p class="sg-eyebrow">Featured</p>
-          <h2><a href="posts/welcome-post/">ようこそ、魔界喫茶《∞》へ</a></h2>
-          <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
-          <p class="sg-meta">読む →</p>
+        <article class="sg-card immersive-card" data-episode-id="ep02">
+          <p class="sg-eyebrow">Episode 02</p>
+          <h2><a href="posts/ep02/">EP02: 世界 W は、仕様書の外に広がってる</a></h2>
+          <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep03">
+          <p class="sg-eyebrow">Episode 03</p>
+          <h2><a href="posts/ep03/">EP03: 同値クラスという、お守りの石</a></h2>
+          <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep04">
+          <p class="sg-eyebrow">Episode 04</p>
+          <h2><a href="posts/ep04/">EP04: 境界線を、一緒に歩いた夜</a></h2>
+          <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep05">
+          <p class="sg-eyebrow">Episode 05</p>
+          <h2><a href="posts/ep05/">EP05: 分岐の森と、先輩の地図</a></h2>
+          <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep06">
+          <p class="sg-eyebrow">Episode 06</p>
+          <h2><a href="posts/ep06/">EP06: 関係は、状態遷移で語れる</a></h2>
+          <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep07">
+          <p class="sg-eyebrow">Episode 07</p>
+          <h2><a href="posts/ep07/">EP07: 全部は試せない、という優しさ</a></h2>
+          <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep08">
+          <p class="sg-eyebrow">Episode 08</p>
+          <h2><a href="posts/ep08/">EP08: カバレッジの虹を見上げて</a></h2>
+          <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep09">
+          <p class="sg-eyebrow">Episode 09</p>
+          <h2><a href="posts/ep09/">EP09: ログは、システムからのラブレター</a></h2>
+          <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep10">
+          <p class="sg-eyebrow">Episode 10</p>
+          <h2><a href="posts/ep10/">EP10: 魔導書と職人の手、Fθと G</a></h2>
+          <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep11">
+          <p class="sg-eyebrow">Episode 11</p>
+          <h2><a href="posts/ep11/">EP11: 先輩も、迷っていた</a></h2>
+          <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+        <article class="sg-card immersive-card" data-episode-id="ep12">
+          <p class="sg-eyebrow">Episode 12</p>
+          <h2><a href="posts/ep12/">EP12: 次の子に渡す、G の地図</a></h2>
+          <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+          <p class="sg-meta">続きを読む →</p>
+        </article>
+      </div>
+    </section>
+    <section class="sg-card" id="characters">
+      <h2>キャラクター</h2>
+      <div class="immersive-stack">
+        <article class="sg-card immersive-card" data-character-id="character-サキュバスメイド喫茶∞">
+          <p class="sg-eyebrow">舞台</p>
+          <h2>サキュバスメイド喫茶《∞》</h2>
+          <p class="sg-lede">きらめく夜の“現場”。 人が集まり、気分が揺れ、選択が生まれる場所。ユイの学びは、いつもここから始まる。</p>
+          <p class="sg-meta">夜のネオン / 現場の温度 / ∞の余白</p>
+        </article>
+        <article class="sg-card immersive-card" data-character-id="character-バルハ">
+          <p class="sg-eyebrow">オーナー</p>
+          <h2>バルハ</h2>
+          <p class="sg-lede">喫茶《∞》のオーナー。二人の成長を少し離れた場所から見つめる存在。 舞台の空気を整え、物語の火種をそっと置く。</p>
+          <p class="sg-meta">黒幕ポジ（やさしめ） / 場を作る</p>
+        </article>
+        <article class="sg-card immersive-card" data-character-id="character-神崎ナギ">
+          <p class="sg-eyebrow">大先輩</p>
+          <h2>神崎ナギ（かんざき・ナギ）</h2>
+          <p class="sg-lede">魔界テック界隈で伝説的なテストアーキテクト。 落ち着いた笑顔で、核心をすっと差し出す。“こうなりたい”と思わせる背中。</p>
+          <p class="sg-meta">静かな強さ / 言葉が地図 / 穏やかに刺す</p>
+        </article>
+        <article class="sg-card immersive-card" data-character-id="character-結城ユイ">
+          <p class="sg-eyebrow">主人公</p>
+          <h2>結城ユイ（ユイリア）</h2>
+          <p class="sg-lede">サキュバスメイド喫茶《∞》で働く新人テストエンジニア。 知っているのは用語だけ。いつも場当たり的で、でも——だからこそ、伸びしろが眩しい。</p>
+          <p class="sg-meta">新人 / まっすぐ / 学びが体温</p>
         </article>
       </div>
     </section>
   </main>
   <footer class="sg-footer">
-    <p>&copy; Immersive Generated Experience</p>
+    <p>&copy; Hina Generated Experience</p>
   </footer>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/list/index.html
+++ b/generated/immersive/list/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>immersive | List</title>
+    <title>Hina Generated Experience | List</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/base.css">
     <link rel="stylesheet" href="../assets/components.css">
@@ -13,12 +13,15 @@
   <body class="sg-surface" data-experience="immersive" data-template="list" data-routes-href="../../routes.json">
   <header class="sg-header">
     <p class="sg-eyebrow">Listing</p>
-    <h1>immersive コンテンツ一覧</h1>
-    <p class="sg-lede">1 件ずつ大きく見せる没入レイアウト。</p>
+    <h1>Hina Generated Experience コンテンツ一覧</h1>
+    <p class="sg-lede">Hina バリエーション用のジェネレート体験。</p>
     <nav class="sg-nav">
       <ul class="sg-nav-links">
         <li><a href="../">ホーム</a></li>
         <li><a href="./">一覧</a></li>
+        <li><a href="../#about">紹介</a></li>
+        <li><a href="../#episodes">12話</a></li>
+        <li><a href="../#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -31,19 +34,80 @@
   </header>
   <main class="sg-main" data-template="list" data-experience="immersive">
     <section class="immersive-stack">
-      <article class="sg-card immersive-card">
-        <p class="sg-eyebrow">Featured</p>
+      <article class="sg-card immersive-card" data-episode-id="ep01">
+        <p class="sg-eyebrow">Episode 01</p>
         <h2><a href="../posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
         <div class="sg-meta">読む →</div>
       </article>
-      <article class="sg-card immersive-card">
-        <p class="sg-eyebrow">Featured</p>
-        <h2><a href="../posts/welcome-post/">ようこそ、魔界喫茶《∞》へ</a></h2>
-        <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
+      <article class="sg-card immersive-card" data-episode-id="ep02">
+        <p class="sg-eyebrow">Episode 02</p>
+        <h2><a href="../posts/ep02/">EP02: 世界 W は、仕様書の外に広がってる</a></h2>
+        <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep03">
+        <p class="sg-eyebrow">Episode 03</p>
+        <h2><a href="../posts/ep03/">EP03: 同値クラスという、お守りの石</a></h2>
+        <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep04">
+        <p class="sg-eyebrow">Episode 04</p>
+        <h2><a href="../posts/ep04/">EP04: 境界線を、一緒に歩いた夜</a></h2>
+        <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep05">
+        <p class="sg-eyebrow">Episode 05</p>
+        <h2><a href="../posts/ep05/">EP05: 分岐の森と、先輩の地図</a></h2>
+        <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep06">
+        <p class="sg-eyebrow">Episode 06</p>
+        <h2><a href="../posts/ep06/">EP06: 関係は、状態遷移で語れる</a></h2>
+        <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep07">
+        <p class="sg-eyebrow">Episode 07</p>
+        <h2><a href="../posts/ep07/">EP07: 全部は試せない、という優しさ</a></h2>
+        <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep08">
+        <p class="sg-eyebrow">Episode 08</p>
+        <h2><a href="../posts/ep08/">EP08: カバレッジの虹を見上げて</a></h2>
+        <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep09">
+        <p class="sg-eyebrow">Episode 09</p>
+        <h2><a href="../posts/ep09/">EP09: ログは、システムからのラブレター</a></h2>
+        <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep10">
+        <p class="sg-eyebrow">Episode 10</p>
+        <h2><a href="../posts/ep10/">EP10: 魔導書と職人の手、Fθと G</a></h2>
+        <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep11">
+        <p class="sg-eyebrow">Episode 11</p>
+        <h2><a href="../posts/ep11/">EP11: 先輩も、迷っていた</a></h2>
+        <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+        <div class="sg-meta">読む →</div>
+      </article>
+      <article class="sg-card immersive-card" data-episode-id="ep12">
+        <p class="sg-eyebrow">Episode 12</p>
+        <h2><a href="../posts/ep12/">EP12: 次の子に渡す、G の地図</a></h2>
+        <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
         <div class="sg-meta">読む →</div>
       </article>
     </section>
   </main>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep01/index.html
+++ b/generated/immersive/posts/ep01/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>immersive | Detail</title>
+    <title>EP01: 開幕、魔界喫茶《∞（インフィニティ）》 | Hina Generated Experience</title>
     <link rel="stylesheet" href="../../assets/tokens.css">
     <link rel="stylesheet" href="../../assets/base.css">
     <link rel="stylesheet" href="../../assets/components.css">
     <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。">
+    <meta property="og:title" content="EP01: 開幕、魔界喫茶《∞（インフィニティ）》">
+    <meta property="og:description" content="新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。">
     <script src="../../../shared/features/init-features.js" defer></script>
     <script src="../../../shared/switcher.js" defer></script>
   </head>
@@ -21,6 +24,9 @@
         <ul class="sg-nav-links">
         <li><a href="../../">ホーム</a></li>
         <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -256,3 +262,4 @@
   </article>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep02/index.html
+++ b/generated/immersive/posts/ep02/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP02: 世界 W は、仕様書の外に広がってる | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="画面の外へ。現場と人の温度が、物語の色を変えていく。">
+    <meta property="og:title" content="EP02: 世界 W は、仕様書の外に広がってる">
+    <meta property="og:description" content="画面の外へ。現場と人の温度が、物語の色を変えていく。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep02">
+  <article class="sg-article" data-template="detail" data-content-id="ep02" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP02: 世界 W は、仕様書の外に広がってる</h1>
+      <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》オープン初夜、新人サキュバスで“なんでも屋のダメダメテストエンジニア”結城ユイ（源氏名ユイリア）は感覚だけでイベントを回し、店を炎上寸前にしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームのログとメモを一瞥しただけで「客のパターン」を整理し、あっという間に状況を見える化。ユイは同じ世界を見ているはずなのに全く違う景色を切り取る先輩の背中に、強く憧れ始める。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>翌日の昼、《∞》はまだ開店前だった。昨夜の喧騒が嘘みたいに静かで、店内にはバルハがグラスを磨く音だけが響いている。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイリア、ちょっと外、付き合ってくれる？」
+            </div>
+<p>カウンター越しに顔を出した神崎ナギが、軽く手を振った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「テスト、ですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストの前に、“世界を見る練習”」
+            </div>
+<p>二人は店の前に並んで立った。昼の魔界歓楽街は、夜とは別人のようだ。ネオンは落ち着き、魔法水晶の看板が淡く光り、隣のインキュバス喫茶からコーヒーの香りが流れてくる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「質問。誰がこの店に入りそう？　誰は絶対入らなさそう？」
+            </div>
+<p>ナギが通りを指さす。黒ローブの魔法使い。ショッピング袋を下げたギャルサキュバスたち。ため息まじりにスマホをいじる人間界のサラリーマン。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと、あのギャルサキュバスたちは絶対来ます！　《∞》のパフェ、昨日SNSでバズってましたし」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ふむ。それで、あのスーツの彼は？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“社畜”っぽい人は来ないと思います。時間なさそうだし、メイド喫茶に寄る余裕なんて――」
+            </div>
+<p>ユイが言い終える前に、ギャルサキュバスたちは《∞》の前を素通りして、向かいのカラオケ魔城に吸い込まれていった。代わりに、クマのできたサラリーマンが店の前で立ち止まる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……え？」
+            </div>
+<p>ユイが固まっていると、男はおずおずと扉を覗き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「すみません、昨日の夜すごく楽しくて……昼もやってるかと思って」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「あ、今は準備中で……」
+            </div>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「ですよね。じゃあメニューの写真だけ撮らせてください。仕事の励みにしたくて」
+            </div>
+<p>入口のメニュー立てをスマホで撮りながら、彼はほっとしたように笑った。その背中を見送りながら、ユイは自分の予想が気持ちいいくらい外れたことを実感する。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「予想、外れちゃったね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ですよね。仕様書では“ターゲットは疲れた社畜”って書いてあったから、てっきり、ああいう人はむしろ来ないんだと思ってて」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「仕様書、昨日渡したやつ？」
+            </div>
+<p>ナギはポケットから折りたたまれた紙を取り出す。ターゲット像、営業時間、コンセプト。昨夜、ふたりで書いたメモだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい。わたし、こういう紙に書いてあることが“世界の全部”だと思ってました」
+            </div>
+<p>ユイが俯くと、ナギは紙の裏に大きな丸を描き、その中に「W」と書き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Wっていうのはね、“この店に関わる世界全部”のこと」
+            </div>
+<p>丸の外側へ矢印を伸ばしながら、ナギは通りを指す。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「時間帯、天気、この通りの空気、さっきの彼の残業状況、SNSの評判、その人の今日の気分……ここ“現場”を歩く人間ぜんぶ。仕様書に書いてないものほど、テストでは効いてくるんだよ」
+            </div>
+<p>ユイはごくりと喉を鳴らした。ナギは丸の中に小さな四角を描き、「仕様書」と書き込む。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「こうやって見ると、仕様書って、W の中のこのくらいの箱にしかすぎない」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……じゃあ、わたし、W のほんの一部しか見てなかったんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「“しか”って言うと、ちょっともったいないかな」
+            </div>
+<p>ナギは首を横に振る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「昨日の君は“仕様書の中だけの世界”を必死に見ていた。でも今はこうして、仕様書の外を見ようとしている」
+            </div>
+<p>通りに向けられたユイの視線を確かめてから、静かに続けた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「見ようとした瞬間から、もうテスターなんだよ」
+            </div>
+<p>胸の奥が、ぽっと温かくなる。ユイはポケットからメモ帳を取り出し、ページの端に「世界W観察ログ」と書き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「じゃあ……さっきのサラリーマンさんは、“昼でもメニューを眺めたいくらい昨日の体験が刺さった客”ってことで……世界 W の中の、ひとつの点？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。仕様書には“疲れた社畜”としか書いてなかった。でも実際の W には、“昨日楽しんでくれた人が、今日も何かを求めてくる”って状態があった」
+            </div>
+<p>ナギは丸の中に小さな点を打つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「その点に気づいたのは、ユイリアだよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……わたし、ちゃんと見れてましたか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。“外した”って落ち込んでたけど、外れたってことは、“こうだろう”って仮説を立ててたってこと。何も考えずに眺めてたら、そもそも外れないからね」
+            </div>
+<p>ユイはきょとんとし、それからふにゃりと笑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「なんか……失敗ログにも、意味がある気がしてきました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「あるよ。世界 W を知るための、立派な観測データ」
+            </div>
+<p>店に戻ると、バルハがカウンターから顔を上げた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「外の空気はどうだった？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……世界、思ったよりずっと広かったです」
+            </div>
+<p>ユイが答えると、バルハはにやりと笑う。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ふたりとも、ちゃんと外を見て帰ってきた顔してるよ」
+            </div>
+<p>夕方、街にネオンが灯り始める。開店準備を終えたユイは扉の前に立ち、通りを見上げた。仕様書の外側に広がる、揺れるような世界 W。その中からどんな瞬間をすくい上げられるだろう――そんなことを思いながら、彼女は「本日開店」のプレートをそっと裏返した。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep02</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep03/index.html
+++ b/generated/immersive/posts/ep03/index.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP03: 同値クラスという、お守りの石 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。">
+    <meta property="og:title" content="EP03: 同値クラスという、お守りの石">
+    <meta property="og:description" content="ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep03">
+  <article class="sg-article" data-template="detail" data-content-id="ep03" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP03: 同値クラスという、お守りの石</h1>
+      <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街にオープンしたサキュバスメイド喫茶《∞（インフィニティ）》。新人メイド・ユイリアこと結城ユイは、“なんでも屋のダメダメテストエンジニア”として場当たりでイベントを回し、オープン初夜にクレーム祭りを引き起こしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、山のようなクレームログを一瞥しただけで客を三つのパターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
+<p>翌日、店の前で通行人を観察したユイは、誰が店に入るかを外し続け、世界 <span class="katex">W</span> が仕様書の外側――時間や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」と笑うナギに励まされ、世界を少しずつ切り取る力を育て始める。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「社畜客」「観光客」「カップル」「ぼっち」――ホワイトボード一面の付箋を前に、ユイは頭を抱えていた。</p>
+<p>イベント仕様：残業明け社畜救済ナイト。対象客層が多すぎると感じながら、バルハからのミッションである「どんな客にも癒やされたと言わせる設計」を考えている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「社畜にもブラックとホワイトがいて、観光客も陽キャと陰キャがいて……これ全部別々にテストしてたら、一生終わらないんだけど…」
+            </div>
+<p>カウンターの上では、オーナー・バルハが黄金の瞳でその様子を眺めている。助け舟は期待できそうにない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「行き詰まった顔してるね」
+            </div>
+<p>背後から聞き慣れた声。振り向けば、神崎ナギが立っていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「せ、先輩！　このカオス見ないでください…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ううん、いいカオスだよ」
+            </div>
+<p>ナギはくすりと笑い、ポケットから小さなガラス瓶を取り出した。中には色も形も違う小さな鉱石がぎゅっと詰まっている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「綺麗ですけど？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部、石英（クォーツ）だよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え、全部同じなんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。見た目は違っても、“この観点から見ると同じ”ってことはよくある」
+            </div>
+<p>ナギは瓶を軽く振ってから、ホワイトボードの前に立つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今ユイが困ってるのは、“全部違って見えるお客さん”でしょ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい…。バリエーション多すぎて、テストパターンが宇宙の端まで増えそうで…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、“お守りの石”を信じてみようか」
+            </div>
+<p>ナギはマーカーを手に取った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今日のイベントで一番守りたい観点 <span class="katex">S</span> は？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと…『ここに来てよかった』…ですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「その中でも、残業明け社畜救済なんだから？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「――“限界の社畜さんが、少しでも呼吸を取り戻せるか”」
+            </div>
+<p>ナギは真ん中に大きな丸を描き、「<span class="katex">S</span>：限界社畜の呼吸ポイント」と書き込む。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、この <span class="katex">S</span> から見て“同じ扱いでよさそうな人たち”を探そう」
+            </div>
+<p>ナギは付箋を二枚はがす。《社畜：三日徹夜、今にも倒れそう》《社畜：残業続き、今日は上司に怒鳴られてきた》。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「この二人にとって一番大事なのは？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「体力ゼロと、心がズタボロ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「どっちも“今すぐ難しい話を聞かされると死ぬ”って意味では同じだよね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「あ、たしかに」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあこの二人は、<span class="katex">S</span> の観点では同じ“限界社畜クラス”」
+            </div>
+<p>ナギは二枚を丸で囲み、「<span class="katex">A_1</span>：限界社畜」とラベルをつけた。</p>
+<p>次にナギがつまんだのは、《社畜：普段は激務だが今日は奇跡の有給》《観光客：魔界出張のついでに寄った》の二枚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「一見違うけど、“今日の気分”は似てない？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どっちも、ちょっと浮かれてる感じ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。“今日は特別な一日”クラスだね」
+            </div>
+<p>新しい丸に「<span class="katex">A_2</span>：特別デー満喫」と書き込む。さっきまでバラバラだった客たちが、観点 <span class="katex">S</span> を通してふわっと集まり始める。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え、じゃあ…このカップルと、このぼっちさんも…」
+            </div>
+<p>ユイは自分で付箋を動かし、ラブラブ観光カップルと、スマホを握りしめてそわそわしている青年を同じ丸に入れた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どっちも“誰かに見せたい特別な夜”クラス…かも」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん、その分け方はユイの <span class="katex">W</span> の見方から出てきたものだよ」
+            </div>
+<p>ナギはホワイトボードの端に小さく書き添える。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「世界 <span class="katex">W</span> のお客さんを、観点 <span class="katex">S</span> から見て“同じ息の仕方かどうか”で分けたグループ。それがテストでいう同値クラス <span class="katex">A(S)</span>」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「同値クラス…用語としてしか知らなかったです」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「名前だけ知ってても、こうやって <span class="katex">W</span> の上に描いてみると、ちょっと身近になるでしょ？」
+            </div>
+<p>ユイはうなずき、ノートを開いた。丸と矢印が増えるたび、混沌だった世界が少しだけ整っていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、それぞれのクラスから代表を一人決めて、その人の一晩を徹底的にシミュレーションしよう」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「<span class="katex">A_1</span> は三日徹夜さん。寝落ちさせない導線と、脳に優しいメニューを…」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「<span class="katex">A_2</span> は有給社畜さん。“頑張ってる自分”を労えるサプライズを入れたいです」
+            </div>
+<p>客の名前の代わりに、「<span class="katex">A_1</span>」「<span class="katex">A_2</span>」の記号がノートの上を跳ね回る。さっきまで怖かったバリエーションが、「塊」として手のひらに乗る感覚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ね、全部バラバラに見えてた世界が、“同じ扱いでよくなる塊”に見えてきたでしょ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい…。世界がちょっと優しくなった気がします」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「それが、同値クラスのお守り効果」
+            </div>
+<p>ナギは瓶から小さな透明な石を一つ取り出した。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今日からユイのお守り。困ったら、この石を見て考えてみて。“この子と同じように扱える仲間、いないかな？”って」
+            </div>
+<p>ユイはそっと石を握りしめる。冷たい感触が、少しずつ手の中で温度を帯びていく。</p>
+<p>――いつか自分も、ナギみたいに。バラバラな世界を、やさしい丸で包んであげられる先輩になれたら。</p>
+<p>石英のかすかなきらめきが、ホワイトボードに映る。そこにはもう、“なんでも屋のダメダメテストエンジニア”ではなく、同値クラスという小さな石を手に入れた、一人のテスト屋の地図が描かれ始めていた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep03</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep04/index.html
+++ b/generated/immersive/posts/ep04/index.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP04: 境界線を、一緒に歩いた夜 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。">
+    <meta property="og:title" content="EP04: 境界線を、一緒に歩いた夜">
+    <meta property="og:description" content="近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep04">
+  <article class="sg-article" data-template="detail" data-content-id="ep04" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP04: 境界線を、一緒に歩いた夜</h1>
+      <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で働く新人メイド兼テストエンジニア・結城ユイ（ユイリア）は、場当たり運営でオープン初夜を炎上させてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、クレームログを一瞬で三つの客パターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
+<p>翌日、店の前で通行人を観察したユイは、誰が店に入るかを外し続け、世界 <span class="katex">W</span> が仕様書の外側──時間や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」と笑うナギに励まされ、さらにイベント準備では、小さな鉱石を例に「観点しだいで同じ扱いにできる塊＝同値クラス」を学び、世界を少し整理して見られるようになってきていた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「社畜救済ナイト、本日かぎり〜！」サキュバスメイド喫茶《∞》のネオンが青く瞬く。スーツ客限定ドリンク無料、残業時間を申告すると「おつかれさまマッサージ」付き──そのイベントを企画したのは、昨日「同値クラス」を教わったばかりのユイだ。</p>
+<p>胸元で、ナギにもらった鉱石の小瓶が揺れる。カラン、と扉の鈴。最初の客はネクタイを緩めた中年の男。目の下のクマが深い。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「いらっしゃいませ。今月の残業時間、よろしければ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">社畜客</span>
+                「百二十時間だ」
+            </div>
+<p>想定テーブルの最大値を軽く超えた数字に、ユイの笑顔が固まる。動揺をごまかそうとして、軽口が滑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「そんな会社、やめちゃえばいいのに！」
+            </div>
+<p>冗談のつもりでウインクした瞬間、男の肩がびくりと震える。</p>
+<div class="dialogue">
+<span class="character-name">社畜客</span>
+                「…やめられたら、とっくにやめてるよ」
+            </div>
+<p>ぽたり、とテーブルに落ちる雫。涙だと気づいたときには遅かった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>休憩に入ると、フィードバックカードが一枚置かれていた。</p>
+<div class="feedback-card">「励ましがきつかったです。そっとしておいてほしかった」</div>
+<p>短い文字が、胸を刺す。そこへまた鈴の音。ユイはカードを握りしめたままホールへ戻った。</p>
+<p>今度は若いサラリーマン風の男。スーツも表情もまだ余裕がある。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「いらっしゃいませ。ドリンクは？」
+            </div>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「おすすめで。…大変そうだね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「まあ、ぼちぼちです」
+            </div>
+<p>仕事の話題を避け、マニュアル通りの笑顔で受け流す。沈黙が増えるたびに、ユイは一歩ずつ下がっていくみたいな気持ちになる。帰り際、その客もカードを書いていった。</p>
+<div class="feedback-card">「可愛いけど、今日はなんか遠くてさみしかった」</div>
+<p>二枚のカード。踏み込みすぎた自分と、引きすぎた自分。どちらも正解に見えなくて、ユイはスタッフルームの椅子に崩れ落ちた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私、どこまで行っていいか、全然分かんない」
+            </div>
+<p>ぽつりと言ったとき、背後から穏やかな声が落ちてくる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、境界線を見に行こっか」
+            </div>
+<p>振り返ると、ナギが白いコートの裾を揺らして立っていた。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>店を出て少し歩くと、歓楽街の端に細い川がある。ネオンを映した黒い水面と石畳。その境目には、濡れて黒い石と乾いて白い石のくっきりした帯ができていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ここ、分かりやすいでしょ。『濡れて滑りやすい世界』と『乾いて歩きやすい世界』の境界」
+            </div>
+<p>ナギは境目の少し色の違う石をつま先でつつく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ここまではセーフ、ここから先はアウト。その“ちょうど変わるところ”を何度も行き来して確かめるのが、境界値分析」
+            </div>
+<p>ユイはおそるおそる境界の上に片足を置く。靴底がかすかにぐにゃっと滑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「…こわ」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でも、テスト屋が一番知りたいのって、この感触なんだよ」
+            </div>
+<p>ナギは境目の石を拾い、ユイの手に乗せた。ひんやり冷たい。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「さっきの二人も、境界線のそばにいたんだと思う。『会社やめちゃえば』って一言で、“うれしい共感”から“一気につらい現実”側に落ちちゃうラインとか」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私、完全に踏み抜いたやつだ」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。でも、その場所が分かったのは大きい。テストで言えば、『ここが 59→60 分で結果が変わるポイントでした』ってログが取れた状態」
+            </div>
+<p>ナギは石に小さく「B」と書く。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Boundary の B。今日のカードは、『このクラスの人はここまで来ると泣いちゃう』『ここまで下がるとさみしい』っていう境界値データ。ダメな自分の証拠じゃなくて、世界 <span class="katex">W</span> からのメモだよ」
+            </div>
+<p>ユイは、ラブレターにしては刺さり方がエグいなと思いながらも、少し笑った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「境界って、人の心が変わるラインでもある。だから、一歩目でつまずくのは普通。大事なのは『ここが危ない』って印をつけて、次は一歩手前から試すこと」
+            </div>
+<p>夜風が川面をわたる。ユイは石と小瓶を握りしめた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「…じゃあ、もう一回だけ、やってみてもいい？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「もちろん。境界値分析って、“もう一度踏み出す勇気”のためのおまじないだから」
+            </div>
+<p>《∞》のネオンが遠くで瞬く。ユイはその光を見つめ、小さくうなずいた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「明日、社畜さん向けのトークを、『天気ゾーン』『仕事ぼやきゾーン』『人生ゾーン』ってライン引いて考えてみる。どこで世界が変わるか、自分でもちゃんと見に行く」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いいね。それ、次の『地図作り』にもつながるよ」
+            </div>
+<p>境界線を一緒に歩いた夜。ユイの中で「失敗」というラベルが、そっと「発見」に書き換わっていった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep04</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep05/index.html
+++ b/generated/immersive/posts/ep05/index.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP05: 分岐の森と、先輩の地図 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="増え続ける条件の森。迷いを“見える形”にしていく一歩。">
+    <meta property="og:title" content="EP05: 分岐の森と、先輩の地図">
+    <meta property="og:description" content="増え続ける条件の森。迷いを“見える形”にしていく一歩。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep05">
+  <article class="sg-article" data-template="detail" data-content-id="ep05" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP05: 分岐の森と、先輩の地図</h1>
+      <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、テストエンジニア見習いとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させてしまう。しかし現れた伝説級テストアーキテクト・神崎ナギが、クレームログを三つの客パターンに整理して見せ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
+<p>翌日、店先で通行人を観察したユイは「誰が店に入るか」を外し続け、世界 <span class="katex">W</span> は仕様書だけでなく、時間帯や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」とナギに言われ、世界をちゃんと見る一歩を踏み出した。</p>
+<p>イベント準備では、属性が増えすぎて混乱するユイに、ナギが小さな鉱石を見せながら「観点しだいで同じ扱いにできる塊＝同値クラス」を説明。見た目は違っても、テストしたい観点 <span class="katex">S</span> から見れば同じグループにできる客たちがいると知り、ユイは世界を少し整理して見られるようになっていく。</p>
+<p>社畜救済イベント本番では、ある客には踏み込みすぎて泣かせ、別の客には距離を取りすぎて「冷たい」と言われてしまう。落ち込むユイに、ナギは夜の河川敷で「どこまで踏み込んだらうれしくて、どこから先は苦しくなるか。人にもテストにも境界がある」と境界値分析を重ねて語る。ユイは、失敗が「境界を探すための一歩」だったと受け止め、もう一度やってみようと顔を上げた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>その夜の《∞》は、レジ前だけ小さな地獄だった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと……平日社畜割でドリンク半額で、雨の日カウンター席 10％オフで、ペア来店＋SNS 投稿でデザートサービスで……」
+            </div>
+<p>ユイはレジ画面と手書きメモを交互ににらみ、指を折っては戻す。バルハオーナーが導入した新ロジックは、社畜証明や天気、席種、SNS 投稿、滞在時間など条件が重なるほど複雑だった。頭の中で IF と AND と OR が枝分かれし、思考は白煙を上げ始める。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「お、お待たせしてしまってすみませんっ！」
+            </div>
+<p>目の前の社畜スーツ客に、とりあえず一番お得そうな割引を全部乗せしてしまった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業終了後。客席が暗くなり、カウンターだけが照明に浮かぶ。ユイは割引条件を書き散らしたノートを前にうなっていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ここで社畜フラグが立って……ここで雨フラグで分岐して、席種でまた分岐して、SNS で……木が増えすぎて根っこが分かんない……」
+            </div>
+<p>ノートには IF 文の断片と矢印が蜘蛛の巣のように広がり、自分でも読めない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「分岐の森で遭難してる顔だね」
+            </div>
+<p>エプロンを外した神崎ナギが立っていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギ先輩……。頭の中で全部追おうとしたら、ぜんぶ混ざって……今日、絶対どこかでミスりました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「分岐が増えるほどね、頭の中だけで持ちきれないものは外に出してあげたほうがいい」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「外に？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。“地図”にしちゃうの」
+            </div>
+<p>ナギが小さなホワイトボードにシンプルな表の枠を引く。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「割引に効いてきそうな条件だけ並べよう。これは決定表。IF 文を文章で追う代わりに、マス目で分岐を見るやり方」
+            </div>
+<p>左端に「社畜証明」「雨の日」「カウンター席」「ペア来店」「SNS 投稿」「〜19:00」「滞在 60 分」、上には「パターン1」「パターン2」……と書き込まれていく。ナギは「パターン1」の列に◯と×を書き込み始めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「たとえば、よく来る黒スーツの社畜さん。証明あり、雨の日に来ることが多くて、カウンター席好きで、仕事仲間と二人で来るけど SNS 投稿はしない。時間は 18:30 ごろ、滞在は 60 分前後」
+            </div>
+<p>ユイの頭に、毎回「おつかれ」と笑う常連の顔が浮かぶ。</p>
+<div class="decision-table">
+<table>
+<tr>
+<th>条件</th>
+<th>パターン1</th>
+<th>パターン2</th>
+</tr>
+<tr><td>社畜証明</td><td>◯</td><td>◯</td></tr>
+<tr><td>雨の日</td><td>◯</td><td>×</td></tr>
+<tr><td>カウンター席</td><td>◯</td><td>×</td></tr>
+<tr><td>ペア来店</td><td>◯</td><td>×</td></tr>
+<tr><td>SNS 投稿</td><td>×</td><td>◯</td></tr>
+<tr><td>〜19:00</td><td>◯</td><td>◯</td></tr>
+<tr><td>滞在 60 分</td><td>◯</td><td>×</td></tr>
+<tr><td>結果</td><td>ドリンク半額＋会計10％オフ＋デザート＋ポイント二倍</td><td>ドリンク半額＋デザート</td></tr>
+</table>
+</div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあパターン2 は？　一人でふらっと来た社畜さん。証明はあるけど、雨じゃなくて、テーブル席で、SNS 投稿はしてくれる」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと……社畜証明＝◯、雨の日＝×、カウンター席＝×、ペア来店＝×、SNS 投稿＝◯、〜19:00＝◯、滞在 60 分＝×……結果は、ドリンク半額とデザートだけ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。雨じゃないから 10％オフは付かないし、滞在も 60 分から外れてる。こうやって一行ずつ見ていけば、迷わない」
+            </div>
+<p>自分のペンで◯と×を書き込みながら、ユイは思う。 同じ森の中にいるはずなのに、地図があるだけで足元がくっきりする。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……さっきまでのぐちゃぐちゃが、ちゃんと“道”に見えてきました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でしょ。人の脳はそんなに分岐を同時には扱えない。だから、地図に肩代わりさせればいい」
+            </div>
+<p>ナギはボードの端に小さな山の絵を描いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「鉱物採集するときも、地形図なしで山に突っ込むと遭難する。“危ない分岐”は最初から赤で印を付けておく」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“売上が吹き飛ぶやばい組合せ”も、赤で囲んでおける……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そうそう。『全部覚えておく』って、実は一番危ない考え方なんだよ」
+            </div>
+<p>ユイは笑いながら、パターン3、4 と常連たちを思い浮かべてマス目を埋めていく。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「これ、明日からレジ横に貼りませんか？　みんなで同じ地図を見られるように」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いいね。分岐の森は、一人で歩かなくていい」
+            </div>
+<p>ナギがふっと目を細める。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「それとね。今日、分岐に呑まれて苦しくなった感覚も、ちゃんと覚えておいて」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え？　忘れたいんですけど……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いつか、もっと迷子になってる新人が現れたときに、『ここに地図があるよ』って渡すために」
+            </div>
+<p>その言葉に、胸の奥が少し熱くなる。手作りの決定表は、まだ粗い線だらけの地図だ。けれどユイには、その端っこから、遠くの“先輩の背中”へ伸びる細い道が続いているように見えた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep05</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep06/index.html
+++ b/generated/immersive/posts/ep06/index.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP06: 関係は、状態遷移で語れる | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="時間で変わるものには、ちゃんと“状態”と“遷移”がある。">
+    <meta property="og:title" content="EP06: 関係は、状態遷移で語れる">
+    <meta property="og:description" content="時間で変わるものには、ちゃんと“状態”と“遷移”がある。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep06">
+  <article class="sg-article" data-template="detail" data-content-id="ep06" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP06: 関係は、状態遷移で語れる</h1>
+      <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で見習いテストエンジニアとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させかける。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームを三つの客パターンに整理してみせ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
+<p>翌日、店先で通行人を観察したユイは、誰が店に入るかをことごとく外し、世界 <span class="katex">W</span> が仕様書の外側──時間帯や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」とナギに認められ、世界をちゃんと見る一歩を踏み出す。</p>
+<p>イベント準備では、増え続ける客の属性に溺れかけるが、ナギから同値クラスの考え方を教わり、「観点しだいで同じ扱いにできる塊」が見えるようになる。社畜救済イベント本番では、踏み込みすぎたり距離を取りすぎたりして失敗するものの、「人にもテストにも境界がある」と境界値分析を重ねて聞かされ、失敗を境界探しの一歩として受け止め直す。</p>
+<p>第5話では、割引条件や時間帯などの分岐が爆発し、頭の中の IF 文で迷子になったユイに、ナギが決定表という「分岐の地図」を描いてみせた。ユイは複雑さを外に出して整理する感覚を掴みかけている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>夕方の《∞》に、見慣れた背広が入ってくる。社畜救済イベント以来の常連客カズマだ。ユイリアはいつものノリでしっぽを振った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「おかえりなさいませ〜社畜さま♡　今日も残業コンボ決めてきました？」
+            </div>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……ああ」
+            </div>
+<p>返事は短く、声は平坦。いつもなら「やめろ」と笑うのに、今日は視線がテーブルから上がってこない。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ご褒美ドリンク、今日は強めにしときます？　魂までとろけるやつ！」
+            </div>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……悪い。今日は、あんまりいじらないでくれると助かる」
+            </div>
+<p>ユイはあわてて頭を下げ、マニュアルどおりの笑顔で注文だけを取る。会話はそれ以上広がらず、彼は一杯飲むと、いつもより早く帰ってしまった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業後、裏口の階段。ユイは膝を抱え、横で缶コーヒーを開けるナギをちらりと見る。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……やっぱり、やらかしましたよね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「カズマくんのこと？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい。前は“社畜さま”っていじると笑ってくれたのに、今日は明らかに刺さってて……。決定表まで作ったのに、“関係の気分”みたいなのは表にできなくて」
+            </div>
+<p>ナギは少し考え、ユイのノートを開いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「決定表は、その瞬間の条件と結果を見るには便利なんだ。でも、人や関係みたいに、時間でじわじわ変わるものは、別の見方がいい」
+            </div>
+<p>ナギが丸をひとつ描き、矢印を伸ばす。</p>
+<p class="diagram">『初来店』 → 『リピーター』 → 『常連』 → 『VIP』<br/>　　　　　　　　　　　　　↘<br/>　　　　　　　　　　　　　『離脱』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これが関係の“状態遷移図”。丸が“今どんな状態か”。矢印が“そこからどこに行きうるか”。ログイン前→ログイン中→ログアウト、みたいな変化も、同じように描けるよ」
+            </div>
+<p>さらに小さな丸が増える。</p>
+<p class="diagram">『限界社畜』 → 『ちょっと回復した常連』 → 『心が折れかけ常連』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「カズマくん、今日はたぶんここだね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“心が折れかけ常連”……」
+            </div>
+<p>言葉になった途端、さっきの沈んだ目が、ただ怖いものじゃなく「そういう状態」として見え直る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「同じ“常連”でも、状態が違えば、かけていい言葉も変わる。今日ユイが投げたのは、“ちょっと回復した常連”向けのいじり方だった」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「うわ……決定表、雑にまとめすぎたかもです……」
+            </div>
+<p>ユイは自分の表のマスを思い出し、うなだれる。ナギは『心が折れかけ常連』から別の丸へ矢印を足した。</p>
+<p class="diagram">『心が折れかけ常連』 → 『静かに休めた常連』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「次に会ったとき、“今日は静かに過ごすコースもありますよ”ってそっと出してみる。もし少しでも休めたら、状態はこっちに遷移する。そこからまた、ゆっくり別の矢印を考えればいい」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……一回ミスったら“離脱”に直行ってわけじゃないんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「人はバージョン固定じゃないからね。何度でもアップデートできる。『今どの状態にいて、どこに行きうるか』が見えると、テストしたい場面も、声のかけ方も見えてくるよ」
+            </div>
+<div class="scene-break">＊　＊　＊</div>
+<p>翌晩。ドアベルが鳴り、またカズマが入ってきた。昨日と同じように疲れた顔。それでも足がここを選んでくれたことが、少しうれしい。エプロンのポケットには、自分で描いた小さな状態遷移メモが入っている。</p>
+<p>（今は“心が折れかけ常連”。ここから、“静かに休めた常連”へ、矢印を伸ばす）</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「おかえりなさいませ、カズマさん。今日は──いじられたい日ですか？　それとも、“そっとしておいてほしい日”ですか？」
+            </div>
+<p>カズマがきょとんとし、やがてふっと笑う。</p>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……後者で、お願いします」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「かしこまりました。“静かに休めた常連”コースですね」
+            </div>
+<p>小声でそう確認しながら、ユイは余計な台詞を挟まず、そっとカップを置く。人の心は仕様書みたいにきれいには並ばない。それでも、丸と矢印で輪郭を描いてみると、モヤモヤが少しだけ形になる。</p>
+<p>立ちのぼる湯気の向こうで、ユイリアの小さな決意が、静かに新しい状態へと遷移していった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep06</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep07/index.html
+++ b/generated/immersive/posts/ep07/index.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP07: 全部は試せない、という優しさ | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="全部を抱えない。“守るために選ぶ”という、やさしい決断。">
+    <meta property="og:title" content="EP07: 全部は試せない、という優しさ">
+    <meta property="og:description" content="全部を抱えない。“守るために選ぶ”という、やさしい決断。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep07">
+  <article class="sg-article" data-template="detail" data-content-id="ep07" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP07: 全部は試せない、という優しさ</h1>
+      <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働き始めた結城ユイ──ユイリアは、炎上しかけたオープン初夜を伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」と教わる。その後、世界 <span class="katex">W</span> が仕様書の外側まで広がること、同値クラスでばらばらの客をまとめられること、境界値分析で踏み込み方を調整できること、決定表で分岐を地図にできること、状態遷移図で関係の変化を見通せることを少しずつ身に付け、図で世界を扱う感覚を育てている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「――じゃ、今度の《魔界横断オールナイトフェス》のテスト計画、ユイリアちゃんに任せたわよん♪」</p>
+<p>オーナーのバルハが、ぎっしり書き込みだらけの企画書を置いた。BGM３種、コスチューム３種、限定メニュー３種、席配置３パターン、客層４パターン。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……多くないですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「魔界の夜は盛りだくさんが正義よ☆　じゃ、よろしく～」
+            </div>
+<p>カウンターの端で、ユイはノートを開く。BGM × コスチューム × メニュー × 席配置 × 客層……。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「全部試そうとすると、3×3×3×3×4で……」
+            </div>
+<p>数字を書きかけたペン先が止まる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「私、こんなにテストケース作る時間、ない……」
+            </div>
+<p>前に教わった決定表を真似してみるが、マス目はすぐ真っ黒になり、頭の中の IF 文も一緒に爆発した。気づけば、ノートに額をつけていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイ、寝落ち？」
+            </div>
+<p>ふわりと影が差し、聞き慣れた声がした。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「な、ナギ先輩……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストケースに轢かれた顔してるね」
+            </div>
+<p>ナギはノートを覗き込み、びっしりの×印を見る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部の組合せを、全部試そうとしてる？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「だって……どれか取りこぼしたところでバグったら、私のせいでイベントが壊れるかもって思ったら……全部やらなきゃって」
+            </div>
+<p>自分でも情けなくて、声が小さくなる。ナギは少しだけ考える顔をしてから、ペンを取った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイ、山で鉱物採集したことある？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ないです」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「山って、全部の石を拾うんじゃなくて、“ここらへんに石英が多い層がある”とか“ここの斜面は崩れやすい”ってポイントを押さえるの。テストも同じ。全部は試せないからこそ、『代表』に絞る」
+            </div>
+<p>ナギは紙に小さな表を描く。BGM・コスチューム・メニュー・席配置・客層。それぞれの組み合わせを均等に拾う直交表ができあがっていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これはペアワイズとか直交表って呼ぶやり方。二つずつの組合せが漏れなく入るように、最小限のケースを選ぶんだ」
+            </div>
+<p>並んだ数字が、さっきまでの 3×3×3×3×4 の暴力から一気に少なくなる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ほんとだ。全部じゃないのに、ちゃんと“組み合わせを見る”って感じが残ってる」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部を試せないって、諦めじゃなくて優しさなんだよ。限られた時間で、壊れやすいところをちゃんと見るための優先順位付け」
+            </div>
+<p>ナギは最後に、空欄にいくつかのリスクメモを書き込む。「深夜帯×ハイヒール→滑りリスク」「辛メニュー×未成年→要注意」。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「直交表は“平均的な組合せ”を見るのが得意。でも、人が滑りやすいところ、燃えやすいところは意識的に足しておくといい」
+            </div>
+<p>ユイは深呼吸し、重かった肩が少し軽くなるのを感じた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……全部はできない、って決めるのって怖かったけど、ちゃんと理由があれば、むしろ守りになるんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。“優しく選ぶ”ってこと。ユイが選んだケースで、当日のお客さんが安全に楽しめるようにしよう」
+            </div>
+<p>フェス当日、ユイは直交表で選んだ組み合わせを丁寧に試し、リスクメモのケースを重点的に確認した。終電を逃した社畜がハイヒールのサキュバスに絡みそうになる場面も、事前に想定していた導線チェックのおかげで大きな事故にはならなかった。</p>
+<p>閉店後、バルハが冷蔵庫のドアに直交表を貼りながら笑う。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「全部は試せない、けど、この表があればみんなで迷子にならないね」
+            </div>
+<p>ユイも笑う。全部を抱え込まなくてもいい。優しく選んだ少ないケースが、確かに世界 <span class="katex">W</span> の安全を守っている手応えがあった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep07</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep08/index.html
+++ b/generated/immersive/posts/ep08/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP08: カバレッジの虹を見上げて | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="足りないより、届いたところを見ていい——色を塗り分ける夜。">
+    <meta property="og:title" content="EP08: カバレッジの虹を見上げて">
+    <meta property="og:description" content="足りないより、届いたところを見ていい——色を塗り分ける夜。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep08">
+  <article class="sg-article" data-template="detail" data-content-id="ep08" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP08: カバレッジの虹を見上げて</h1>
+      <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働く結城ユイ──源氏名ユイリア。場当たり運営で炎上しかけたオープン初夜、伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」だと知る。</p>
+<p>店の前を行き交う人々を観察し、仕様書の外側まで含めた世界 <span class="katex">W</span> を意識するようになったユイは、ばらばらに見える客たちを同値クラスとしてまとめ、境界値分析で踏み込み方を整え、決定表で分岐の森を地図にし、状態遷移図で関係の変化を見通す力を磨いてきた。大イベント前にはペアワイズで「筋のいい組合せ」だけを選び、「全部は試せない」という賢いあきらめ方も学びつつある。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>イベント閉店後の《∞》は、嘘みたいに静かだった。さっきまで魔界 EDM が鳴り響き、社畜も観光客もカップルもごちゃまぜだったフロアが、今は片付いたテーブルとほのかな魔灯の明かりだけを残している。</p>
+<p>ユイリアはカウンター席で大きくため息をついた。目の前には今日のイベント用に自分で書いたテストケースノート。ページの端には「ペアワイズ OK」「境界△」「カズマさん来たら追加観察」と走り書きのメモが乱れている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「一応、事故はなかったし……みんな楽しそうだった、よね」
+            </div>
+<p>つぶやきながらも、胸のあたりがざわざわして落ち着かない。何かを忘れている気がする。どこかに穴があって、明日突然そこから炎が噴き出すんじゃないか、みたいな感覚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「顔に“テスト不安”って書いてあるよ」
+            </div>
+<p>振り向くと、いつの間にか神崎ナギがグラスに水を入れて座っていた。奥の厨房では、オーナーのバルハがしっぽで鍋を器用に運びながらこちらをちらりと見てニヤリと笑っている。</p>
+<p>ユイは観念して、ノートをぐるっと回してナギのほうに押し出した。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「今日、ペアワイズで組合せはかなり削れて……決定表も一応作って……境界っぽいところも、前に怒られたやつは踏み直して。でも、どこまでやれてるのか、全然わかんなくて。“まだ足りない気がする”って感覚だけが、ずっと残っちゃうんです」
+            </div>
+<p>ナギはノートをぱらぱらとめくり、ページの端に描かれた小さな丸や矢印を眺めながら、ふっと目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。いい顔してるよ、ユイ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっ、今にも泣きそうなんですけど」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「『ここまではやった。でも、どこまで守れてるんだろう？』って、カバレッジを気にし始めた目だもん」
+            </div>
+<p>ナギはナプキンの裏に小さな七色の弧を描いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストで『どのくらい試せてる？』を考えるとき、私はよく虹を描く。網羅したいものを色で塗っていくイメージね」
+            </div>
+<p>弧には「機能」「組合せ」「境界」「役割」「時間帯」「デバイス」などのラベルが並ぶ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部を同じ濃さで塗るのは無理。だから、今日みたいに組合せはペアワイズで薄めに、でも境界と役割は濃く塗る、とか、塗り分けを決める」
+            </div>
+<p>ユイは虹の欠けたところを指でなぞった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「私、時間帯とデバイス、ほぼ塗ってないかも……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ次の改善ポイントが見えたね。『虹のこの色は薄いけど、今回は許容する』『この色だけは濃く塗る』って自分で決めると、不安はだいぶ形になるよ」
+            </div>
+<p>ユイはノートの隅に、小さな虹を描き写す。「機能：濃」「境界：濃」「組合せ：中」「役割：中」「時間帯：薄」「デバイス：薄」。</p>
+<p>バルハが厨房から顔を出し、鍋をかき混ぜながら笑った。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「虹、いいじゃない。うちの店も七色に光ってるんだし」
+            </div>
+<p>ユイはふっと笑う。不安は消えない。けれど、どの色をどこまで塗ったかを自分で説明できると思うと、胸のざわつきが少しだけ静まった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「次のイベントでは、時間帯の色もちゃんと塗ってみます」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。虹は一晩じゃ完成しないからね。少しずつ重ねていこう」
+            </div>
+<p>虹色のメモをポケットにしまいながら、ユイは静かなフロアを見渡した。テストは終わらない。それでも、どの色を濃く塗るかを選べる自分が、少しだけ誇らしかった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep08</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep09/index.html
+++ b/generated/immersive/posts/ep09/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP09: ログは、システムからのラブレター | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="沈黙のデータが、ふいに語りはじめる。気づきはそこにある。">
+    <meta property="og:title" content="EP09: ログは、システムからのラブレター">
+    <meta property="og:description" content="沈黙のデータが、ふいに語りはじめる。気づきはそこにある。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep09">
+  <article class="sg-article" data-template="detail" data-content-id="ep09" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP09: ログは、システムからのラブレター</h1>
+      <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>新人テストエンジニア・結城ユイ（源氏名ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれながら、サキュバスメイド喫茶《∞（インフィニティ）》で世界 <span class="katex">W</span> の見方を学び続けている。客を同値クラスで捉え、境界値で踏み込み方を調整し、決定表で分岐を地図にし、状態遷移図で関係の揺れを眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹で自分のテストの濃淡を確かめるようになった。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>金曜の夜。《∞》は社畜救済ナイトとハーフアニバーサリー割引が重なり、開店直後から満席だった。</p>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「ユイリアさーん！　会計が通りません！」
+            </div>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「ドリンクだけ永遠に『処理中』です！」
+            </div>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「レシート、古代語みたいになってるんですけど！」
+            </div>
+<p>新人メイドたちの悲鳴が一斉に飛んできて、ユイは固まる。頭の中で IF 文が暴走し始めたそのとき、カウンターの端から落ち着いた声がした。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「深呼吸、ユイリア。まずは、世界で何が起きてるかを見よっか」
+            </div>
+<p>ナギはバックヤードの端末を指さす。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギ先輩！？」「カズマくんが『今日は地獄だ』って騒いでたからね」
+            </div>
+<p>画面にはタイムスタンプやエラーコードの並んだログがびっしりと流れていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「うっ……ログって、やっぱり怖いです。怒られてるみたいで」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「怒ってるんじゃなくて、“苦しかった場所”を教えてくれてるだけだよ」
+            </div>
+<p>ナギはスクロールを止め、一行を指でなぞる。</p>
+<pre>WARN discount-rule-07 condition overflow for pattern[社畜救済×ハーフアニバ×深夜延長]</pre>
+<p>それはユイが決定表の空いていたマスに勢いで書き足した新コンボだった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「WARN は『ここ、ちょっとしんどかったよ』っていう弱めの悲鳴。世界 <span class="katex">W</span> から届いた、“ここが痛い”っていうラブレターだね」
+            </div>
+<p>客席を振り返ると、奥のボックス席でスーツ姿のグループが会計を待ちながら伝票の山とにらめっこしていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「このコンボのときだけ、料金計算を何度もやり直してる。だから端末がタイムアウトして、レシートもぐちゃぐちゃになる」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「じゃあ、このコンボだけ一時的に止めれば……？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。世界 <span class="katex">W</span> 全体を止める必要はない。“痛がってる同値クラス”だけをそっと保護する」
+            </div>
+<p>二人でオーナーのバルハに状況を説明すると、バルハは肩をすくめて笑った。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「OK。そのコンボは今夜だけ封印ね。『悪魔的負荷のため、社畜救済とハーフアニバの同時適用は停止中』ってポップ書いとくわ」
+            </div>
+<p>対応後、ラッシュは戻ってきたが、端末の悲鳴はぴたりと止んだ。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業終了後。ユイはバックヤードで改めてログを眺める。イベントの時間帯、席の組み合わせ、特定のメニュー。赤い文字が集まる場所は、今日の世界 <span class="katex">W</span> が痛んでいた場所そのものだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ラブレター、ですね。本当に」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でしょ？　『ここ、もっと優しくして』『この組合せ、重すぎる』って、システムがちゃんと教えてくれる」
+            </div>
+<p>ユイはラブレターを丁寧にノートへ貼り付け、次のテスト計画のページに矢印を引いた。ログの文字列が、少しだけ温かく見えた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep09</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep10/index.html
+++ b/generated/immersive/posts/ep10/index.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP10: 魔導書と職人の手、Fθと G | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="便利さの向こう側。最後に“触る一点”を決めるのは誰？">
+    <meta property="og:title" content="EP10: 魔導書と職人の手、Fθと G">
+    <meta property="og:description" content="便利さの向こう側。最後に“触る一点”を決めるのは誰？">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep10">
+  <article class="sg-article" data-template="detail" data-content-id="ep10" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP10: 魔導書と職人の手、Fθと G</h1>
+      <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》の新人テストエンジニア・結城ユイ（ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれ、世界 <span class="katex">W</span> の見方を育ててきた。客を同値クラスでまとめ、心の境界値にぶつかり、決定表で分岐を地図にし、状態遷移図で関係を眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹でテストの濃淡を確かめ、ログを「システムからのラブレター」と読むようになった。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>営業後のカウンターで、バルハが分厚い黒い本を置いた。表紙には銀色で《汎用魔導書 Fθ》とある。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ねえユイリア。“頭数勝負”じゃないやり方、試してみない？」
+            </div>
+<p>不安を飲み込みつつ、ユイはナギと三人で実験することになった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「この前の社畜救済イベントの仕様とログ、流してみようか」
+            </div>
+<p>ナギが端末から魔導書へ魔力ケーブルを繋ぐと、黒いページが勝手にめくれ、光る文字が浮かぶ。</p>
+<pre>&lt;テスト案候補：
+ 1. 残業時間 0〜100 時間の全範囲で割引率が正しいこと
+ 2. 客の職種ごとに専用セリフが表示されること
+ 3. ログイン失敗時に励ましメッセージが表示されること
+ ……（以下 120 件）&gt;</pre>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ひゃ、百二十件！？」
+            </div>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ね、量では私たち敵わないでしょ？」
+            </div>
+<p>ユイは喉を鳴らす。魔導書が吐き出すテスト案の量と速度は、今まで自分が夜通しひねり出してきたものを軽々と超えていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……じゃあ、私の仕事、なくなっちゃうんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そうはならないよ。Fθは“材料”はたくさんくれる。でも、それをどう選ぶか、どう世界 <span class="katex">W</span> に合わせて磨くかは、職人の手がいる」
+            </div>
+<p>ナギは手元の紙に小さな記号を書いた。「Fθ → G」。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Fθ は魔導書の提案関数。G は私たちが持つ“現場の眼”。Fθ(G(x)) で初めて、店のテストケースになる」
+            </div>
+<p>ユイは試しに、魔導書の案から今日のイベントに関係しそうなものを三つ選び、決定表や状態遷移図と突き合わせていく。バルハはキッチン側の制約やコストを口にし、ユイはカバレッジの虹を思い浮かべながら優先度を塗り分けていった。</p>
+<p>深夜、テーブルには魔導書からの 120 件と、ユイが選んだ 12 件が並ぶ。後者は丸や矢印や色で塗られ、具体的な手順が添えられていた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「同じ“テスト案”でも、仕上がりが全然違うね。後ろの 12 件は、店の匂いがする」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Fθ がくれた素材を、G で整える。それが職人の手仕事」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……よかった。じゃあ、私、まだここでやることあるんだ」
+            </div>
+<p>魔導書は便利だ。それでも、店の匂いと温度を知っている手が要る。その手を、もっと確かにしていきたい。ユイはそう思いながら、魔導書の光るページをそっと閉じた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep10</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep11/index.html
+++ b/generated/immersive/posts/ep11/index.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP11: 先輩も、迷っていた | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="憧れの背中にも、消しては書いた線がある。その温度を知る。">
+    <meta property="og:title" content="EP11: 先輩も、迷っていた">
+    <meta property="og:description" content="憧れの背中にも、消しては書いた線がある。その温度を知る。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep11">
+  <article class="sg-article" data-template="detail" data-content-id="ep11" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP11: 先輩も、迷っていた</h1>
+      <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞》の新人テストエンジニア・ユイ（ユイリア）は、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という神崎ナギの言葉に導かれ、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジの虹、ログ解析、そして魔導書 Fθ と現場写像 G といった道具を手にしてきた。いつかナギのように <span class="katex">W</span> と制約 <span class="katex">E</span> から観点 <span class="katex">S</span> を選び取りたいと願い始めている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>閉店後の《∞》は、ネオンの名残だけがテーブルを染めていた。ユイはホワイトボードの前で固まっている。世界 <span class="katex">W</span>、制約 <span class="katex">E</span>、観点 <span class="katex">S</span>──書いたはずの図は、行き止まりの矢印と二重線で消された丸の墓場だ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「最終イベントの設計、ぜんぜん <span class="katex">G</span> が引けない……」
+            </div>
+<p>カラン、と裏口の鈴が鳴いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「派手に迷子ってるね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギさん……！」
+            </div>
+<p>神崎ナギは、魔界ブレンドコーヒーを二つ持って現れた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「バルハから、“ユイが世界の端でフリーズしてる”って連絡きたよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「監視社会だ……」
+            </div>
+<p>ナギはユイの隣に並び、ボードを一瞥する。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ふむ。ちゃんと <span class="katex">W</span> も <span class="katex">E</span> も <span class="katex">S</span> も書き出してる。いい迷子だ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どこがですか！　そこから先がぐちゃぐちゃで……。ナギさんみたいに、一本スッと <span class="katex">G</span> を引けないんです。私、相変わらず“なんでも屋のダメテストエンジニア”のままな気がして……」
+            </div>
+<p>ナギは何も言わず、くるりと背を向けた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ちょっと待ってて。昔の私を連れてくる」
+            </div>
+<div class="scene-break">＊　＊　＊</div>
+<p>しばらくして戻ってきたナギの腕には、分厚いノートが抱えられていた。角がすり切れ、コーヒーの染みが地図のように広がっている。端には小さく「テストアーキテクチャーの頭脳」と走り書きされていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これ、私がまだ“迷子のなんでも屋”だった頃のノート」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……見ていいですか」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「覚悟があるなら」
+            </div>
+<p>ユイがそっと開くと、中身は線でぐちゃぐちゃに消されたテスト案、観点が二重線で潰されたメモ、途中で放り出された決定表。今のユイのボードと瓜二つだった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ナギさんも、迷ってたんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。迷うよ。世界 <span class="katex">W</span> を丸ごと扱おうとしたら、毎回ね。一本で <span class="katex">G</span> を引けるのは、何度も迷子になったからだと思う」
+            </div>
+<p>ナギはノートの端に描かれた薄い矢印を指さす。そこには「ここで諦めた」「ここから <span class="katex">S</span> を減らした」と小さな字が添えられていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「迷った跡も、仕事の一部。『ここで詰まった』『ここは捨てた』ってログを残すと、次に <span class="katex">G</span> を引くときの支えになるよ」
+            </div>
+<p>ユイは自分のボードに「ここで迷った」「ここは捨てた」と赤ペンで書き込んだ。線で塗りつぶされた丸が、少しだけ愛おしく見えてくる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私も、この迷子ログ、残しておきます」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。そのログを渡せる後輩が来たら、ユイはもう“魅力ある大先輩”になってるよ」
+            </div>
+<p>ネオンの残光がホワイトボードを照らす。迷路のような線と赤いメモが、少しずつ「道」に見えてきた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep11</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/immersive/posts/ep12/index.html
+++ b/generated/immersive/posts/ep12/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP12: 次の子に渡す、G の地図 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。">
+    <meta property="og:title" content="EP12: 次の子に渡す、G の地図">
+    <meta property="og:description" content="最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="immersive" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep12">
+  <article class="sg-article" data-template="detail" data-content-id="ep12" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP12: 次の子に渡す、G の地図</h1>
+      <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》で新人テストエンジニアとして働き始めたユイリア。場当たり運営でオープン初夜を炎上させかけた彼女は、伝説のテストアーキテクト神崎ナギと出会い、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という言葉に導かれる。仕様書の外に広がる世界 <span class="katex">W</span> と制約 <span class="katex">E</span> を意識し、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジ、ログ解析、魔導書 Fθ と写像 <span class="katex">G</span> などの道具を手にしてきた。</p>
+<p>最終イベント設計では再び迷子になるが、ナギのボロボロの昔のノートに自分と同じぐちゃぐちゃの図を見つけ、憧れの先輩もかつては迷っていたと知る。ユイは「自分もあの背中に向かって歩いていい」と胸の奥でそっと決めた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>最終イベントの朝、まだ客のいない《∞》は、壁一面のホワイトボードで白く光っていた。同値クラスで色分けされた客の分類、境界値の付箋、決定表、状態遷移図、ログのグラフ。十一話分の失敗と発見が層になって張りついている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……すごいカオス。でも、今日はここから一本の線を引く日」
+            </div>
+<p>ユイはマーカーを握り、中央に縦線を引いた。その左に大きく「<span class="katex">W</span>」。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「この店の世界 <span class="katex">W</span> は、ここに来る人たちの人生全部」
+            </div>
+<p>右側には「<span class="katex">E</span>」。営業時間、スタッフの体力、厨房のキャパシティ。制約が並ぶ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「今日守りたい観点 <span class="katex">S</span> は、“常連も初見さんも『ここが居場所だ』と思えるか”」
+            </div>
+<p>矢印が伸び、同値クラスが丸で囲まれ、境界値のメモが配置される。ペアワイズで選んだ組合せ、虹で塗ったカバレッジの濃淡、ログから拾った痛みのポイント。全部が一本の地図に重なる。</p>
+<p>ドアが開き、オーナーのバルハと神崎ナギが入ってくる。壁いっぱいの図を見て、ふたりは目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「おお……店の歴史が壁に詰まってる」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイの <span class="katex">G</span> だね。どう引いたの？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「全部はできないから、今日の <span class="katex">S</span> に合わせて濃く塗る色を決めました。失敗ログも残しておきたくて」
+            </div>
+<p>ナギはうなずき、ポケットから小さな空ノートを取り出した。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これ、次に入る新人用に。今日の地図、写しておいて」
+            </div>
+<p>ユイは驚きながらノートを受け取る。白紙のページがまぶしい。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私が、書いていいんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。君が迷って見つけた道は、きっと次の子の助けになる」
+            </div>
+<p>開店のベルが鳴る。ユイはマーカーを置き、胸ポケットに小さなノートをしまった。G の地図は、もう自分だけのものじゃない。次の誰かに渡すためのものだ。</p>
+<p>「いらっしゃいませ！」――新人の声が、まぶしいほど真っ直ぐに響いた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep12</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/assets/base.css
+++ b/generated/magazine/assets/base.css
@@ -91,6 +91,33 @@ body[data-experience] .sg-nav {
   flex-wrap: wrap;
 }
 
+body[data-experience] .sg-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+body[data-experience] .sg-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--sg-border);
+  background: var(--sg-panel);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+body[data-experience] .sg-button:hover,
+body[data-experience] .sg-button:focus-visible {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+  outline: none;
+}
+
 body[data-experience] .sg-nav-links {
   list-style: none;
   margin: 0;
@@ -196,6 +223,11 @@ body[data-experience] .magazine-shelf {
 body[data-experience] .magazine-tile {
   display: grid;
   gap: 8px;
+}
+
+body[data-experience] .sg-markdown {
+  display: grid;
+  gap: 10px;
 }
 
 @media (max-width: 640px) {

--- a/generated/magazine/index.html
+++ b/generated/magazine/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>Magazine Generated Experience | Home</title>
+    <title>Hina Generated Experience | Home</title>
     <link rel="stylesheet" href="./assets/tokens.css">
     <link rel="stylesheet" href="./assets/base.css">
     <link rel="stylesheet" href="./assets/components.css">
     <link rel="stylesheet" href="../shared/switcher.css">
+    <meta name="description" content="Hina バリエーション用のジェネレート体験。">
+    <meta property="og:title" content="Hina Generated Experience">
+    <meta property="og:description" content="Hina バリエーション用のジェネレート体験。">
     <script src="../shared/switcher.js" defer></script>
   </head>
   <body class="sg-surface" data-experience="magazine" data-template="home" data-routes-href="../routes.json">
@@ -22,6 +25,9 @@
       <ul class="sg-nav-links">
         <li><a href="./">ホーム</a></li>
         <li><a href="list/">一覧</a></li>
+        <li><a href="./#about">紹介</a></li>
+        <li><a href="./#episodes">12話</a></li>
+        <li><a href="./#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -33,28 +39,148 @@
       </button>
     </nav>
     <p class="sg-eyebrow">Experience</p>
-    <h1>Magazine Generated Experience ホーム</h1>
-    <p class="sg-lede">雑誌風の体験を提供するジェネレートテンプレート。</p>
+    <h1>Hina Generated Experience</h1>
+    <p class="sg-lede">Hina バリエーション用のジェネレート体験。</p>
+    <div class="sg-actions">
+      <a class="sg-button" href="list/">一覧を見る</a>
+    </div>
   </header>
   <main id="content" class="sg-main">
-    <section class="sg-card">
-      <h2>最新コンテンツ</h2>
+    <section class="sg-card" id="about">
+      <h2>紹介</h2>
       <div class="magazine-shelf">
-        <article class="sg-card magazine-tile">
-          <h2><a href="posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
-          <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
-          <p class="sg-meta">#ep01</p>
+        <article class="sg-card magazine-tile" data-about-id="about-世界観">
+          <p class="sg-eyebrow">世界観</p>
+          <h3>サキュバスメイド喫茶《∞》の、きらめく現場</h3>
+          <p class="sg-lede">甘い匂いとネオンの間で、ユイは“なんとなく”から抜け出したいと思い始める。
+            目の前の出来事に名前がつき、線が引けるようになったとき、世界は少しだけ優しくなる。</p>
+          <p class="sg-meta">観察 / 分類 / 境界 / 地図 / ログ</p>
         </article>
-        <article class="sg-card magazine-tile">
-          <h2><a href="posts/welcome-post/">ようこそ、魔界喫茶《∞》へ</a></h2>
+        <article class="sg-card magazine-tile" data-about-id="about-読みどころ">
+          <p class="sg-eyebrow">読みどころ</p>
+          <h3>1話1粒、“宝石みたいな気づき”</h3>
+          <p class="sg-lede">各話は短編のように読めて、でも繋がっている。
+            何かを学ぶというより、 見える範囲が広がる 感覚を楽しむ物語です。</p>
+          <p class="sg-meta">成長 / 師弟 / やさしい刺さり / 夜の余韻</p>
+        </article>
+        <article class="sg-card magazine-tile" data-about-id="welcome-post">
+          <p class="sg-eyebrow">イントロ</p>
+          <h3>ようこそ、魔界喫茶《∞》へ</h3>
           <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
-          <p class="sg-meta">#welcome-post</p>
+          <p class="sg-meta">sample / intro</p>
+        </article>
+      </div>
+    </section>
+    <section class="sg-card" id="episodes">
+      <h2>エピソード</h2>
+      <div class="magazine-shelf">
+        <article class="sg-card magazine-tile" data-episode-id="ep01">
+          <p class="sg-eyebrow">Episode 01</p>
+          <h3><a href="posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h3>
+          <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
+          <p class="sg-meta">story / episode / 魔界喫茶</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep02">
+          <p class="sg-eyebrow">Episode 02</p>
+          <h3><a href="posts/ep02/">EP02: 世界 W は、仕様書の外に広がってる</a></h3>
+          <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep03">
+          <p class="sg-eyebrow">Episode 03</p>
+          <h3><a href="posts/ep03/">EP03: 同値クラスという、お守りの石</a></h3>
+          <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep04">
+          <p class="sg-eyebrow">Episode 04</p>
+          <h3><a href="posts/ep04/">EP04: 境界線を、一緒に歩いた夜</a></h3>
+          <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep05">
+          <p class="sg-eyebrow">Episode 05</p>
+          <h3><a href="posts/ep05/">EP05: 分岐の森と、先輩の地図</a></h3>
+          <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep06">
+          <p class="sg-eyebrow">Episode 06</p>
+          <h3><a href="posts/ep06/">EP06: 関係は、状態遷移で語れる</a></h3>
+          <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep07">
+          <p class="sg-eyebrow">Episode 07</p>
+          <h3><a href="posts/ep07/">EP07: 全部は試せない、という優しさ</a></h3>
+          <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep08">
+          <p class="sg-eyebrow">Episode 08</p>
+          <h3><a href="posts/ep08/">EP08: カバレッジの虹を見上げて</a></h3>
+          <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep09">
+          <p class="sg-eyebrow">Episode 09</p>
+          <h3><a href="posts/ep09/">EP09: ログは、システムからのラブレター</a></h3>
+          <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep10">
+          <p class="sg-eyebrow">Episode 10</p>
+          <h3><a href="posts/ep10/">EP10: 魔導書と職人の手、Fθと G</a></h3>
+          <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep11">
+          <p class="sg-eyebrow">Episode 11</p>
+          <h3><a href="posts/ep11/">EP11: 先輩も、迷っていた</a></h3>
+          <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+        <article class="sg-card magazine-tile" data-episode-id="ep12">
+          <p class="sg-eyebrow">Episode 12</p>
+          <h3><a href="posts/ep12/">EP12: 次の子に渡す、G の地図</a></h3>
+          <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+          <p class="sg-meta">story / episode</p>
+        </article>
+      </div>
+    </section>
+    <section class="sg-card" id="characters">
+      <h2>キャラクター</h2>
+      <div class="magazine-shelf">
+        <article class="sg-card magazine-tile" data-character-id="character-サキュバスメイド喫茶∞">
+          <p class="sg-eyebrow">舞台</p>
+          <h3>サキュバスメイド喫茶《∞》</h3>
+          <p class="sg-lede">きらめく夜の“現場”。 人が集まり、気分が揺れ、選択が生まれる場所。ユイの学びは、いつもここから始まる。</p>
+          <p class="sg-meta">夜のネオン / 現場の温度 / ∞の余白</p>
+        </article>
+        <article class="sg-card magazine-tile" data-character-id="character-バルハ">
+          <p class="sg-eyebrow">オーナー</p>
+          <h3>バルハ</h3>
+          <p class="sg-lede">喫茶《∞》のオーナー。二人の成長を少し離れた場所から見つめる存在。 舞台の空気を整え、物語の火種をそっと置く。</p>
+          <p class="sg-meta">黒幕ポジ（やさしめ） / 場を作る</p>
+        </article>
+        <article class="sg-card magazine-tile" data-character-id="character-神崎ナギ">
+          <p class="sg-eyebrow">大先輩</p>
+          <h3>神崎ナギ（かんざき・ナギ）</h3>
+          <p class="sg-lede">魔界テック界隈で伝説的なテストアーキテクト。 落ち着いた笑顔で、核心をすっと差し出す。“こうなりたい”と思わせる背中。</p>
+          <p class="sg-meta">静かな強さ / 言葉が地図 / 穏やかに刺す</p>
+        </article>
+        <article class="sg-card magazine-tile" data-character-id="character-結城ユイ">
+          <p class="sg-eyebrow">主人公</p>
+          <h3>結城ユイ（ユイリア）</h3>
+          <p class="sg-lede">サキュバスメイド喫茶《∞》で働く新人テストエンジニア。 知っているのは用語だけ。いつも場当たり的で、でも——だからこそ、伸びしろが眩しい。</p>
+          <p class="sg-meta">新人 / まっすぐ / 学びが体温</p>
         </article>
       </div>
     </section>
   </main>
   <footer class="sg-footer">
-    <p>&copy; Magazine Generated Experience</p>
+    <p>&copy; Hina Generated Experience</p>
   </footer>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/list/index.html
+++ b/generated/magazine/list/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>magazine | List</title>
+    <title>Hina Generated Experience | List</title>
     <link rel="stylesheet" href="../assets/tokens.css">
     <link rel="stylesheet" href="../assets/base.css">
     <link rel="stylesheet" href="../assets/components.css">
@@ -13,12 +13,15 @@
   <body class="sg-surface" data-experience="magazine" data-template="list" data-routes-href="../../routes.json">
   <header class="sg-header">
     <p class="sg-eyebrow">Listing</p>
-    <h1>magazine コンテンツ一覧</h1>
-    <p class="sg-lede">棚に並べるように横スクロールで見せるマガジン風。</p>
+    <h1>Hina Generated Experience コンテンツ一覧</h1>
+    <p class="sg-lede">Hina バリエーション用のジェネレート体験。</p>
     <nav class="sg-nav">
       <ul class="sg-nav-links">
         <li><a href="../">ホーム</a></li>
         <li><a href="./">一覧</a></li>
+        <li><a href="../#about">紹介</a></li>
+        <li><a href="../#episodes">12話</a></li>
+        <li><a href="../#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -31,17 +34,80 @@
   </header>
   <main class="sg-main" data-template="list" data-experience="magazine">
     <div class="magazine-shelf">
-      <article class="sg-card magazine-tile">
+      <article class="sg-card magazine-tile" data-episode-id="ep01">
+        <p class="sg-eyebrow">Episode 01</p>
         <h2><a href="../posts/ep01/">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a></h2>
         <p class="sg-lede">新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。</p>
         <p class="sg-meta">タグ: story, episode, 魔界喫茶</p>
       </article>
-      <article class="sg-card magazine-tile">
-        <h2><a href="../posts/welcome-post/">ようこそ、魔界喫茶《∞》へ</a></h2>
-        <p class="sg-lede">サイトジェネレータの検証用サンプルコンテンツ。</p>
-        <p class="sg-meta">タグ: sample, intro</p>
+      <article class="sg-card magazine-tile" data-episode-id="ep02">
+        <p class="sg-eyebrow">Episode 02</p>
+        <h2><a href="../posts/ep02/">EP02: 世界 W は、仕様書の外に広がってる</a></h2>
+        <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep03">
+        <p class="sg-eyebrow">Episode 03</p>
+        <h2><a href="../posts/ep03/">EP03: 同値クラスという、お守りの石</a></h2>
+        <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep04">
+        <p class="sg-eyebrow">Episode 04</p>
+        <h2><a href="../posts/ep04/">EP04: 境界線を、一緒に歩いた夜</a></h2>
+        <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep05">
+        <p class="sg-eyebrow">Episode 05</p>
+        <h2><a href="../posts/ep05/">EP05: 分岐の森と、先輩の地図</a></h2>
+        <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep06">
+        <p class="sg-eyebrow">Episode 06</p>
+        <h2><a href="../posts/ep06/">EP06: 関係は、状態遷移で語れる</a></h2>
+        <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep07">
+        <p class="sg-eyebrow">Episode 07</p>
+        <h2><a href="../posts/ep07/">EP07: 全部は試せない、という優しさ</a></h2>
+        <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep08">
+        <p class="sg-eyebrow">Episode 08</p>
+        <h2><a href="../posts/ep08/">EP08: カバレッジの虹を見上げて</a></h2>
+        <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep09">
+        <p class="sg-eyebrow">Episode 09</p>
+        <h2><a href="../posts/ep09/">EP09: ログは、システムからのラブレター</a></h2>
+        <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep10">
+        <p class="sg-eyebrow">Episode 10</p>
+        <h2><a href="../posts/ep10/">EP10: 魔導書と職人の手、Fθと G</a></h2>
+        <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep11">
+        <p class="sg-eyebrow">Episode 11</p>
+        <h2><a href="../posts/ep11/">EP11: 先輩も、迷っていた</a></h2>
+        <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+        <p class="sg-meta">タグ: story, episode</p>
+      </article>
+      <article class="sg-card magazine-tile" data-episode-id="ep12">
+        <p class="sg-eyebrow">Episode 12</p>
+        <h2><a href="../posts/ep12/">EP12: 次の子に渡す、G の地図</a></h2>
+        <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+        <p class="sg-meta">タグ: story, episode</p>
       </article>
     </div>
   </main>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep01/index.html
+++ b/generated/magazine/posts/ep01/index.html
@@ -3,11 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>magazine | Detail</title>
+    <title>EP01: 開幕、魔界喫茶《∞（インフィニティ）》 | Hina Generated Experience</title>
     <link rel="stylesheet" href="../../assets/tokens.css">
     <link rel="stylesheet" href="../../assets/base.css">
     <link rel="stylesheet" href="../../assets/components.css">
     <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。">
+    <meta property="og:title" content="EP01: 開幕、魔界喫茶《∞（インフィニティ）》">
+    <meta property="og:description" content="新人サキュバス兼なんでも屋テストエンジニア、ユイリアの初日を描く本編エピソード。">
     <script src="../../../shared/features/init-features.js" defer></script>
     <script src="../../../shared/switcher.js" defer></script>
   </head>
@@ -21,6 +24,9 @@
         <ul class="sg-nav-links">
         <li><a href="../../">ホーム</a></li>
         <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
       </ul>
       <button
         type="button"
@@ -256,3 +262,4 @@
   </article>
   </body>
 </html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep02/index.html
+++ b/generated/magazine/posts/ep02/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP02: 世界 W は、仕様書の外に広がってる | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="画面の外へ。現場と人の温度が、物語の色を変えていく。">
+    <meta property="og:title" content="EP02: 世界 W は、仕様書の外に広がってる">
+    <meta property="og:description" content="画面の外へ。現場と人の温度が、物語の色を変えていく。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep02">
+  <article class="sg-article" data-template="detail" data-content-id="ep02" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP02: 世界 W は、仕様書の外に広がってる</h1>
+      <p class="sg-lede">画面の外へ。現場と人の温度が、物語の色を変えていく。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》オープン初夜、新人サキュバスで“なんでも屋のダメダメテストエンジニア”結城ユイ（源氏名ユイリア）は感覚だけでイベントを回し、店を炎上寸前にしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームのログとメモを一瞥しただけで「客のパターン」を整理し、あっという間に状況を見える化。ユイは同じ世界を見ているはずなのに全く違う景色を切り取る先輩の背中に、強く憧れ始める。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>翌日の昼、《∞》はまだ開店前だった。昨夜の喧騒が嘘みたいに静かで、店内にはバルハがグラスを磨く音だけが響いている。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイリア、ちょっと外、付き合ってくれる？」
+            </div>
+<p>カウンター越しに顔を出した神崎ナギが、軽く手を振った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「テスト、ですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストの前に、“世界を見る練習”」
+            </div>
+<p>二人は店の前に並んで立った。昼の魔界歓楽街は、夜とは別人のようだ。ネオンは落ち着き、魔法水晶の看板が淡く光り、隣のインキュバス喫茶からコーヒーの香りが流れてくる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「質問。誰がこの店に入りそう？　誰は絶対入らなさそう？」
+            </div>
+<p>ナギが通りを指さす。黒ローブの魔法使い。ショッピング袋を下げたギャルサキュバスたち。ため息まじりにスマホをいじる人間界のサラリーマン。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと、あのギャルサキュバスたちは絶対来ます！　《∞》のパフェ、昨日SNSでバズってましたし」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ふむ。それで、あのスーツの彼は？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“社畜”っぽい人は来ないと思います。時間なさそうだし、メイド喫茶に寄る余裕なんて――」
+            </div>
+<p>ユイが言い終える前に、ギャルサキュバスたちは《∞》の前を素通りして、向かいのカラオケ魔城に吸い込まれていった。代わりに、クマのできたサラリーマンが店の前で立ち止まる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……え？」
+            </div>
+<p>ユイが固まっていると、男はおずおずと扉を覗き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「すみません、昨日の夜すごく楽しくて……昼もやってるかと思って」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「あ、今は準備中で……」
+            </div>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「ですよね。じゃあメニューの写真だけ撮らせてください。仕事の励みにしたくて」
+            </div>
+<p>入口のメニュー立てをスマホで撮りながら、彼はほっとしたように笑った。その背中を見送りながら、ユイは自分の予想が気持ちいいくらい外れたことを実感する。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「予想、外れちゃったね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ですよね。仕様書では“ターゲットは疲れた社畜”って書いてあったから、てっきり、ああいう人はむしろ来ないんだと思ってて」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「仕様書、昨日渡したやつ？」
+            </div>
+<p>ナギはポケットから折りたたまれた紙を取り出す。ターゲット像、営業時間、コンセプト。昨夜、ふたりで書いたメモだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい。わたし、こういう紙に書いてあることが“世界の全部”だと思ってました」
+            </div>
+<p>ユイが俯くと、ナギは紙の裏に大きな丸を描き、その中に「W」と書き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Wっていうのはね、“この店に関わる世界全部”のこと」
+            </div>
+<p>丸の外側へ矢印を伸ばしながら、ナギは通りを指す。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「時間帯、天気、この通りの空気、さっきの彼の残業状況、SNSの評判、その人の今日の気分……ここ“現場”を歩く人間ぜんぶ。仕様書に書いてないものほど、テストでは効いてくるんだよ」
+            </div>
+<p>ユイはごくりと喉を鳴らした。ナギは丸の中に小さな四角を描き、「仕様書」と書き込む。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「こうやって見ると、仕様書って、W の中のこのくらいの箱にしかすぎない」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……じゃあ、わたし、W のほんの一部しか見てなかったんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「“しか”って言うと、ちょっともったいないかな」
+            </div>
+<p>ナギは首を横に振る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「昨日の君は“仕様書の中だけの世界”を必死に見ていた。でも今はこうして、仕様書の外を見ようとしている」
+            </div>
+<p>通りに向けられたユイの視線を確かめてから、静かに続けた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「見ようとした瞬間から、もうテスターなんだよ」
+            </div>
+<p>胸の奥が、ぽっと温かくなる。ユイはポケットからメモ帳を取り出し、ページの端に「世界W観察ログ」と書き込んだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「じゃあ……さっきのサラリーマンさんは、“昼でもメニューを眺めたいくらい昨日の体験が刺さった客”ってことで……世界 W の中の、ひとつの点？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。仕様書には“疲れた社畜”としか書いてなかった。でも実際の W には、“昨日楽しんでくれた人が、今日も何かを求めてくる”って状態があった」
+            </div>
+<p>ナギは丸の中に小さな点を打つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「その点に気づいたのは、ユイリアだよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……わたし、ちゃんと見れてましたか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。“外した”って落ち込んでたけど、外れたってことは、“こうだろう”って仮説を立ててたってこと。何も考えずに眺めてたら、そもそも外れないからね」
+            </div>
+<p>ユイはきょとんとし、それからふにゃりと笑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「なんか……失敗ログにも、意味がある気がしてきました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「あるよ。世界 W を知るための、立派な観測データ」
+            </div>
+<p>店に戻ると、バルハがカウンターから顔を上げた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「外の空気はどうだった？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……世界、思ったよりずっと広かったです」
+            </div>
+<p>ユイが答えると、バルハはにやりと笑う。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ふたりとも、ちゃんと外を見て帰ってきた顔してるよ」
+            </div>
+<p>夕方、街にネオンが灯り始める。開店準備を終えたユイは扉の前に立ち、通りを見上げた。仕様書の外側に広がる、揺れるような世界 W。その中からどんな瞬間をすくい上げられるだろう――そんなことを思いながら、彼女は「本日開店」のプレートをそっと裏返した。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep02</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep03/index.html
+++ b/generated/magazine/posts/ep03/index.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP03: 同値クラスという、お守りの石 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。">
+    <meta property="og:title" content="EP03: 同値クラスという、お守りの石">
+    <meta property="og:description" content="ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep03">
+  <article class="sg-article" data-template="detail" data-content-id="ep03" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP03: 同値クラスという、お守りの石</h1>
+      <p class="sg-lede">ばらばらに見えるものが、観点ひとつで“同じ”になる瞬間。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街にオープンしたサキュバスメイド喫茶《∞（インフィニティ）》。新人メイド・ユイリアこと結城ユイは、“なんでも屋のダメダメテストエンジニア”として場当たりでイベントを回し、オープン初夜にクレーム祭りを引き起こしてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、山のようなクレームログを一瞥しただけで客を三つのパターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
+<p>翌日、店の前で通行人を観察したユイは、誰が店に入るかを外し続け、世界 <span class="katex">W</span> が仕様書の外側――時間や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」と笑うナギに励まされ、世界を少しずつ切り取る力を育て始める。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「社畜客」「観光客」「カップル」「ぼっち」――ホワイトボード一面の付箋を前に、ユイは頭を抱えていた。</p>
+<p>イベント仕様：残業明け社畜救済ナイト。対象客層が多すぎると感じながら、バルハからのミッションである「どんな客にも癒やされたと言わせる設計」を考えている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「社畜にもブラックとホワイトがいて、観光客も陽キャと陰キャがいて……これ全部別々にテストしてたら、一生終わらないんだけど…」
+            </div>
+<p>カウンターの上では、オーナー・バルハが黄金の瞳でその様子を眺めている。助け舟は期待できそうにない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「行き詰まった顔してるね」
+            </div>
+<p>背後から聞き慣れた声。振り向けば、神崎ナギが立っていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「せ、先輩！　このカオス見ないでください…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ううん、いいカオスだよ」
+            </div>
+<p>ナギはくすりと笑い、ポケットから小さなガラス瓶を取り出した。中には色も形も違う小さな鉱石がぎゅっと詰まっている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「綺麗ですけど？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部、石英（クォーツ）だよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え、全部同じなんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。見た目は違っても、“この観点から見ると同じ”ってことはよくある」
+            </div>
+<p>ナギは瓶を軽く振ってから、ホワイトボードの前に立つ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今ユイが困ってるのは、“全部違って見えるお客さん”でしょ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい…。バリエーション多すぎて、テストパターンが宇宙の端まで増えそうで…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、“お守りの石”を信じてみようか」
+            </div>
+<p>ナギはマーカーを手に取った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今日のイベントで一番守りたい観点 <span class="katex">S</span> は？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと…『ここに来てよかった』…ですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「その中でも、残業明け社畜救済なんだから？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「――“限界の社畜さんが、少しでも呼吸を取り戻せるか”」
+            </div>
+<p>ナギは真ん中に大きな丸を描き、「<span class="katex">S</span>：限界社畜の呼吸ポイント」と書き込む。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、この <span class="katex">S</span> から見て“同じ扱いでよさそうな人たち”を探そう」
+            </div>
+<p>ナギは付箋を二枚はがす。《社畜：三日徹夜、今にも倒れそう》《社畜：残業続き、今日は上司に怒鳴られてきた》。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「この二人にとって一番大事なのは？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「体力ゼロと、心がズタボロ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「どっちも“今すぐ難しい話を聞かされると死ぬ”って意味では同じだよね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「あ、たしかに」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあこの二人は、<span class="katex">S</span> の観点では同じ“限界社畜クラス”」
+            </div>
+<p>ナギは二枚を丸で囲み、「<span class="katex">A_1</span>：限界社畜」とラベルをつけた。</p>
+<p>次にナギがつまんだのは、《社畜：普段は激務だが今日は奇跡の有給》《観光客：魔界出張のついでに寄った》の二枚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「一見違うけど、“今日の気分”は似てない？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どっちも、ちょっと浮かれてる感じ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。“今日は特別な一日”クラスだね」
+            </div>
+<p>新しい丸に「<span class="katex">A_2</span>：特別デー満喫」と書き込む。さっきまでバラバラだった客たちが、観点 <span class="katex">S</span> を通してふわっと集まり始める。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え、じゃあ…このカップルと、このぼっちさんも…」
+            </div>
+<p>ユイは自分で付箋を動かし、ラブラブ観光カップルと、スマホを握りしめてそわそわしている青年を同じ丸に入れた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どっちも“誰かに見せたい特別な夜”クラス…かも」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん、その分け方はユイの <span class="katex">W</span> の見方から出てきたものだよ」
+            </div>
+<p>ナギはホワイトボードの端に小さく書き添える。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「世界 <span class="katex">W</span> のお客さんを、観点 <span class="katex">S</span> から見て“同じ息の仕方かどうか”で分けたグループ。それがテストでいう同値クラス <span class="katex">A(S)</span>」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「同値クラス…用語としてしか知らなかったです」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「名前だけ知ってても、こうやって <span class="katex">W</span> の上に描いてみると、ちょっと身近になるでしょ？」
+            </div>
+<p>ユイはうなずき、ノートを開いた。丸と矢印が増えるたび、混沌だった世界が少しだけ整っていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、それぞれのクラスから代表を一人決めて、その人の一晩を徹底的にシミュレーションしよう」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「<span class="katex">A_1</span> は三日徹夜さん。寝落ちさせない導線と、脳に優しいメニューを…」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「<span class="katex">A_2</span> は有給社畜さん。“頑張ってる自分”を労えるサプライズを入れたいです」
+            </div>
+<p>客の名前の代わりに、「<span class="katex">A_1</span>」「<span class="katex">A_2</span>」の記号がノートの上を跳ね回る。さっきまで怖かったバリエーションが、「塊」として手のひらに乗る感覚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ね、全部バラバラに見えてた世界が、“同じ扱いでよくなる塊”に見えてきたでしょ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい…。世界がちょっと優しくなった気がします」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「それが、同値クラスのお守り効果」
+            </div>
+<p>ナギは瓶から小さな透明な石を一つ取り出した。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「今日からユイのお守り。困ったら、この石を見て考えてみて。“この子と同じように扱える仲間、いないかな？”って」
+            </div>
+<p>ユイはそっと石を握りしめる。冷たい感触が、少しずつ手の中で温度を帯びていく。</p>
+<p>――いつか自分も、ナギみたいに。バラバラな世界を、やさしい丸で包んであげられる先輩になれたら。</p>
+<p>石英のかすかなきらめきが、ホワイトボードに映る。そこにはもう、“なんでも屋のダメダメテストエンジニア”ではなく、同値クラスという小さな石を手に入れた、一人のテスト屋の地図が描かれ始めていた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep03</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep04/index.html
+++ b/generated/magazine/posts/ep04/index.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP04: 境界線を、一緒に歩いた夜 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。">
+    <meta property="og:title" content="EP04: 境界線を、一緒に歩いた夜">
+    <meta property="og:description" content="近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep04">
+  <article class="sg-article" data-template="detail" data-content-id="ep04" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP04: 境界線を、一緒に歩いた夜</h1>
+      <p class="sg-lede">近づく優しさと、踏み込みすぎる痛み。その線を探しに行く。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で働く新人メイド兼テストエンジニア・結城ユイ（ユイリア）は、場当たり運営でオープン初夜を炎上させてしまう。そこへ現れた伝説級テストアーキテクト・神崎ナギは、クレームログを一瞬で三つの客パターンに整理し、「テストは世界の見方を設計する仕事」だと示した。</p>
+<p>翌日、店の前で通行人を観察したユイは、誰が店に入るかを外し続け、世界 <span class="katex">W</span> が仕様書の外側──時間や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」と笑うナギに励まされ、さらにイベント準備では、小さな鉱石を例に「観点しだいで同じ扱いにできる塊＝同値クラス」を学び、世界を少し整理して見られるようになってきていた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「社畜救済ナイト、本日かぎり〜！」サキュバスメイド喫茶《∞》のネオンが青く瞬く。スーツ客限定ドリンク無料、残業時間を申告すると「おつかれさまマッサージ」付き──そのイベントを企画したのは、昨日「同値クラス」を教わったばかりのユイだ。</p>
+<p>胸元で、ナギにもらった鉱石の小瓶が揺れる。カラン、と扉の鈴。最初の客はネクタイを緩めた中年の男。目の下のクマが深い。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「いらっしゃいませ。今月の残業時間、よろしければ…」
+            </div>
+<div class="dialogue">
+<span class="character-name">社畜客</span>
+                「百二十時間だ」
+            </div>
+<p>想定テーブルの最大値を軽く超えた数字に、ユイの笑顔が固まる。動揺をごまかそうとして、軽口が滑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「そんな会社、やめちゃえばいいのに！」
+            </div>
+<p>冗談のつもりでウインクした瞬間、男の肩がびくりと震える。</p>
+<div class="dialogue">
+<span class="character-name">社畜客</span>
+                「…やめられたら、とっくにやめてるよ」
+            </div>
+<p>ぽたり、とテーブルに落ちる雫。涙だと気づいたときには遅かった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>休憩に入ると、フィードバックカードが一枚置かれていた。</p>
+<div class="feedback-card">「励ましがきつかったです。そっとしておいてほしかった」</div>
+<p>短い文字が、胸を刺す。そこへまた鈴の音。ユイはカードを握りしめたままホールへ戻った。</p>
+<p>今度は若いサラリーマン風の男。スーツも表情もまだ余裕がある。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「いらっしゃいませ。ドリンクは？」
+            </div>
+<div class="dialogue">
+<span class="character-name">サラリーマン</span>
+                「おすすめで。…大変そうだね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「まあ、ぼちぼちです」
+            </div>
+<p>仕事の話題を避け、マニュアル通りの笑顔で受け流す。沈黙が増えるたびに、ユイは一歩ずつ下がっていくみたいな気持ちになる。帰り際、その客もカードを書いていった。</p>
+<div class="feedback-card">「可愛いけど、今日はなんか遠くてさみしかった」</div>
+<p>二枚のカード。踏み込みすぎた自分と、引きすぎた自分。どちらも正解に見えなくて、ユイはスタッフルームの椅子に崩れ落ちた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私、どこまで行っていいか、全然分かんない」
+            </div>
+<p>ぽつりと言ったとき、背後から穏やかな声が落ちてくる。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ、境界線を見に行こっか」
+            </div>
+<p>振り返ると、ナギが白いコートの裾を揺らして立っていた。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>店を出て少し歩くと、歓楽街の端に細い川がある。ネオンを映した黒い水面と石畳。その境目には、濡れて黒い石と乾いて白い石のくっきりした帯ができていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ここ、分かりやすいでしょ。『濡れて滑りやすい世界』と『乾いて歩きやすい世界』の境界」
+            </div>
+<p>ナギは境目の少し色の違う石をつま先でつつく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ここまではセーフ、ここから先はアウト。その“ちょうど変わるところ”を何度も行き来して確かめるのが、境界値分析」
+            </div>
+<p>ユイはおそるおそる境界の上に片足を置く。靴底がかすかにぐにゃっと滑った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「…こわ」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でも、テスト屋が一番知りたいのって、この感触なんだよ」
+            </div>
+<p>ナギは境目の石を拾い、ユイの手に乗せた。ひんやり冷たい。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「さっきの二人も、境界線のそばにいたんだと思う。『会社やめちゃえば』って一言で、“うれしい共感”から“一気につらい現実”側に落ちちゃうラインとか」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私、完全に踏み抜いたやつだ」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。でも、その場所が分かったのは大きい。テストで言えば、『ここが 59→60 分で結果が変わるポイントでした』ってログが取れた状態」
+            </div>
+<p>ナギは石に小さく「B」と書く。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Boundary の B。今日のカードは、『このクラスの人はここまで来ると泣いちゃう』『ここまで下がるとさみしい』っていう境界値データ。ダメな自分の証拠じゃなくて、世界 <span class="katex">W</span> からのメモだよ」
+            </div>
+<p>ユイは、ラブレターにしては刺さり方がエグいなと思いながらも、少し笑った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「境界って、人の心が変わるラインでもある。だから、一歩目でつまずくのは普通。大事なのは『ここが危ない』って印をつけて、次は一歩手前から試すこと」
+            </div>
+<p>夜風が川面をわたる。ユイは石と小瓶を握りしめた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「…じゃあ、もう一回だけ、やってみてもいい？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「もちろん。境界値分析って、“もう一度踏み出す勇気”のためのおまじないだから」
+            </div>
+<p>《∞》のネオンが遠くで瞬く。ユイはその光を見つめ、小さくうなずいた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「明日、社畜さん向けのトークを、『天気ゾーン』『仕事ぼやきゾーン』『人生ゾーン』ってライン引いて考えてみる。どこで世界が変わるか、自分でもちゃんと見に行く」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いいね。それ、次の『地図作り』にもつながるよ」
+            </div>
+<p>境界線を一緒に歩いた夜。ユイの中で「失敗」というラベルが、そっと「発見」に書き換わっていった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep04</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep05/index.html
+++ b/generated/magazine/posts/ep05/index.html
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP05: 分岐の森と、先輩の地図 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="増え続ける条件の森。迷いを“見える形”にしていく一歩。">
+    <meta property="og:title" content="EP05: 分岐の森と、先輩の地図">
+    <meta property="og:description" content="増え続ける条件の森。迷いを“見える形”にしていく一歩。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep05">
+  <article class="sg-article" data-template="detail" data-content-id="ep05" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP05: 分岐の森と、先輩の地図</h1>
+      <p class="sg-lede">増え続ける条件の森。迷いを“見える形”にしていく一歩。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、テストエンジニア見習いとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させてしまう。しかし現れた伝説級テストアーキテクト・神崎ナギが、クレームログを三つの客パターンに整理して見せ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
+<p>翌日、店先で通行人を観察したユイは「誰が店に入るか」を外し続け、世界 <span class="katex">W</span> は仕様書だけでなく、時間帯や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」とナギに言われ、世界をちゃんと見る一歩を踏み出した。</p>
+<p>イベント準備では、属性が増えすぎて混乱するユイに、ナギが小さな鉱石を見せながら「観点しだいで同じ扱いにできる塊＝同値クラス」を説明。見た目は違っても、テストしたい観点 <span class="katex">S</span> から見れば同じグループにできる客たちがいると知り、ユイは世界を少し整理して見られるようになっていく。</p>
+<p>社畜救済イベント本番では、ある客には踏み込みすぎて泣かせ、別の客には距離を取りすぎて「冷たい」と言われてしまう。落ち込むユイに、ナギは夜の河川敷で「どこまで踏み込んだらうれしくて、どこから先は苦しくなるか。人にもテストにも境界がある」と境界値分析を重ねて語る。ユイは、失敗が「境界を探すための一歩」だったと受け止め、もう一度やってみようと顔を上げた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>その夜の《∞》は、レジ前だけ小さな地獄だった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと……平日社畜割でドリンク半額で、雨の日カウンター席 10％オフで、ペア来店＋SNS 投稿でデザートサービスで……」
+            </div>
+<p>ユイはレジ画面と手書きメモを交互ににらみ、指を折っては戻す。バルハオーナーが導入した新ロジックは、社畜証明や天気、席種、SNS 投稿、滞在時間など条件が重なるほど複雑だった。頭の中で IF と AND と OR が枝分かれし、思考は白煙を上げ始める。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「お、お待たせしてしまってすみませんっ！」
+            </div>
+<p>目の前の社畜スーツ客に、とりあえず一番お得そうな割引を全部乗せしてしまった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業終了後。客席が暗くなり、カウンターだけが照明に浮かぶ。ユイは割引条件を書き散らしたノートを前にうなっていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ここで社畜フラグが立って……ここで雨フラグで分岐して、席種でまた分岐して、SNS で……木が増えすぎて根っこが分かんない……」
+            </div>
+<p>ノートには IF 文の断片と矢印が蜘蛛の巣のように広がり、自分でも読めない。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「分岐の森で遭難してる顔だね」
+            </div>
+<p>エプロンを外した神崎ナギが立っていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギ先輩……。頭の中で全部追おうとしたら、ぜんぶ混ざって……今日、絶対どこかでミスりました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「分岐が増えるほどね、頭の中だけで持ちきれないものは外に出してあげたほうがいい」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「外に？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。“地図”にしちゃうの」
+            </div>
+<p>ナギが小さなホワイトボードにシンプルな表の枠を引く。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「割引に効いてきそうな条件だけ並べよう。これは決定表。IF 文を文章で追う代わりに、マス目で分岐を見るやり方」
+            </div>
+<p>左端に「社畜証明」「雨の日」「カウンター席」「ペア来店」「SNS 投稿」「〜19:00」「滞在 60 分」、上には「パターン1」「パターン2」……と書き込まれていく。ナギは「パターン1」の列に◯と×を書き込み始めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「たとえば、よく来る黒スーツの社畜さん。証明あり、雨の日に来ることが多くて、カウンター席好きで、仕事仲間と二人で来るけど SNS 投稿はしない。時間は 18:30 ごろ、滞在は 60 分前後」
+            </div>
+<p>ユイの頭に、毎回「おつかれ」と笑う常連の顔が浮かぶ。</p>
+<div class="decision-table">
+<table>
+<tr>
+<th>条件</th>
+<th>パターン1</th>
+<th>パターン2</th>
+</tr>
+<tr><td>社畜証明</td><td>◯</td><td>◯</td></tr>
+<tr><td>雨の日</td><td>◯</td><td>×</td></tr>
+<tr><td>カウンター席</td><td>◯</td><td>×</td></tr>
+<tr><td>ペア来店</td><td>◯</td><td>×</td></tr>
+<tr><td>SNS 投稿</td><td>×</td><td>◯</td></tr>
+<tr><td>〜19:00</td><td>◯</td><td>◯</td></tr>
+<tr><td>滞在 60 分</td><td>◯</td><td>×</td></tr>
+<tr><td>結果</td><td>ドリンク半額＋会計10％オフ＋デザート＋ポイント二倍</td><td>ドリンク半額＋デザート</td></tr>
+</table>
+</div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあパターン2 は？　一人でふらっと来た社畜さん。証明はあるけど、雨じゃなくて、テーブル席で、SNS 投稿はしてくれる」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっと……社畜証明＝◯、雨の日＝×、カウンター席＝×、ペア来店＝×、SNS 投稿＝◯、〜19:00＝◯、滞在 60 分＝×……結果は、ドリンク半額とデザートだけ？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。雨じゃないから 10％オフは付かないし、滞在も 60 分から外れてる。こうやって一行ずつ見ていけば、迷わない」
+            </div>
+<p>自分のペンで◯と×を書き込みながら、ユイは思う。 同じ森の中にいるはずなのに、地図があるだけで足元がくっきりする。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……さっきまでのぐちゃぐちゃが、ちゃんと“道”に見えてきました」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でしょ。人の脳はそんなに分岐を同時には扱えない。だから、地図に肩代わりさせればいい」
+            </div>
+<p>ナギはボードの端に小さな山の絵を描いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「鉱物採集するときも、地形図なしで山に突っ込むと遭難する。“危ない分岐”は最初から赤で印を付けておく」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“売上が吹き飛ぶやばい組合せ”も、赤で囲んでおける……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そうそう。『全部覚えておく』って、実は一番危ない考え方なんだよ」
+            </div>
+<p>ユイは笑いながら、パターン3、4 と常連たちを思い浮かべてマス目を埋めていく。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「これ、明日からレジ横に貼りませんか？　みんなで同じ地図を見られるように」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いいね。分岐の森は、一人で歩かなくていい」
+            </div>
+<p>ナギがふっと目を細める。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「それとね。今日、分岐に呑まれて苦しくなった感覚も、ちゃんと覚えておいて」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「え？　忘れたいんですけど……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「いつか、もっと迷子になってる新人が現れたときに、『ここに地図があるよ』って渡すために」
+            </div>
+<p>その言葉に、胸の奥が少し熱くなる。手作りの決定表は、まだ粗い線だらけの地図だ。けれどユイには、その端っこから、遠くの“先輩の背中”へ伸びる細い道が続いているように見えた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep05</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep06/index.html
+++ b/generated/magazine/posts/ep06/index.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP06: 関係は、状態遷移で語れる | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="時間で変わるものには、ちゃんと“状態”と“遷移”がある。">
+    <meta property="og:title" content="EP06: 関係は、状態遷移で語れる">
+    <meta property="og:description" content="時間で変わるものには、ちゃんと“状態”と“遷移”がある。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep06">
+  <article class="sg-article" data-template="detail" data-content-id="ep06" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP06: 関係は、状態遷移で語れる</h1>
+      <p class="sg-lede">時間で変わるものには、ちゃんと“状態”と“遷移”がある。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で見習いテストエンジニアとして働き始めた結城ユイ──ユイリアは、場当たり運営でオープン初夜を炎上させかける。そこへ現れた伝説級テストアーキテクト・神崎ナギが、クレームを三つの客パターンに整理してみせ、「テストは世界の見方を設計する仕事」だと教えてくれた。</p>
+<p>翌日、店先で通行人を観察したユイは、誰が店に入るかをことごとく外し、世界 <span class="katex">W</span> が仕様書の外側──時間帯や天気、SNS、その人の気分まで含むと知る。「見ようとした瞬間からテスター」とナギに認められ、世界をちゃんと見る一歩を踏み出す。</p>
+<p>イベント準備では、増え続ける客の属性に溺れかけるが、ナギから同値クラスの考え方を教わり、「観点しだいで同じ扱いにできる塊」が見えるようになる。社畜救済イベント本番では、踏み込みすぎたり距離を取りすぎたりして失敗するものの、「人にもテストにも境界がある」と境界値分析を重ねて聞かされ、失敗を境界探しの一歩として受け止め直す。</p>
+<p>第5話では、割引条件や時間帯などの分岐が爆発し、頭の中の IF 文で迷子になったユイに、ナギが決定表という「分岐の地図」を描いてみせた。ユイは複雑さを外に出して整理する感覚を掴みかけている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>夕方の《∞》に、見慣れた背広が入ってくる。社畜救済イベント以来の常連客カズマだ。ユイリアはいつものノリでしっぽを振った。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「おかえりなさいませ〜社畜さま♡　今日も残業コンボ決めてきました？」
+            </div>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……ああ」
+            </div>
+<p>返事は短く、声は平坦。いつもなら「やめろ」と笑うのに、今日は視線がテーブルから上がってこない。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ご褒美ドリンク、今日は強めにしときます？　魂までとろけるやつ！」
+            </div>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……悪い。今日は、あんまりいじらないでくれると助かる」
+            </div>
+<p>ユイはあわてて頭を下げ、マニュアルどおりの笑顔で注文だけを取る。会話はそれ以上広がらず、彼は一杯飲むと、いつもより早く帰ってしまった。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業後、裏口の階段。ユイは膝を抱え、横で缶コーヒーを開けるナギをちらりと見る。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……やっぱり、やらかしましたよね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「カズマくんのこと？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「はい。前は“社畜さま”っていじると笑ってくれたのに、今日は明らかに刺さってて……。決定表まで作ったのに、“関係の気分”みたいなのは表にできなくて」
+            </div>
+<p>ナギは少し考え、ユイのノートを開いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「決定表は、その瞬間の条件と結果を見るには便利なんだ。でも、人や関係みたいに、時間でじわじわ変わるものは、別の見方がいい」
+            </div>
+<p>ナギが丸をひとつ描き、矢印を伸ばす。</p>
+<p class="diagram">『初来店』 → 『リピーター』 → 『常連』 → 『VIP』<br/>　　　　　　　　　　　　　↘<br/>　　　　　　　　　　　　　『離脱』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これが関係の“状態遷移図”。丸が“今どんな状態か”。矢印が“そこからどこに行きうるか”。ログイン前→ログイン中→ログアウト、みたいな変化も、同じように描けるよ」
+            </div>
+<p>さらに小さな丸が増える。</p>
+<p class="diagram">『限界社畜』 → 『ちょっと回復した常連』 → 『心が折れかけ常連』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「カズマくん、今日はたぶんここだね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「“心が折れかけ常連”……」
+            </div>
+<p>言葉になった途端、さっきの沈んだ目が、ただ怖いものじゃなく「そういう状態」として見え直る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「同じ“常連”でも、状態が違えば、かけていい言葉も変わる。今日ユイが投げたのは、“ちょっと回復した常連”向けのいじり方だった」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「うわ……決定表、雑にまとめすぎたかもです……」
+            </div>
+<p>ユイは自分の表のマスを思い出し、うなだれる。ナギは『心が折れかけ常連』から別の丸へ矢印を足した。</p>
+<p class="diagram">『心が折れかけ常連』 → 『静かに休めた常連』</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「次に会ったとき、“今日は静かに過ごすコースもありますよ”ってそっと出してみる。もし少しでも休めたら、状態はこっちに遷移する。そこからまた、ゆっくり別の矢印を考えればいい」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……一回ミスったら“離脱”に直行ってわけじゃないんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「人はバージョン固定じゃないからね。何度でもアップデートできる。『今どの状態にいて、どこに行きうるか』が見えると、テストしたい場面も、声のかけ方も見えてくるよ」
+            </div>
+<div class="scene-break">＊　＊　＊</div>
+<p>翌晩。ドアベルが鳴り、またカズマが入ってきた。昨日と同じように疲れた顔。それでも足がここを選んでくれたことが、少しうれしい。エプロンのポケットには、自分で描いた小さな状態遷移メモが入っている。</p>
+<p>（今は“心が折れかけ常連”。ここから、“静かに休めた常連”へ、矢印を伸ばす）</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「おかえりなさいませ、カズマさん。今日は──いじられたい日ですか？　それとも、“そっとしておいてほしい日”ですか？」
+            </div>
+<p>カズマがきょとんとし、やがてふっと笑う。</p>
+<div class="dialogue">
+<span class="character-name">カズマ</span>
+                「……後者で、お願いします」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「かしこまりました。“静かに休めた常連”コースですね」
+            </div>
+<p>小声でそう確認しながら、ユイは余計な台詞を挟まず、そっとカップを置く。人の心は仕様書みたいにきれいには並ばない。それでも、丸と矢印で輪郭を描いてみると、モヤモヤが少しだけ形になる。</p>
+<p>立ちのぼる湯気の向こうで、ユイリアの小さな決意が、静かに新しい状態へと遷移していった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep06</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep07/index.html
+++ b/generated/magazine/posts/ep07/index.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP07: 全部は試せない、という優しさ | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="全部を抱えない。“守るために選ぶ”という、やさしい決断。">
+    <meta property="og:title" content="EP07: 全部は試せない、という優しさ">
+    <meta property="og:description" content="全部を抱えない。“守るために選ぶ”という、やさしい決断。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep07">
+  <article class="sg-article" data-template="detail" data-content-id="ep07" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP07: 全部は試せない、という優しさ</h1>
+      <p class="sg-lede">全部を抱えない。“守るために選ぶ”という、やさしい決断。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働き始めた結城ユイ──ユイリアは、炎上しかけたオープン初夜を伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」と教わる。その後、世界 <span class="katex">W</span> が仕様書の外側まで広がること、同値クラスでばらばらの客をまとめられること、境界値分析で踏み込み方を調整できること、決定表で分岐を地図にできること、状態遷移図で関係の変化を見通せることを少しずつ身に付け、図で世界を扱う感覚を育てている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>「――じゃ、今度の《魔界横断オールナイトフェス》のテスト計画、ユイリアちゃんに任せたわよん♪」</p>
+<p>オーナーのバルハが、ぎっしり書き込みだらけの企画書を置いた。BGM３種、コスチューム３種、限定メニュー３種、席配置３パターン、客層４パターン。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……多くないですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「魔界の夜は盛りだくさんが正義よ☆　じゃ、よろしく～」
+            </div>
+<p>カウンターの端で、ユイはノートを開く。BGM × コスチューム × メニュー × 席配置 × 客層……。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「全部試そうとすると、3×3×3×3×4で……」
+            </div>
+<p>数字を書きかけたペン先が止まる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「私、こんなにテストケース作る時間、ない……」
+            </div>
+<p>前に教わった決定表を真似してみるが、マス目はすぐ真っ黒になり、頭の中の IF 文も一緒に爆発した。気づけば、ノートに額をつけていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイ、寝落ち？」
+            </div>
+<p>ふわりと影が差し、聞き慣れた声がした。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「な、ナギ先輩……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストケースに轢かれた顔してるね」
+            </div>
+<p>ナギはノートを覗き込み、びっしりの×印を見る。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部の組合せを、全部試そうとしてる？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「だって……どれか取りこぼしたところでバグったら、私のせいでイベントが壊れるかもって思ったら……全部やらなきゃって」
+            </div>
+<p>自分でも情けなくて、声が小さくなる。ナギは少しだけ考える顔をしてから、ペンを取った。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイ、山で鉱物採集したことある？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ないです」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「山って、全部の石を拾うんじゃなくて、“ここらへんに石英が多い層がある”とか“ここの斜面は崩れやすい”ってポイントを押さえるの。テストも同じ。全部は試せないからこそ、『代表』に絞る」
+            </div>
+<p>ナギは紙に小さな表を描く。BGM・コスチューム・メニュー・席配置・客層。それぞれの組み合わせを均等に拾う直交表ができあがっていく。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これはペアワイズとか直交表って呼ぶやり方。二つずつの組合せが漏れなく入るように、最小限のケースを選ぶんだ」
+            </div>
+<p>並んだ数字が、さっきまでの 3×3×3×3×4 の暴力から一気に少なくなる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ほんとだ。全部じゃないのに、ちゃんと“組み合わせを見る”って感じが残ってる」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部を試せないって、諦めじゃなくて優しさなんだよ。限られた時間で、壊れやすいところをちゃんと見るための優先順位付け」
+            </div>
+<p>ナギは最後に、空欄にいくつかのリスクメモを書き込む。「深夜帯×ハイヒール→滑りリスク」「辛メニュー×未成年→要注意」。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「直交表は“平均的な組合せ”を見るのが得意。でも、人が滑りやすいところ、燃えやすいところは意識的に足しておくといい」
+            </div>
+<p>ユイは深呼吸し、重かった肩が少し軽くなるのを感じた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……全部はできない、って決めるのって怖かったけど、ちゃんと理由があれば、むしろ守りになるんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。“優しく選ぶ”ってこと。ユイが選んだケースで、当日のお客さんが安全に楽しめるようにしよう」
+            </div>
+<p>フェス当日、ユイは直交表で選んだ組み合わせを丁寧に試し、リスクメモのケースを重点的に確認した。終電を逃した社畜がハイヒールのサキュバスに絡みそうになる場面も、事前に想定していた導線チェックのおかげで大きな事故にはならなかった。</p>
+<p>閉店後、バルハが冷蔵庫のドアに直交表を貼りながら笑う。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「全部は試せない、けど、この表があればみんなで迷子にならないね」
+            </div>
+<p>ユイも笑う。全部を抱え込まなくてもいい。優しく選んだ少ないケースが、確かに世界 <span class="katex">W</span> の安全を守っている手応えがあった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep07</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep08/index.html
+++ b/generated/magazine/posts/ep08/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP08: カバレッジの虹を見上げて | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="足りないより、届いたところを見ていい——色を塗り分ける夜。">
+    <meta property="og:title" content="EP08: カバレッジの虹を見上げて">
+    <meta property="og:description" content="足りないより、届いたところを見ていい——色を塗り分ける夜。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep08">
+  <article class="sg-article" data-template="detail" data-content-id="ep08" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP08: カバレッジの虹を見上げて</h1>
+      <p class="sg-lede">足りないより、届いたところを見ていい——色を塗り分ける夜。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>魔界歓楽街のサキュバスメイド喫茶《∞（インフィニティ）》で、新人テストエンジニアとして働く結城ユイ──源氏名ユイリア。場当たり運営で炎上しかけたオープン初夜、伝説のテストアーキテクト・神崎ナギに救われ、「テストは世界の見方を設計する仕事」だと知る。</p>
+<p>店の前を行き交う人々を観察し、仕様書の外側まで含めた世界 <span class="katex">W</span> を意識するようになったユイは、ばらばらに見える客たちを同値クラスとしてまとめ、境界値分析で踏み込み方を整え、決定表で分岐の森を地図にし、状態遷移図で関係の変化を見通す力を磨いてきた。大イベント前にはペアワイズで「筋のいい組合せ」だけを選び、「全部は試せない」という賢いあきらめ方も学びつつある。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>イベント閉店後の《∞》は、嘘みたいに静かだった。さっきまで魔界 EDM が鳴り響き、社畜も観光客もカップルもごちゃまぜだったフロアが、今は片付いたテーブルとほのかな魔灯の明かりだけを残している。</p>
+<p>ユイリアはカウンター席で大きくため息をついた。目の前には今日のイベント用に自分で書いたテストケースノート。ページの端には「ペアワイズ OK」「境界△」「カズマさん来たら追加観察」と走り書きのメモが乱れている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「一応、事故はなかったし……みんな楽しそうだった、よね」
+            </div>
+<p>つぶやきながらも、胸のあたりがざわざわして落ち着かない。何かを忘れている気がする。どこかに穴があって、明日突然そこから炎が噴き出すんじゃないか、みたいな感覚。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「顔に“テスト不安”って書いてあるよ」
+            </div>
+<p>振り向くと、いつの間にか神崎ナギがグラスに水を入れて座っていた。奥の厨房では、オーナーのバルハがしっぽで鍋を器用に運びながらこちらをちらりと見てニヤリと笑っている。</p>
+<p>ユイは観念して、ノートをぐるっと回してナギのほうに押し出した。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「今日、ペアワイズで組合せはかなり削れて……決定表も一応作って……境界っぽいところも、前に怒られたやつは踏み直して。でも、どこまでやれてるのか、全然わかんなくて。“まだ足りない気がする”って感覚だけが、ずっと残っちゃうんです」
+            </div>
+<p>ナギはノートをぱらぱらとめくり、ページの端に描かれた小さな丸や矢印を眺めながら、ふっと目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。いい顔してるよ、ユイ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「えっ、今にも泣きそうなんですけど」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「『ここまではやった。でも、どこまで守れてるんだろう？』って、カバレッジを気にし始めた目だもん」
+            </div>
+<p>ナギはナプキンの裏に小さな七色の弧を描いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「テストで『どのくらい試せてる？』を考えるとき、私はよく虹を描く。網羅したいものを色で塗っていくイメージね」
+            </div>
+<p>弧には「機能」「組合せ」「境界」「役割」「時間帯」「デバイス」などのラベルが並ぶ。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「全部を同じ濃さで塗るのは無理。だから、今日みたいに組合せはペアワイズで薄めに、でも境界と役割は濃く塗る、とか、塗り分けを決める」
+            </div>
+<p>ユイは虹の欠けたところを指でなぞった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「私、時間帯とデバイス、ほぼ塗ってないかも……」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「じゃあ次の改善ポイントが見えたね。『虹のこの色は薄いけど、今回は許容する』『この色だけは濃く塗る』って自分で決めると、不安はだいぶ形になるよ」
+            </div>
+<p>ユイはノートの隅に、小さな虹を描き写す。「機能：濃」「境界：濃」「組合せ：中」「役割：中」「時間帯：薄」「デバイス：薄」。</p>
+<p>バルハが厨房から顔を出し、鍋をかき混ぜながら笑った。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「虹、いいじゃない。うちの店も七色に光ってるんだし」
+            </div>
+<p>ユイはふっと笑う。不安は消えない。けれど、どの色をどこまで塗ったかを自分で説明できると思うと、胸のざわつきが少しだけ静まった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「次のイベントでは、時間帯の色もちゃんと塗ってみます」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。虹は一晩じゃ完成しないからね。少しずつ重ねていこう」
+            </div>
+<p>虹色のメモをポケットにしまいながら、ユイは静かなフロアを見渡した。テストは終わらない。それでも、どの色を濃く塗るかを選べる自分が、少しだけ誇らしかった。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep08</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep09/index.html
+++ b/generated/magazine/posts/ep09/index.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP09: ログは、システムからのラブレター | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="沈黙のデータが、ふいに語りはじめる。気づきはそこにある。">
+    <meta property="og:title" content="EP09: ログは、システムからのラブレター">
+    <meta property="og:description" content="沈黙のデータが、ふいに語りはじめる。気づきはそこにある。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep09">
+  <article class="sg-article" data-template="detail" data-content-id="ep09" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP09: ログは、システムからのラブレター</h1>
+      <p class="sg-lede">沈黙のデータが、ふいに語りはじめる。気づきはそこにある。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>新人テストエンジニア・結城ユイ（源氏名ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれながら、サキュバスメイド喫茶《∞（インフィニティ）》で世界 <span class="katex">W</span> の見方を学び続けている。客を同値クラスで捉え、境界値で踏み込み方を調整し、決定表で分岐を地図にし、状態遷移図で関係の揺れを眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹で自分のテストの濃淡を確かめるようになった。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>金曜の夜。《∞》は社畜救済ナイトとハーフアニバーサリー割引が重なり、開店直後から満席だった。</p>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「ユイリアさーん！　会計が通りません！」
+            </div>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「ドリンクだけ永遠に『処理中』です！」
+            </div>
+<div class="dialogue">
+<span class="character-name">メイドたち</span>
+                「レシート、古代語みたいになってるんですけど！」
+            </div>
+<p>新人メイドたちの悲鳴が一斉に飛んできて、ユイは固まる。頭の中で IF 文が暴走し始めたそのとき、カウンターの端から落ち着いた声がした。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「深呼吸、ユイリア。まずは、世界で何が起きてるかを見よっか」
+            </div>
+<p>ナギはバックヤードの端末を指さす。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギ先輩！？」「カズマくんが『今日は地獄だ』って騒いでたからね」
+            </div>
+<p>画面にはタイムスタンプやエラーコードの並んだログがびっしりと流れていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「うっ……ログって、やっぱり怖いです。怒られてるみたいで」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「怒ってるんじゃなくて、“苦しかった場所”を教えてくれてるだけだよ」
+            </div>
+<p>ナギはスクロールを止め、一行を指でなぞる。</p>
+<pre>WARN discount-rule-07 condition overflow for pattern[社畜救済×ハーフアニバ×深夜延長]</pre>
+<p>それはユイが決定表の空いていたマスに勢いで書き足した新コンボだった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「WARN は『ここ、ちょっとしんどかったよ』っていう弱めの悲鳴。世界 <span class="katex">W</span> から届いた、“ここが痛い”っていうラブレターだね」
+            </div>
+<p>客席を振り返ると、奥のボックス席でスーツ姿のグループが会計を待ちながら伝票の山とにらめっこしていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「このコンボのときだけ、料金計算を何度もやり直してる。だから端末がタイムアウトして、レシートもぐちゃぐちゃになる」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「じゃあ、このコンボだけ一時的に止めれば……？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そう。世界 <span class="katex">W</span> 全体を止める必要はない。“痛がってる同値クラス”だけをそっと保護する」
+            </div>
+<p>二人でオーナーのバルハに状況を説明すると、バルハは肩をすくめて笑った。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「OK。そのコンボは今夜だけ封印ね。『悪魔的負荷のため、社畜救済とハーフアニバの同時適用は停止中』ってポップ書いとくわ」
+            </div>
+<p>対応後、ラッシュは戻ってきたが、端末の悲鳴はぴたりと止んだ。</p>
+<div class="scene-break">＊　＊　＊</div>
+<p>営業終了後。ユイはバックヤードで改めてログを眺める。イベントの時間帯、席の組み合わせ、特定のメニュー。赤い文字が集まる場所は、今日の世界 <span class="katex">W</span> が痛んでいた場所そのものだ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ラブレター、ですね。本当に」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「でしょ？　『ここ、もっと優しくして』『この組合せ、重すぎる』って、システムがちゃんと教えてくれる」
+            </div>
+<p>ユイはラブレターを丁寧にノートへ貼り付け、次のテスト計画のページに矢印を引いた。ログの文字列が、少しだけ温かく見えた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep09</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep10/index.html
+++ b/generated/magazine/posts/ep10/index.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP10: 魔導書と職人の手、Fθと G | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="便利さの向こう側。最後に“触る一点”を決めるのは誰？">
+    <meta property="og:title" content="EP10: 魔導書と職人の手、Fθと G">
+    <meta property="og:description" content="便利さの向こう側。最後に“触る一点”を決めるのは誰？">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep10">
+  <article class="sg-article" data-template="detail" data-content-id="ep10" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP10: 魔導書と職人の手、Fθと G</h1>
+      <p class="sg-lede">便利さの向こう側。最後に“触る一点”を決めるのは誰？</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》の新人テストエンジニア・結城ユイ（ユイリア）は、伝説のテストアーキテクト神崎ナギに導かれ、世界 <span class="katex">W</span> の見方を育ててきた。客を同値クラスでまとめ、心の境界値にぶつかり、決定表で分岐を地図にし、状態遷移図で関係を眺め、ペアワイズで筋の良い組合せを選び、カバレッジの虹でテストの濃淡を確かめ、ログを「システムからのラブレター」と読むようになった。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>営業後のカウンターで、バルハが分厚い黒い本を置いた。表紙には銀色で《汎用魔導書 Fθ》とある。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ねえユイリア。“頭数勝負”じゃないやり方、試してみない？」
+            </div>
+<p>不安を飲み込みつつ、ユイはナギと三人で実験することになった。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「この前の社畜救済イベントの仕様とログ、流してみようか」
+            </div>
+<p>ナギが端末から魔導書へ魔力ケーブルを繋ぐと、黒いページが勝手にめくれ、光る文字が浮かぶ。</p>
+<pre>&lt;テスト案候補：
+ 1. 残業時間 0〜100 時間の全範囲で割引率が正しいこと
+ 2. 客の職種ごとに専用セリフが表示されること
+ 3. ログイン失敗時に励ましメッセージが表示されること
+ ……（以下 120 件）&gt;</pre>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ひゃ、百二十件！？」
+            </div>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「ね、量では私たち敵わないでしょ？」
+            </div>
+<p>ユイは喉を鳴らす。魔導書が吐き出すテスト案の量と速度は、今まで自分が夜通しひねり出してきたものを軽々と超えていた。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……じゃあ、私の仕事、なくなっちゃうんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「そうはならないよ。Fθは“材料”はたくさんくれる。でも、それをどう選ぶか、どう世界 <span class="katex">W</span> に合わせて磨くかは、職人の手がいる」
+            </div>
+<p>ナギは手元の紙に小さな記号を書いた。「Fθ → G」。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Fθ は魔導書の提案関数。G は私たちが持つ“現場の眼”。Fθ(G(x)) で初めて、店のテストケースになる」
+            </div>
+<p>ユイは試しに、魔導書の案から今日のイベントに関係しそうなものを三つ選び、決定表や状態遷移図と突き合わせていく。バルハはキッチン側の制約やコストを口にし、ユイはカバレッジの虹を思い浮かべながら優先度を塗り分けていった。</p>
+<p>深夜、テーブルには魔導書からの 120 件と、ユイが選んだ 12 件が並ぶ。後者は丸や矢印や色で塗られ、具体的な手順が添えられていた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「同じ“テスト案”でも、仕上がりが全然違うね。後ろの 12 件は、店の匂いがする」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「Fθ がくれた素材を、G で整える。それが職人の手仕事」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……よかった。じゃあ、私、まだここでやることあるんだ」
+            </div>
+<p>魔導書は便利だ。それでも、店の匂いと温度を知っている手が要る。その手を、もっと確かにしていきたい。ユイはそう思いながら、魔導書の光るページをそっと閉じた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep10</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep11/index.html
+++ b/generated/magazine/posts/ep11/index.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP11: 先輩も、迷っていた | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="憧れの背中にも、消しては書いた線がある。その温度を知る。">
+    <meta property="og:title" content="EP11: 先輩も、迷っていた">
+    <meta property="og:description" content="憧れの背中にも、消しては書いた線がある。その温度を知る。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep11">
+  <article class="sg-article" data-template="detail" data-content-id="ep11" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP11: 先輩も、迷っていた</h1>
+      <p class="sg-lede">憧れの背中にも、消しては書いた線がある。その温度を知る。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞》の新人テストエンジニア・ユイ（ユイリア）は、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という神崎ナギの言葉に導かれ、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジの虹、ログ解析、そして魔導書 Fθ と現場写像 G といった道具を手にしてきた。いつかナギのように <span class="katex">W</span> と制約 <span class="katex">E</span> から観点 <span class="katex">S</span> を選び取りたいと願い始めている。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>閉店後の《∞》は、ネオンの名残だけがテーブルを染めていた。ユイはホワイトボードの前で固まっている。世界 <span class="katex">W</span>、制約 <span class="katex">E</span>、観点 <span class="katex">S</span>──書いたはずの図は、行き止まりの矢印と二重線で消された丸の墓場だ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「最終イベントの設計、ぜんぜん <span class="katex">G</span> が引けない……」
+            </div>
+<p>カラン、と裏口の鈴が鳴いた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「派手に迷子ってるね」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「ナギさん……！」
+            </div>
+<p>神崎ナギは、魔界ブレンドコーヒーを二つ持って現れた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「バルハから、“ユイが世界の端でフリーズしてる”って連絡きたよ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「監視社会だ……」
+            </div>
+<p>ナギはユイの隣に並び、ボードを一瞥する。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ふむ。ちゃんと <span class="katex">W</span> も <span class="katex">E</span> も <span class="katex">S</span> も書き出してる。いい迷子だ」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「どこがですか！　そこから先がぐちゃぐちゃで……。ナギさんみたいに、一本スッと <span class="katex">G</span> を引けないんです。私、相変わらず“なんでも屋のダメテストエンジニア”のままな気がして……」
+            </div>
+<p>ナギは何も言わず、くるりと背を向けた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ちょっと待ってて。昔の私を連れてくる」
+            </div>
+<div class="scene-break">＊　＊　＊</div>
+<p>しばらくして戻ってきたナギの腕には、分厚いノートが抱えられていた。角がすり切れ、コーヒーの染みが地図のように広がっている。端には小さく「テストアーキテクチャーの頭脳」と走り書きされていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これ、私がまだ“迷子のなんでも屋”だった頃のノート」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……見ていいですか」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「覚悟があるなら」
+            </div>
+<p>ユイがそっと開くと、中身は線でぐちゃぐちゃに消されたテスト案、観点が二重線で潰されたメモ、途中で放り出された決定表。今のユイのボードと瓜二つだった。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……ナギさんも、迷ってたんですね」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。迷うよ。世界 <span class="katex">W</span> を丸ごと扱おうとしたら、毎回ね。一本で <span class="katex">G</span> を引けるのは、何度も迷子になったからだと思う」
+            </div>
+<p>ナギはノートの端に描かれた薄い矢印を指さす。そこには「ここで諦めた」「ここから <span class="katex">S</span> を減らした」と小さな字が添えられていた。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「迷った跡も、仕事の一部。『ここで詰まった』『ここは捨てた』ってログを残すと、次に <span class="katex">G</span> を引くときの支えになるよ」
+            </div>
+<p>ユイは自分のボードに「ここで迷った」「ここは捨てた」と赤ペンで書き込んだ。線で塗りつぶされた丸が、少しだけ愛おしく見えてくる。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私も、この迷子ログ、残しておきます」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。そのログを渡せる後輩が来たら、ユイはもう“魅力ある大先輩”になってるよ」
+            </div>
+<p>ネオンの残光がホワイトボードを照らす。迷路のような線と赤いメモが、少しずつ「道」に見えてきた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep11</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/magazine/posts/ep12/index.html
+++ b/generated/magazine/posts/ep12/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <title>EP12: 次の子に渡す、G の地図 | Hina Generated Experience</title>
+    <link rel="stylesheet" href="../../assets/tokens.css">
+    <link rel="stylesheet" href="../../assets/base.css">
+    <link rel="stylesheet" href="../../assets/components.css">
+    <link rel="stylesheet" href="../../../shared/switcher.css">
+    <meta name="description" content="最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。">
+    <meta property="og:title" content="EP12: 次の子に渡す、G の地図">
+    <meta property="og:description" content="最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。">
+    <script src="../../../shared/features/init-features.js" defer></script>
+    <script src="../../../shared/switcher.js" defer></script>
+  </head>
+  <body class="sg-surface" data-experience="magazine" data-template="detail" data-routes-href="../../../routes.json" data-content-id="ep12">
+  <article class="sg-article" data-template="detail" data-content-id="ep12" data-routes-href="../../../routes.json">
+    <header class="sg-header" data-tts="ignore">
+      <p class="sg-eyebrow">Detail</p>
+      <h1>EP12: 次の子に渡す、G の地図</h1>
+      <p class="sg-lede">最後の夜、ユイは“自分の言葉”を探す。受け取るのは、あなた。</p>
+      <nav class="sg-nav">
+        <ul class="sg-nav-links">
+        <li><a href="../../">ホーム</a></li>
+        <li><a href="../../list/">一覧</a></li>
+        <li><a href="../../#about">紹介</a></li>
+        <li><a href="../../#episodes">12話</a></li>
+        <li><a href="../../#characters">キャラクター</a></li>
+      </ul>
+      <button
+        type="button"
+        class="view-switcher"
+        data-action="switch-experience"
+      >
+        体験を切り替える
+      </button>
+      </nav>
+    </header>
+    <section class="sg-main" data-content-body>
+      <div class="section">
+<h2>◆前回までのあらすじ</h2>
+<p>サキュバスメイド喫茶《∞（インフィニティ）》で新人テストエンジニアとして働き始めたユイリア。場当たり運営でオープン初夜を炎上させかけた彼女は、伝説のテストアーキテクト神崎ナギと出会い、「テストは世界 <span class="katex">W</span> の見方を設計する仕事」という言葉に導かれる。仕様書の外に広がる世界 <span class="katex">W</span> と制約 <span class="katex">E</span> を意識し、同値クラス、境界値分析、決定表、状態遷移図、ペアワイズ、カバレッジ、ログ解析、魔導書 Fθ と写像 <span class="katex">G</span> などの道具を手にしてきた。</p>
+<p>最終イベント設計では再び迷子になるが、ナギのボロボロの昔のノートに自分と同じぐちゃぐちゃの図を見つけ、憧れの先輩もかつては迷っていたと知る。ユイは「自分もあの背中に向かって歩いていい」と胸の奥でそっと決めた。</p>
+</div>
+<div class="section">
+<h2>◆本編</h2>
+<p>最終イベントの朝、まだ客のいない《∞》は、壁一面のホワイトボードで白く光っていた。同値クラスで色分けされた客の分類、境界値の付箋、決定表、状態遷移図、ログのグラフ。十一話分の失敗と発見が層になって張りついている。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……すごいカオス。でも、今日はここから一本の線を引く日」
+            </div>
+<p>ユイはマーカーを握り、中央に縦線を引いた。その左に大きく「<span class="katex">W</span>」。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「この店の世界 <span class="katex">W</span> は、ここに来る人たちの人生全部」
+            </div>
+<p>右側には「<span class="katex">E</span>」。営業時間、スタッフの体力、厨房のキャパシティ。制約が並ぶ。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「今日守りたい観点 <span class="katex">S</span> は、“常連も初見さんも『ここが居場所だ』と思えるか”」
+            </div>
+<p>矢印が伸び、同値クラスが丸で囲まれ、境界値のメモが配置される。ペアワイズで選んだ組合せ、虹で塗ったカバレッジの濃淡、ログから拾った痛みのポイント。全部が一本の地図に重なる。</p>
+<p>ドアが開き、オーナーのバルハと神崎ナギが入ってくる。壁いっぱいの図を見て、ふたりは目を細めた。</p>
+<div class="dialogue">
+<span class="character-name">バルハ</span>
+                「おお……店の歴史が壁に詰まってる」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「ユイの <span class="katex">G</span> だね。どう引いたの？」
+            </div>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「全部はできないから、今日の <span class="katex">S</span> に合わせて濃く塗る色を決めました。失敗ログも残しておきたくて」
+            </div>
+<p>ナギはうなずき、ポケットから小さな空ノートを取り出した。</p>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「これ、次に入る新人用に。今日の地図、写しておいて」
+            </div>
+<p>ユイは驚きながらノートを受け取る。白紙のページがまぶしい。</p>
+<div class="dialogue">
+<span class="character-name">ユイリア</span>
+                「……私が、書いていいんですか？」
+            </div>
+<div class="dialogue">
+<span class="character-name">神崎ナギ</span>
+                「うん。君が迷って見つけた道は、きっと次の子の助けになる」
+            </div>
+<p>開店のベルが鳴る。ユイはマーカーを置き、胸ポケットに小さなノートをしまった。G の地図は、もう自分だけのものじゃない。次の誰かに渡すためのものだ。</p>
+<p>「いらっしゃいませ！」――新人の声が、まぶしいほど真っ直ぐに響いた。</p>
+</div>
+    </section>
+    <footer class="sg-meta">
+      <p>コンテンツ ID: ep12</p>
+    </footer>
+  </article>
+  </body>
+</html>
+<!-- sitegen build: ts=2025-12-30T09:24:01.652280+00:00 sha=650ad45f381242f987b751219c21b53a1069fec8 items=20 -->

--- a/generated/routes.json
+++ b/generated/routes.json
@@ -1,6 +1,7 @@
 {
   "order": [
     "ruri",
+    "blog",
     "hina",
     "immersive",
     "magazine"
@@ -12,12 +13,48 @@
         "ep01": "../story1.html"
       }
     },
+    "blog": {
+      "home": "../index.html",
+      "content": {
+        "about-世界観": "../posts/about-世界観.html",
+        "about-読みどころ": "../posts/about-読みどころ.html",
+        "character-サキュバスメイド喫茶∞": "../posts/character-サキュバスメイド喫茶∞.html",
+        "character-バルハ": "../posts/character-バルハ.html",
+        "character-神崎ナギ": "../posts/character-神崎ナギ.html",
+        "character-結城ユイ": "../posts/character-結城ユイ.html",
+        "ep01": "../posts/ep01.html",
+        "ep02": "../posts/ep02.html",
+        "ep03": "../posts/ep03.html",
+        "ep04": "../posts/ep04.html",
+        "ep05": "../posts/ep05.html",
+        "ep06": "../posts/ep06.html",
+        "ep07": "../posts/ep07.html",
+        "ep08": "../posts/ep08.html",
+        "ep09": "../posts/ep09.html",
+        "ep10": "../posts/ep10.html",
+        "ep11": "../posts/ep11.html",
+        "ep12": "../posts/ep12.html",
+        "site-meta": "../posts/site-meta.html",
+        "welcome-post": "../posts/welcome-post.html"
+      }
+    },
     "hina": {
       "home": "hina/",
       "list": "hina/list/",
       "content": {
         "ep01": "hina/posts/ep01/",
-        "welcome-post": "hina/posts/welcome-post/"
+        "ep02": "hina/posts/ep02/",
+        "ep03": "hina/posts/ep03/",
+        "ep04": "hina/posts/ep04/",
+        "ep05": "hina/posts/ep05/",
+        "ep06": "hina/posts/ep06/",
+        "ep07": "hina/posts/ep07/",
+        "ep08": "hina/posts/ep08/",
+        "ep09": "hina/posts/ep09/",
+        "ep10": "hina/posts/ep10/",
+        "ep11": "hina/posts/ep11/",
+        "ep12": "hina/posts/ep12/",
+        "site-meta": "hina/posts/site-meta/"
       }
     },
     "immersive": {
@@ -25,7 +62,18 @@
       "list": "immersive/list/",
       "content": {
         "ep01": "immersive/posts/ep01/",
-        "welcome-post": "immersive/posts/welcome-post/"
+        "ep02": "immersive/posts/ep02/",
+        "ep03": "immersive/posts/ep03/",
+        "ep04": "immersive/posts/ep04/",
+        "ep05": "immersive/posts/ep05/",
+        "ep06": "immersive/posts/ep06/",
+        "ep07": "immersive/posts/ep07/",
+        "ep08": "immersive/posts/ep08/",
+        "ep09": "immersive/posts/ep09/",
+        "ep10": "immersive/posts/ep10/",
+        "ep11": "immersive/posts/ep11/",
+        "ep12": "immersive/posts/ep12/",
+        "site-meta": "immersive/posts/site-meta/"
       }
     },
     "magazine": {
@@ -33,7 +81,18 @@
       "list": "magazine/list/",
       "content": {
         "ep01": "magazine/posts/ep01/",
-        "welcome-post": "magazine/posts/welcome-post/"
+        "ep02": "magazine/posts/ep02/",
+        "ep03": "magazine/posts/ep03/",
+        "ep04": "magazine/posts/ep04/",
+        "ep05": "magazine/posts/ep05/",
+        "ep06": "magazine/posts/ep06/",
+        "ep07": "magazine/posts/ep07/",
+        "ep08": "magazine/posts/ep08/",
+        "ep09": "magazine/posts/ep09/",
+        "ep10": "magazine/posts/ep10/",
+        "ep11": "magazine/posts/ep11/",
+        "ep12": "magazine/posts/ep12/",
+        "site-meta": "magazine/posts/site-meta/"
       }
     }
   }

--- a/scripts/verify_fullspec_generated.py
+++ b/scripts/verify_fullspec_generated.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Lightweight check to ensure generated home pages render full-spec sections."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+EXPECTED_EXPERIENCES = ("hina", "immersive", "magazine")
+EXPECTED_EPISODE_COUNT = 12
+
+
+def _fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+def _load_html(path: Path) -> BeautifulSoup:
+    try:
+        return BeautifulSoup(path.read_text(encoding="utf-8"), "html.parser")
+    except FileNotFoundError as exc:
+        _fail(f"Missing generated file: {path}")  # pragma: no cover
+        raise exc
+
+
+def _validate_experience(out_dir: Path, experience: str) -> None:
+    index_path = out_dir / experience / "index.html"
+    soup = _load_html(index_path)
+
+    for section_id in ("episodes", "characters"):
+        if not soup.select_one(f"#{section_id}"):
+            _fail(f"[{experience}] section with id='{section_id}' not found in {index_path}")
+
+    episode_nodes = soup.select("#episodes [data-episode-id]")
+    if not episode_nodes:
+        episode_nodes = soup.select("#episodes li")
+
+    if len(episode_nodes) < EXPECTED_EPISODE_COUNT:
+        _fail(
+            f"[{experience}] expected {EXPECTED_EPISODE_COUNT} episodes, "
+            f"found {len(episode_nodes)} in {index_path}"
+        )
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) != 2:
+        _fail("Usage: python scripts/verify_fullspec_generated.py <OUT_DIR>")
+
+    out_dir = Path(argv[1])
+    if not out_dir.exists():
+        _fail(f"Output directory not found: {out_dir}")
+
+    for experience in EXPECTED_EXPERIENCES:
+        _validate_experience(out_dir, experience)
+
+    print(f"OK: verified {len(EXPECTED_EXPERIENCES)} experiences in {out_dir}")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
### Summary
- generated 体験の home がカード1枚のみだった問題を修正し、フルスペック構造を生成するようにした
- sitegen buildinfo を出して、Pages が最新生成物を見ているか即確認可能にした

### Changes
- build_home の context を拡張（episodes/about/characters/siteMeta）
- 各体験テンプレをフルスペック対応（about/episodes/characters）
- buildinfo 出力と HTML コメント埋め込み
- スモーク検証スクリプト追加

### Test
- `python -m sitegen validate --experiences config/experiences.yaml --content content/posts`
- `python -m sitegen build --experiences config/experiences.yaml --src experience_src --out generated --content content/posts --all`
- `python scripts/verify_fullspec_generated.py generated`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69539896066083339a87f6a09c20c7ce)