### PR TITLE
Refactor routing to single site plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 時間や気持ち、環境などの流れを言葉にしたものの集合
 
 ## sitegen の概要
-`python -m sitegen`（エントリポイントは `sitegen/cli.py`）で静的サイトを生成・検証するツールセットです。生成対象は `config/experiences.yaml` に定義された各エクスペリエンスで、テンプレートは `experience_src/<key>` 配下、コンテンツは `content/posts/*.json` を参照します。
+`python -m sitegen`（エントリポイントは `sitegen/cli.py`）で静的サイトを生成・検証するツールセットです。生成対象は `config/experiences.yaml` に定義された各エクスペリエンスで、テンプレートは `experience_src/<key>` 配下、コンテンツは `content/posts/*.json` を参照します。ルーティングは `sitegen/routing.SiteRouter` が単一のサイトプランとして組み立て、ビルド・`routes.json`・テンプレートリンクすべてが同じ PageSpec から決定されます。
 
 ## sitegen 関数（CLI）の入出力と型
 - インプット型
@@ -16,15 +16,15 @@
   - 生成対象（kind が `generated`）ごとに `build_home`／`build_list`／`build_detail` が Jinja2（`StrictUndefined` で欠損を検出）で HTML を描画し、アセットをコピー。
   - `--shared` または `--all` 指定時は共有初期化スクリプトを生成。`--all` 指定時は `routes.json`、エクスペリエンス切替用 CSS/JS、レガシー HTML へのパッチも作成。
 - アウトプット型
-  - `generated/<experience.output_dir>/` 以下の HTML（`index.html`, `list/index.html`, `posts/<slug>/index.html`）。
+  - `generated/<experience.output_dir>/` 以下の HTML（`index.html`, `list/index.html`, `posts/<slug>/index.html`）。各詳細ページには後方互換用の `.html` リダイレクトも生成されます。
   - 共有アセット: `generated/shared/switcher.{js,css}` と `generated/shared/features/init-features.js`（フラグ次第）。
   - ルーティング定義: `generated/routes.json`。
   - レガシー補助: 既存 `index.html`/`story1.html` を書き換えたファイル（`--all` 時）。
 
 ## 処理フロー（sitegen build）
 1. `experiences.yaml` とコンテンツ JSON をロードし、`kind == "generated"` の体験のみを対象にする。
-2. `BuildContext` に基づきテンプレート検索パスと出力パスを決定し、テンプレートごとにホーム・一覧・詳細ページを描画。
-3. 必要に応じて `shared` アセットや `routes.json` を生成し、レガシーページにスイッチャーボタンとデータ属性を付与。
+2. `BuildContext` と `SiteRouter` が PageSpec を列挙し、テンプレート検索パス・出力パス・URL を一括で決定する。PageSpec をもとにホーム・一覧・詳細ページを描画し、必要に応じて `.html` エイリアスを自動生成。
+3. 必要に応じて `shared` アセットや `routes.json` を生成し、レガシーページにスイッチャーボタンとデータ属性を付与。`routes.json` も SiteRouter のサイトプランから直に書き出されるため、HTML・実ファイル・マニフェストの不整合を防ぐ。
 
 ## 使い方
 ### 前提インストール

--- a/sitegen/routes_gen.py
+++ b/sitegen/routes_gen.py
@@ -3,90 +3,21 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Iterable
 
-from .models import ContentItem, ExperienceSpec
+from .routing import SiteRouter
 from .util_fs import ensure_dir
 
 
-def _detail_href(experience: ExperienceSpec, slug: str) -> str:
-    """Build a detail href by substituting the slug into the pattern."""
-
-    return experience.route_patterns.detail.replace("{slug}", slug)
-
-
-def _pretty_href(target: Path, base: Path, *, collapse_index: bool = True) -> str:
-    """Return a relative href and optionally collapse index.html into a trailing slash."""
-
-    href = Path(os.path.relpath(target, base)).as_posix()
-    if collapse_index and href.endswith("index.html"):
-        href = href[: -len("index.html")]
-        if not href:
-            return "./"
-        if not href.endswith("/"):
-            href += "/"
-    return href
-
-
-def build_routes_payload(
-    experiences: list[ExperienceSpec], items: list[ContentItem], *, out_root: Path, routes_filename: str = "routes.json"
-) -> dict:
+def build_routes_payload(router: SiteRouter) -> dict:
     """Create a merged payload describing available routes per experience.
 
-    The resulting structure is optimized for the client-side view switcher:
-    {
-      "order": ["ruri", "hina"],
-      "routes": {
-        "ruri": {"home": "../index.html", "content": {"ep01": "../story1.html"}},
-        "hina": {"home": "hina/", "content": {"ep01": "hina/ep01/"}}
-      }
-    }
+    SiteRouter is the single source of truth for route resolution; this wrapper
+    exists for backward compatibility with previous call sites.
     """
 
