### PR TITLE
Add Playwright usage guide with local run example

### DIFF
--- a/README_PLAYWRIGHT.md
+++ b/README_PLAYWRIGHT.md
@@ -19,6 +19,8 @@ pnpm install
 
 # Playwright のブラウザと Linux 依存関係（ヘッドレス対応）をインストール
 pnpm run e2e:install
+
+# 403 などで最初のダウンロード元に拒否された場合も、自動で別 CDN にフォールバックします
 ```
 
 ## スモークテストの実行
@@ -39,3 +41,21 @@ zip -r artifacts_bundle.zip artifacts
 ### プロキシ / 制限付きネットワークでの注意点
 - プロキシで `github.io` がブロックされている場合は、実行前に到達可能なミラーを `BASE_URL` に設定してください（例: `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/`）。
 - 設定は `HTTP_PROXY` / `HTTPS_PROXY` も尊重し、MITM プロキシに対応するため証明書エラーを無視します。
+- ローカルでホストして検証したい場合は、`NO_PROXY=127.0.0.1,localhost` を付けてプロキシをバイパスしてください。
+
+## 実行例（ローカルサーバーを使うケース）
+GitHub Pages への疎通が遮断される環境だったため、リポジトリ直下を Python の簡易サーバーでホストし、`BASE_URL` を上書きしてテストを実行しました。
+
+```bash
+# 1. 別シェルまたはバックグラウンドでローカルサーバーを起動
+python -m http.server 8000 --bind 127.0.0.1
+
+# 2. プロキシをバイパスしつつ BASE_URL をローカルに向けてテストを実行
+NO_PROXY=127.0.0.1,localhost BASE_URL=http://127.0.0.1:8000/ pnpm run e2e
+```
+
+結果として `artifacts/screenshots/` に以下の 3 枚のスクリーンショットが保存され、`artifacts/test-results/` に動画と実行ログが残りました。
+
+- `01_home.png`: `http://127.0.0.1:8000/`
+- `02_home.png`: `http://127.0.0.1:8000/#content`
+- `03_home.png`: `http://127.0.0.1:8000/#about`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.49.1
+        specifier: ^1.57.0
         version: 1.57.0
 
 packages:


### PR DESCRIPTION
## Summary
- document CDN fallback during Playwright dependency installation
- add proxy bypass guidance and a local-server example for running the smoke test when GitHub Pages is unreachable
- refresh the pnpm lockfile to align with the current Playwright version

## Testing
- NO_PROXY=127.0.0.1,localhost BASE_URL=http://127.0.0.1:8000/ pnpm run e2e


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954045cec8c8333b46711bce025ccf2)