### PR TITLE
Add Playwright smoke tests for Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ __pycache__/
 *.pyc
 .pytest_cache/
 .ruff_cache/
+node_modules/
+artifacts/
+playwright-report/
+test-results/
+artifacts_bundle.zip

--- a/README_PLAYWRIGHT.md
+++ b/README_PLAYWRIGHT.md
@@ -1,0 +1,41 @@
+# Playwright smoke tests for GitHub Pages
+
+This repository includes a Playwright-based smoke test that captures full-page screenshots of the published GitHub Pages site.
+
+## Base URL detection order
+The `playwright.config.ts` resolves `baseURL` automatically in the following order:
+1. `BASE_URL` environment variable (respects any provided URL).
+2. `gh api repos/{owner}/{repo}/pages --jq .html_url` when the `gh` CLI and repo info are available.
+3. `CNAME` file in the repository root.
+4. Git remote `origin` (or last commit author’s noreply email) → `https://{owner}.github.io/{repo}/` (or `{owner}.github.io` if the repo matches that pattern).
+5. Fallback: `https://<repository-name>.github.io/`
+
+Trailing slashes are enforced to keep routing consistent.
+
+## Setup
+```bash
+# Install dependencies
+pnpm install
+
+# Install Playwright browsers & Linux dependencies (headless-friendly)
+pnpm run e2e:install
+```
+
+## Run the smoke test
+```bash
+pnpm run e2e   # runs: playwright test --project=chromium
+```
+
+Outputs:
+- Screenshots: `artifacts/screenshots/`
+- Test results: `artifacts/test-results/`
+- HTML report: `artifacts/playwright-report/`
+
+To bundle the artifacts for download:
+```bash
+zip -r artifacts_bundle.zip artifacts
+```
+
+### Proxy / restricted network notes
+- If `github.io` is blocked by your proxy, set `BASE_URL` to a reachable mirror before running (e.g., `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/`).
+- The config also honors `HTTP_PROXY`/`HTTPS_PROXY` and ignores certificate errors to accommodate MITM proxies.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stories",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Playwright smoke tests for the stories GitHub Pages site",
+  "scripts": {
+    "e2e": "playwright test --project=chromium",
+    "e2e:report": "playwright show-report artifacts/playwright-report",
+    "e2e:install": "pnpm exec playwright install --with-deps chromium"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.13.1",
+  "devDependencies": {
+    "@playwright/test": "^1.57.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,133 @@
+import { defineConfig, devices } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+type Repo = { owner: string; repo: string };
+
+const ensureTrailingSlash = (url: string): string => (url.endsWith('/') ? url : `${url}/`);
+
+const tryExec = (command: string): string | null => {
+  try {
+    const output = execSync(command, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    return output.length > 0 ? output : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseOwnerRepoFromRemote = (remote: string): Repo | null => {
+  const normalized = remote.trim();
+  const sshMatch = normalized.match(/git@github\.com:([^/]+)\/([^/.]+)(?:\.git)?/);
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  const httpsMatch = normalized.match(/https?:\/\/github\.com\/([^/]+)\/([^/.]+)(?:\.git)?/);
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  }
+
+  return null;
+};
+
+const parseOwnerFromEmail = (email: string): string | null => {
+  const noreply = email.match(/^(?:\d+\+)?([^@+]+)@users\.noreply\.github\.com$/i);
+  if (noreply?.[1]) return noreply[1];
+  return null;
+};
+
+const detectRepo = (): Repo | null => {
+  const envRepo = process.env.GITHUB_REPOSITORY ?? process.env.REPOSITORY;
+  if (envRepo && envRepo.includes('/')) {
+    const [owner, repo] = envRepo.split('/', 2);
+    return { owner, repo };
+  }
+
+  const remote = tryExec('git config --get remote.origin.url');
+  if (remote) {
+    const parsed = parseOwnerRepoFromRemote(remote);
+    if (parsed) return parsed;
+  }
+
+  const lastCommitEmail = tryExec('git log -1 --pretty=format:%ae');
+  const ownerFromEmail = lastCommitEmail ? parseOwnerFromEmail(lastCommitEmail) : null;
+  if (ownerFromEmail) {
+    return { owner: ownerFromEmail, repo: path.basename(process.cwd()) };
+  }
+
+  return null;
+};
+
+const detectBaseURL = (): string => {
+  const envBase = process.env.BASE_URL?.trim();
+  if (envBase) {
+    return ensureTrailingSlash(envBase);
+  }
+
+  const repo = detectRepo();
+
+  if (repo) {
+    const ghCli = tryExec('command -v gh');
+    if (ghCli) {
+      const pagesUrl = tryExec(`gh api repos/${repo.owner}/${repo.repo}/pages --jq .html_url`);
+      if (pagesUrl) {
+        return ensureTrailingSlash(pagesUrl);
+      }
+    }
+  }
+
+  const cnamePath = path.join(process.cwd(), 'CNAME');
+  if (fs.existsSync(cnamePath)) {
+    const cname = fs.readFileSync(cnamePath, 'utf-8').split('\n')[0]?.trim();
+    if (cname) {
+      const prefixed = cname.startsWith('http') ? cname : `https://${cname}`;
+      return ensureTrailingSlash(prefixed);
+    }
+  }
+
+  if (repo) {
+    if (repo.repo.toLowerCase() === `${repo.owner.toLowerCase()}.github.io`) {
+      return ensureTrailingSlash(`https://${repo.owner}.github.io/`);
+    }
+    return ensureTrailingSlash(`https://${repo.owner}.github.io/${repo.repo}/`);
+  }
+
+  const fallbackRepo = path.basename(process.cwd());
+  return ensureTrailingSlash(`https://${fallbackRepo}.github.io/`);
+};
+
+const resolvedBaseURL = detectBaseURL();
+console.log(`Playwright baseURL resolved to: ${resolvedBaseURL}`);
+
+export default defineConfig({
+  testDir: 'tests',
+  timeout: 120 * 1000,
+  outputDir: path.join('artifacts', 'test-results'),
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: path.join('artifacts', 'playwright-report'), open: 'never' }],
+  ],
+  use: {
+    baseURL: resolvedBaseURL,
+    headless: true,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    ignoreHTTPSErrors: true,
+    proxy:
+      process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+        ? {
+            server: (process.env.HTTPS_PROXY || process.env.HTTP_PROXY)!,
+            bypass: process.env.NO_PROXY,
+          }
+        : undefined,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.57.0
+
+packages:
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/tests/gh-pages-screenshots.spec.ts
+++ b/tests/gh-pages-screenshots.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const ensureTrailingSlash = (url: string) => (url.endsWith('/') ? url : `${url}/`);
+
+const normalizeCandidate = (href: string, baseURL: string): string | null => {
+  const trimmed = href.trim();
+  if (!trimmed || trimmed === '#') return null;
+  if (/^(mailto:|tel:|javascript:)/i.test(trimmed)) return null;
+  if (trimmed.startsWith('#')) return null;
+
+  try {
+    const candidate = new URL(trimmed, baseURL);
+    const base = new URL(baseURL);
+    if (candidate.origin !== base.origin) return null;
+    return candidate.toString();
+  } catch {
+    return null;
+  }
+};
+
+const slugFromUrl = (value: string): string => {
+  try {
+    const parsed = new URL(value);
+    const pathPart = parsed.pathname.replace(/\/+/g, '/').replace(/^\/+|\/+$/g, '');
+    const slug = pathPart.length > 0 ? pathPart : 'home';
+    return slug.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-+|-+$/g, '').toLowerCase() || 'page';
+  } catch {
+    return 'page';
+  }
+};
+
+const fallbackPaths = [
+  '/index.html',
+  '/story1.html',
+  '/story2.html',
+  '/story3.html',
+  '/story4.html',
+  '/story5.html',
+  '/generated/hina/index.html',
+  '/generated/immersive/index.html',
+  '/generated/magazine/index.html',
+];
+
+test('captures GitHub Pages screenshots', async ({ page, request }) => {
+  const baseURL = test.info().project.use.baseURL;
+  expect(baseURL, 'Base URL must be resolved before running the test').toBeTruthy();
+  const resolvedBase = ensureTrailingSlash(baseURL!);
+
+  const screenshotsDir = path.join('artifacts', 'screenshots');
+  await fs.promises.mkdir(screenshotsDir, { recursive: true });
+
+  const pageErrors: string[] = [];
+  const consoleErrors: string[] = [];
+
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  let landingUrl = resolvedBase;
+  let response = await page.goto(resolvedBase, { waitUntil: 'domcontentloaded' });
+  if (!response || response.status() >= 400) {
+    const indexFallback = new URL('index.html', resolvedBase).toString();
+    if (indexFallback !== resolvedBase) {
+      landingUrl = indexFallback;
+      response = await page.goto(indexFallback, { waitUntil: 'domcontentloaded' });
+    }
+  }
+  await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+  expect(response?.status()).toBeLessThan(400);
+
+  const discoveredLinks = await page.$$eval(
+    'a[href]',
+    (anchors, base) =>
+      Array.from(new Set(
+        anchors
+          .map((anchor) => anchor.getAttribute('href') || '')
+          .filter((href) => href && href !== '#')
+          .map((href) => {
+            try {
+              const candidate = new URL(href, base);
+              const baseUrl = new URL(base);
+              if (candidate.origin !== baseUrl.origin) return null;
+              if (/^(mailto:|tel:|javascript:)/i.test(href)) return null;
+              if (href.trim() === '#') return null;
+              return candidate.toString();
+            } catch {
+              return null;
+            }
+          })
+          .filter(Boolean) as string[],
+      )),
+    landingUrl,
+  );
+
+  const candidates = new Set<string>();
+  discoveredLinks.forEach((href) => {
+    const normalized = normalizeCandidate(href, landingUrl);
+    if (normalized) candidates.add(normalized);
+  });
+
+  for (const fallback of fallbackPaths) {
+    if (candidates.size >= 5) break;
+    const url = new URL(fallback, resolvedBase).toString();
+    if (candidates.has(url)) continue;
+    try {
+      const fallbackResponse = await request.get(url, { failOnStatusCode: false });
+      if (fallbackResponse.status() >= 200 && fallbackResponse.status() < 400) {
+        candidates.add(url);
+      }
+    } catch (error) {
+      test.info().annotations.push({
+        type: 'issue',
+        description: `Skipping fallback ${url}: ${(error as Error).message}`,
+      });
+    }
+  }
+
+  if (candidates.size < 2) {
+    [
+      'story1.html',
+      'story2.html',
+      'generated/hina/index.html',
+      'generated/immersive/index.html',
+    ].forEach((pathCandidate) => {
+      if (candidates.size >= 5) return;
+      candidates.add(new URL(pathCandidate, resolvedBase).toString());
+    });
+  }
+
+  const targetUrls = [landingUrl, ...Array.from(candidates).slice(0, 4)].slice(0, 3);
+  expect(targetUrls.length).toBeGreaterThanOrEqual(3);
+
+  const visited: string[] = [];
+
+  for (const [index, url] of targetUrls.entries()) {
+    const navigation = await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
+    if (navigation) {
+      expect(navigation.status(), `Failed to load ${url}`).toBeLessThan(400);
+    }
+    const filename = `${String(index + 1).padStart(2, '0')}_${slugFromUrl(url)}.png`;
+    const outputPath = path.join(screenshotsDir, filename);
+    await page.screenshot({ path: outputPath, fullPage: true });
+    visited.push(`${filename}: ${url}`);
+  }
+
+  if (pageErrors.length || consoleErrors.length) {
+    const combined = [
+      pageErrors.length ? `Page errors:\\n${pageErrors.join('\\n')}` : null,
+      consoleErrors.length ? `Console errors:\\n${consoleErrors.join('\\n')}` : null,
+    ]
+      .filter(Boolean)
+      .join('\\n\\n');
+    test.info().annotations.push({ type: 'issue', description: combined });
+  }
+
+  test.info().attach('captured-urls', {
+    body: visited.join('\\n'),
+    contentType: 'text/plain',
+  });
+
+  console.log('Captured pages:', visited);
+});


### PR DESCRIPTION
## Summary
- set up a Playwright harness with automatic baseURL resolution, proxy support, and artifacts under the artifacts/ folder
- add a resilient screenshot smoke test that discovers same-origin links or falls back to common story pages to capture at least three full-page shots
- document how to run the suite and override BASE_URL when github.io is blocked

## Testing
- BASE_URL=https://raw.githubusercontent.com/kakurai49/stories/main/ pnpm run e2e

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fb17bce48333b834fcabc82cc30d)