-    order = [exp.key for exp in experiences]
-    routes: dict[str, dict] = {}
-    base_dir = (out_root / routes_filename).parent
-
-    for experience in experiences:
-        targeted = [item for item in items if item.experience == experience.key]
-        if not targeted:
-            targeted = items
-
-        if experience.kind == "legacy":
-            home_source = experience.home or experience.route_patterns.home
-            home = Path(home_source)
-            content_map = {cid: Path(href) for cid, href in experience.content.items()}
-            if not content_map:
-                for item in targeted:
-                    content_map[item.content_id] = Path(_detail_href(experience, item.content_id))
-
-            routes[experience.key] = {
-                "home": _pretty_href(home, base_dir, collapse_index=False),
-                "content": {cid: _pretty_href(href, base_dir, collapse_index=False) for cid, href in content_map.items()},
-            }
-            continue
-
-        output_dir = Path(experience.output_dir or experience.key)
-        home_path = out_root / output_dir / "index.html"
-        list_path = out_root / output_dir / "list" / "index.html"
-
-        content_map: dict[str, str] = {}
-        for item in targeted:
-            if item.page_type in {"about", "character"}:
-                continue
-            slug = item.content_id
-            detail_path = out_root / output_dir / "posts" / slug / "index.html"
-            content_map[slug] = _pretty_href(detail_path, base_dir)
-
-        routes[experience.key] = {
-            "home": _pretty_href(home_path, base_dir),
-            "list": _pretty_href(list_path, base_dir),
-            "content": content_map,
-        }
-
-    return {"order": order, "routes": routes}
+    return router.routes_payload()
 
 
 def write_routes_payload(payload: dict, targets: Iterable[Path]) -> list[Path]:

--- a/sitegen/routing.py
+++ b/sitegen/routing.py
@@ -1,0 +1,280 @@
+"""Routing helpers and build-time site plan management."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
+
+from .models import ContentItem, ExperienceSpec
+from .util_fs import ensure_dir
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .build import BuildContext
+
+
+def relative_href(target: Path, base: Path) -> str:
+    """Return a POSIX-style relative href from base to target."""
+
+    return Path(os.path.relpath(target, base)).as_posix()
+
+
+def relative_route(target: Path, base: Path, *, collapse_index: bool = True) -> str:
+    """Return a pretty href to the target, collapsing index.html to a slash."""
+
+    href = relative_href(target, base)
+    if collapse_index and href.endswith("index.html"):
+        href = href[: -len("index.html")]
+        if not href:
+            return "./"
+        if not href.endswith("/"):
+            href += "/"
+    return href
+
+
+@dataclass
+class PageAlias:
+    """Alias pointing to a canonical page."""
+
+    url_path: str
+    out_file: Path
+    redirect_to: str
+
+
+@dataclass
+class PageSpec:
+    """Description of a page to render."""
+
+    experience: ExperienceSpec
+    page_type: str
+    template: str
+    url_path: str
+    out_file: Path
+    content: ContentItem | None = None
+    aliases: list[PageAlias] = field(default_factory=list)
+
+    def href_from(self, base: Path, *, collapse_index: bool = True) -> str:
+        return relative_route(self.out_file, base, collapse_index=collapse_index)
+
+
+class SiteRouter:
+    """Single source of truth for page specs and route payloads."""
+
+    def __init__(
+        self,
+        ctx: "BuildContext",
+        experiences: list[ExperienceSpec],
+        items: list[ContentItem],
+    ) -> None:
+        self.ctx = ctx
+        self.experiences = experiences
+        self.items = items
+        self.pages: list[PageSpec] = []
+        self.aliases: list[PageAlias] = []
+        self._home: Dict[str, PageSpec] = {}
+        self._list: Dict[str, PageSpec] = {}
+        self._content: Dict[str, Dict[str, PageSpec]] = {}
+        self._legacy_routes: Dict[str, Dict[str, str]] = {}
+        self._build()
+
+    def _targeted_items(self, experience: ExperienceSpec) -> list[ContentItem]:
+        targeted = [item for item in self.items if item.experience == experience.key]
+        if experience.kind == "generated" and not targeted:
+            return list(self.items)
+        return targeted
+
+    def _canonical_url(self, out_file: Path) -> str:
+        return relative_route(out_file, self.ctx.out_root)
+
+    def _register_page(
+        self,
+        *,
+        experience: ExperienceSpec,
+        page_type: str,
+        template: str,
+        out_file: Path,
+        content: ContentItem | None = None,
+        aliases: Optional[list[PageAlias]] = None,
+    ) -> PageSpec:
+        url_path = self._canonical_url(out_file)
+        spec = PageSpec(
+            experience=experience,
+            page_type=page_type,
+            template=template,
+            url_path=url_path,
+            out_file=out_file,
+            content=content,
+            aliases=aliases or [],
+        )
+        self.pages.append(spec)
+        if page_type == "home":
+            self._home[experience.key] = spec
+        elif page_type == "list":
+            self._list[experience.key] = spec
+        elif content:
+            self._content.setdefault(experience.key, {})[content.content_id] = spec
+        return spec
+
+    def _detail_template_name(self, experience: ExperienceSpec, page_type: str) -> str:
+        candidate = f"detail_{page_type}.jinja"
+        if (self.ctx.templates_dir(experience) / candidate).exists():
+            return candidate
+        return "detail.jinja"
+
+    def _build_generated(self, experience: ExperienceSpec) -> None:
+        output_dir = self.ctx.output_dir(experience)
+        home_out = output_dir / "index.html"
+        list_out = output_dir / "list" / "index.html"
+        self._register_page(
+            experience=experience, page_type="home", template="home.jinja", out_file=home_out
+        )
+        self._register_page(
+            experience=experience, page_type="list", template="list.jinja", out_file=list_out
+        )
+
+        targeted = self._targeted_items(experience)
+        for item in targeted:
+            detail_dir = output_dir / "posts" / item.content_id
+            detail_out = detail_dir / "index.html"
+            alias_out = output_dir / "posts" / f"{item.content_id}.html"
+            alias = PageAlias(
+                url_path=relative_route(alias_out, self.ctx.out_root, collapse_index=False),
+                out_file=alias_out,
+                redirect_to=relative_route(detail_out, self.ctx.out_root),
+            )
+            spec = self._register_page(
+                experience=experience,
+                page_type=item.page_type,
+                template=self._detail_template_name(experience, item.page_type),
+                out_file=detail_out,
+                content=item,
+                aliases=[alias],
+            )
+            self.aliases.append(alias)
+            self._content.setdefault(experience.key, {})[item.content_id] = spec
+
+    def _register_legacy(self, experience: ExperienceSpec) -> None:
+        base_dir = self.ctx.out_root
+        payload: dict[str, str] = {}
+
+        def _resolve_target(href: str) -> Path | None:
+            raw = Path(href)
+            candidates = []
+            if raw.is_absolute():
+                candidates.append(raw)
+            else:
+                candidates.append(raw.resolve())
+                candidates.append((base_dir / href).resolve())
+            for candidate in candidates:
+                if candidate.exists():
+                    return candidate
+            return None
+
+        home_href = experience.home or experience.route_patterns.home
+        home_path = _resolve_target(home_href)
+        if home_path:
+            payload["home"] = relative_route(home_path, base_dir, collapse_index=True)
+
+        list_href = experience.route_patterns.list
+        list_path = _resolve_target(list_href)
+        if list_path:
+            payload["list"] = relative_route(list_path, base_dir, collapse_index=True)
+
+        content_map: dict[str, str] = {}
+        for cid, href in (experience.content or {}).items():
+            target = _resolve_target(href)
+            if target and target.exists():
+                content_map[cid] = relative_route(target, base_dir, collapse_index=False)
+        if content_map:
+            payload["content"] = content_map
+        if payload:
+            self._legacy_routes[experience.key] = payload
+
+    def _build(self) -> None:
+        for experience in self.experiences:
+            if experience.kind == "generated":
+                self._build_generated(experience)
+            else:
+                self._register_legacy(experience)
+
+    def home(self, experience_key: str) -> Optional[PageSpec]:
+        return self._home.get(experience_key)
+
+    def list_page(self, experience_key: str) -> Optional[PageSpec]:
+        return self._list.get(experience_key)
+
+    def content_page(self, experience_key: str, content_id: str) -> Optional[PageSpec]:
+        return self._content.get(experience_key, {}).get(content_id)
+
+    def content_ids(self, experience_key: str) -> set[str]:
+        return set(self._content.get(experience_key, {}))
+
+    def detail_template_for(self, experience: ExperienceSpec, page_type: str) -> str:
+        return self._detail_template_name(experience, page_type)
+
+    def href_for_page(self, spec: PageSpec | None, base: Path) -> str:
+        if not spec:
+            return ""
+        return spec.href_from(base)
+
+    def routes_payload(self) -> dict:
+        order = [exp.key for exp in self.experiences]
+        routes: dict[str, dict] = {}
+        for exp in self.experiences:
+            payload: dict[str, object] = {}
+            home_spec = self.home(exp.key)
+            list_spec = self.list_page(exp.key)
+            if home_spec:
+                payload["home"] = home_spec.url_path
+            if list_spec:
+                payload["list"] = list_spec.url_path
+
+            content_routes: dict[str, str] = {}
+            content_aliases: dict[str, list[str]] = {}
+            for slug, spec in sorted(self._content.get(exp.key, {}).items()):
+                content_routes[slug] = spec.url_path
+                if spec.aliases:
+                    content_aliases[slug] = [alias.url_path for alias in spec.aliases]
+            if content_routes:
+                payload["content"] = content_routes
+            if content_aliases:
+                payload["contentAliases"] = content_aliases
+            if exp.key in self._legacy_routes:
+                payload.update(self._legacy_routes[exp.key])
+            routes[exp.key] = payload
+        return {"order": order, "routes": routes}
+
+    def render_aliases(self) -> list[Path]:
+        """Render redirect stubs for alias routes."""
+
+        written: list[Path] = []
+        for spec in self.pages:
+            for alias in spec.aliases:
+                ensure_dir(alias.out_file.parent)
+                redirect_href = relative_route(spec.out_file, alias.out_file.parent)
+                html = "\n".join(
+                    [
+                        "<!doctype html>",
+                        '<html lang="ja">',
+                        "  <head>",
+                        '    <meta charset="utf-8">',
+                        f'    <meta http-equiv="refresh" content="0; url={redirect_href}">',
+                        f'    <link rel="canonical" href="{redirect_href}">',
+                        "    <title>Redirecting…</title>",
+                        "  </head>",
+                        "  <body>",
+                        f'    <p>Redirecting to <a href="{redirect_href}">{redirect_href}</a></p>',
+                        "  </body>",
+                        "</html>",
+                    ]
+                )
+                alias.out_file.write_text(html, encoding="utf-8")
+                written.append(alias.out_file)
+        return written
+
+    def pages_for_experience(self, experience_key: str) -> list[PageSpec]:
+        return [page for page in self.pages if page.experience.key == experience_key]
+
+
+__all__ = ["PageAlias", "PageSpec", "SiteRouter", "relative_href", "relative_route"]

--- a/tests/test_routing_plan.py
+++ b/tests/test_routing_plan.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from sitegen.build import BuildContext, load_content_items
+from sitegen.models import ExperienceSpec
+from sitegen.routing import SiteRouter
+from sitegen.util_fs import ensure_dir
+
+
+def _load_experiences() -> list[ExperienceSpec]:
+    data = yaml.safe_load(Path("config/experiences.yaml").read_text(encoding="utf-8"))
+    return [ExperienceSpec.model_validate(item) for item in data]
+
+
+@pytest.fixture()
+def router(tmp_path: Path) -> SiteRouter:
+    ctx = BuildContext(src_root=Path("experience_src"), out_root=tmp_path / "generated")
+    items = load_content_items(Path("content/posts"))
+    experiences = _load_experiences()
+    return SiteRouter(ctx, experiences, items)
+
+
+def test_router_includes_all_hina_content(router: SiteRouter):
+    hina_pages = {
+        page.content.content_id
+        for page in router.pages_for_experience("hina")
+        if page.content
+    }
+    expected = {
+        item.content_id for item in load_content_items(Path("content/posts"))
+    }
+    assert expected.issubset(hina_pages)
+
+
+def test_router_renders_unicode_alias_redirect(router: SiteRouter, tmp_path: Path):
+    hina_about = router.content_page("hina", "about-世界観")
+    assert hina_about is not None
+
+    ensure_dir(hina_about.out_file.parent)
+    hina_about.out_file.write_text("<html></html>", encoding="utf-8")
+    written = router.render_aliases()
+    alias_file = tmp_path / "generated" / "hina" / "posts" / "about-世界観.html"
+    assert alias_file in written
+
+    html = alias_file.read_text(encoding="utf-8")
+    assert 'http-equiv="refresh"' in html
+    assert "about-世界観/" in html


### PR DESCRIPTION
## Summary
- introduce a SiteRouter-driven PageSpec plan that centralizes URL/output/alias decisions and feeds both rendering and routes.json
- render detail pages for all content types with router-driven nav/CTA links and generate redirect aliases for legacy .html URLs
- add routing coverage tests (including Unicode slugs) and document the unified routing model

## Testing
- `python -m pytest`
- `python -m sitegen build --experiences config/experiences.yaml --src experience_src --out generated --content content/posts --all`
- `python scripts/audit_generated_site.py --out generated --routes generated/routes.json --experiences config/experiences.yaml --content content/posts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f521ce2c8333be0395392c4ffe7d)