### PR TITLE
Add micro world migration pipeline

### DIFF
--- a/sitegen/cli_build_posts.py
+++ b/sitegen/cli_build_posts.py
@@ -1,0 +1,21 @@
+"""CLI entrypoint to build legacy-compatible posts from micro world."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .compile_pipeline import build_posts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build posts from micro world store")
+    parser.add_argument("--micro", type=Path, required=True, help="Path to micro world directory")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for dist files")
+    args = parser.parse_args()
+
+    build_posts(args.micro, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/sitegen/cli_migrate_legacy.py
+++ b/sitegen/cli_migrate_legacy.py
@@ -1,0 +1,21 @@
+"""CLI entrypoint for migrating legacy posts to micro world."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .migrate_legacy import migrate_legacy_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate legacy posts to micro world format")
+    parser.add_argument("--posts", type=Path, required=True, help="Path to legacy posts directory")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for micro files")
+    args = parser.parse_args()
+
+    migrate_legacy_dir(args.posts, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/sitegen/compile_pipeline.py
+++ b/sitegen/compile_pipeline.py
@@ -1,0 +1,170 @@
+"""Compilation pipeline from micro world to legacy HTML output."""
+
+from __future__ import annotations
+
+import importlib.util
+import html
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from .dom_model import DomNode, dom_to_html
+from .io_utils import write_json
+from .micro_store import MicroStore, load_micro_store
+
+
+def resolve_blocks(entity: Dict[str, Any], store: MicroStore) -> List[Dict[str, Any]]:
+    resolved = []
+    for block_id in entity.get("body", {}).get("blockRefs", []):
+        if block_id not in store.blocks_by_id:
+            raise KeyError(f"Block {block_id} not found in store")
+        resolved.append(store.blocks_by_id[block_id])
+    return resolved
+
+
+def _render_inlines(inlines: List[Dict[str, Any]]) -> List[Any]:
+    rendered: List[Any] = []
+    for inline in inlines:
+        if inline["type"] == "Text":
+            rendered.append(inline["text"])
+        elif inline["type"] == "InlineLink":
+            rendered.append(
+                DomNode(
+                    tag="a",
+                    attrs={"class": "mw-link", "href": inline["href"]},
+                    text=inline["label"],
+                )
+            )
+    return rendered
+
+
+def _convert_block(block: Dict[str, Any], lookup: Dict[str, Dict[str, Any]]) -> List[DomNode]:
+    btype = block["type"]
+    if btype == "Heading":
+        level = int(block.get("level", 1))
+        return [
+            DomNode(
+                tag=f"h{level}",
+                attrs={"class": f"mw-heading level-{level}"},
+                text=block.get("text", ""),
+            )
+        ]
+    if btype == "Paragraph":
+        children = _render_inlines(block.get("inlines", []))
+        return [DomNode(tag="p", attrs={"class": "mw-paragraph"}, children=children)]
+    if btype == "Link":
+        return [
+            DomNode(
+                tag="a",
+                attrs={"class": "mw-link", "href": block.get("href", "")},
+                text=block.get("label", ""),
+            )
+        ]
+    if btype == "Image":
+        img = DomNode(
+            tag="img",
+            attrs={"class": "mw-image-img", "src": block.get("src", ""), "alt": block.get("alt", "")},
+            self_closing=True,
+        )
+        children: List[Any] = [img]
+        caption = block.get("caption")
+        if caption:
+            children.append(DomNode(tag="figcaption", attrs={"class": "mw-image-caption"}, text=caption))
+        figure = DomNode(tag="figure", attrs={"class": "mw-image"}, children=children)
+        return [figure]
+    if btype == "Section":
+        children: List[Any] = []
+        for child_id in block.get("children", []):
+            if child_id not in lookup:
+                continue
+            children.extend(_convert_block(lookup[child_id], lookup))
+        return [DomNode(tag="div", attrs={"class": "mw-section"}, children=children)]
+    if btype == "RawHtml":
+        return [
+            DomNode(
+                tag="div",
+                attrs={"class": "mw-raw", "data-kind": "rawHtml"},
+                raw_html=block.get("html", ""),
+            )
+        ]
+    if btype == "Markdown":
+        html_text = None
+        if importlib.util.find_spec("markdown"):
+            from markdown import markdown
+
+            html_text = markdown(block.get("source", ""))
+        if html_text is not None:
+            return [DomNode(tag="div", attrs={"class": "mw-md"}, raw_html=html_text)]
+        escaped = html.escape(block.get("source", ""))
+        return [DomNode(tag="pre", attrs={"class": "mw-md"}, raw_html=escaped)]
+    return []
+
+
+def blocks_to_dom(blocks: List[Dict[str, Any]], ctx: Dict[str, Any] | None = None) -> List[DomNode]:
+    ctx = ctx or {}
+    lookup = {block["id"]: block for block in blocks}
+    dom: List[DomNode] = []
+    for block in blocks:
+        dom.extend(_convert_block(block, lookup))
+    return dom
+
+
+def apply_theme(dom: List[DomNode], theme: Dict[str, Any] | None = None) -> Tuple[List[DomNode], str]:
+    theme = theme or {}
+    css_lines = [
+        ":root {",
+        "  --mw-font-size-base: 16px;",
+        "  --mw-font-family: sans-serif;",
+        "  --mw-text-color: #222;",
+        "}",
+        ".mw-heading { font-family: var(--mw-font-family); color: var(--mw-text-color); }",
+        ".mw-paragraph { font-family: var(--mw-font-family); color: var(--mw-text-color); line-height: 1.6; }",
+        ".mw-link { color: #0a6cff; text-decoration: underline; }",
+        ".mw-image { margin: 1em 0; }",
+        ".mw-image-img { max-width: 100%; height: auto; display: block; }",
+        ".mw-image-caption { font-size: 0.9em; color: #555; }",
+        ".mw-section { margin: 1.5em 0; }",
+        ".mw-raw { margin: 1em 0; }",
+        ".mw-md { margin: 1em 0; }",
+    ]
+    if theme:
+        for key, value in theme.items():
+            css_lines.append(f":root {{ --{key}: {value}; }}")
+    css_text = "\n".join(css_lines) + "\n"
+    return dom, css_text
+
+
+def emit_legacy(entity: Dict[str, Any], html_text: str) -> Dict[str, Any]:
+    legacy: Dict[str, Any] = {
+        "contentId": entity["id"],
+        "experience": entity["variant"],
+        "pageType": entity["type"],
+        "title": entity.get("meta", {}).get("title"),
+        "summary": entity.get("meta", {}).get("summary"),
+        "tags": entity.get("meta", {}).get("tags", []),
+        "render": {"kind": "html", "html": html_text},
+    }
+    for extra in ("role", "profile"):
+        if extra in entity.get("meta", {}):
+            legacy[extra] = entity["meta"][extra]
+    return legacy
+
+
+def build_posts(micro_dir: Path, dist_dir: Path) -> None:
+    store = load_micro_store(micro_dir)
+    blocks_dir = dist_dir / "posts"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    css_path = dist_dir / "micro.css"
+
+    generated_css = None
+
+    for entity in store.entities:
+        blocks = resolve_blocks(entity, store)
+        dom = blocks_to_dom(blocks, ctx={"entity": entity})
+        dom, css_text = apply_theme(dom, theme={})
+        if generated_css is None:
+            css_path.write_text(css_text, encoding="utf-8")
+            generated_css = css_text
+        html_text = dom_to_html(dom)
+        legacy = emit_legacy(entity, html_text)
+        blocks_dir.mkdir(parents=True, exist_ok=True)
+        write_json(blocks_dir / f"{entity['id']}.json", legacy)

--- a/sitegen/dom_model.py
+++ b/sitegen/dom_model.py
@@ -1,0 +1,56 @@
+"""Simple DOM model for HTML serialization."""
+
+from __future__ import annotations
+
+import html
+from dataclasses import dataclass, field
+from typing import Dict, List, Sequence
+
+
+@dataclass
+class DomNode:
+    tag: str
+    attrs: Dict[str, str] = field(default_factory=dict)
+    children: List["DomContent"] = field(default_factory=list)
+    text: str | None = None
+    raw_html: str | None = None
+    self_closing: bool = False
+
+
+DomContent = DomNode | str
+
+
+def _render_attrs(attrs: Dict[str, str]) -> str:
+    if not attrs:
+        return ""
+    parts = [f'{name}="{html.escape(value, quote=True)}"' for name, value in attrs.items()]
+    return " " + " ".join(parts)
+
+
+def _render_children(children: Sequence[DomContent]) -> str:
+    html_parts: List[str] = []
+    for child in children:
+        if isinstance(child, DomNode):
+            html_parts.append(dom_to_html([child]))
+        else:
+            html_parts.append(html.escape(str(child)))
+    return "".join(html_parts)
+
+
+def dom_to_html(dom: List[DomNode]) -> str:
+    parts: List[str] = []
+    for node in dom:
+        attrs = _render_attrs(node.attrs)
+        if node.self_closing:
+            parts.append(f"<{node.tag}{attrs}/>")
+            continue
+        parts.append(f"<{node.tag}{attrs}>")
+        if node.raw_html is not None:
+            # Raw HTML insertion assumes content is trusted.
+            parts.append(node.raw_html)
+        elif node.text is not None:
+            parts.append(html.escape(node.text))
+        if node.children:
+            parts.append(_render_children(node.children))
+        parts.append(f"</{node.tag}>")
+    return "".join(parts)

--- a/sitegen/io_utils.py
+++ b/sitegen/io_utils.py
@@ -1,0 +1,28 @@
+"""Utility helpers for JSON IO and logging."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def stable_json_dumps(obj: object) -> str:
+    """Serialize JSON in a stable way for hashing."""
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+def warn(msg: str) -> None:
+    print(msg, file=sys.stderr)

--- a/sitegen/micro_store.py
+++ b/sitegen/micro_store.py
@@ -1,0 +1,64 @@
+"""Micro world storage helpers."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .io_utils import read_json, stable_json_dumps
+
+
+def _normalize_for_fingerprint(obj: Any, *, drop_id: bool = False) -> Any:
+    if isinstance(obj, dict):
+        items = {}
+        for key in sorted(obj.keys()):
+            if drop_id and key == "id":
+                continue
+            value = obj[key]
+            if value is None:
+                continue
+            items[key] = _normalize_for_fingerprint(value, drop_id=drop_id)
+        return items
+    if isinstance(obj, list):
+        return [_normalize_for_fingerprint(item, drop_id=drop_id) for item in obj]
+    return obj
+
+
+def block_fingerprint(block: Dict[str, Any]) -> str:
+    normalized = _normalize_for_fingerprint(block, drop_id=True)
+    return stable_json_dumps(normalized)
+
+
+def block_id_from_block(block: Dict[str, Any]) -> str:
+    fp = block_fingerprint(block)
+    digest = hashlib.sha1(fp.encode("utf-8")).hexdigest()
+    return f"blk_{digest}"
+
+
+@dataclass
+class MicroStore:
+    blocks_by_id: Dict[str, Dict[str, Any]]
+    entities: List[Dict[str, Any]]
+
+    def resolve_block(self, block_id: str) -> Dict[str, Any]:
+        return self.blocks_by_id[block_id]
+
+
+def load_micro_store(micro_dir: Path) -> MicroStore:
+    blocks_dir = micro_dir / "blocks"
+    entities_dir = micro_dir / "entities"
+
+    blocks_by_id: Dict[str, Dict[str, Any]] = {}
+    if blocks_dir.exists():
+        for path in blocks_dir.glob("*.json"):
+            block = read_json(path)
+            blocks_by_id[block["id"]] = block
+
+    entities: List[Dict[str, Any]] = []
+    if entities_dir.exists():
+        for path in entities_dir.glob("*.json"):
+            entities.append(read_json(path))
+
+    return MicroStore(blocks_by_id=blocks_by_id, entities=entities)

--- a/sitegen/migrate_legacy.py
+++ b/sitegen/migrate_legacy.py
@@ -1,0 +1,113 @@
+"""Migration from legacy posts to micro world representation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from .io_utils import read_json, warn, write_json
+from .micro_store import block_id_from_block
+from .types_legacy import LegacyPost
+from .types_micro import MicroBlock, MicroEntity
+
+
+REQUIRED_FIELDS = ["contentId", "experience", "pageType", "title", "summary", "render"]
+
+
+def _to_pascal(name: str) -> str:
+    if not name:
+        return name
+    return "".join(part.capitalize() for part in name.replace("-", " ").split())
+
+
+def load_legacy_posts(posts_dir: Path) -> List[LegacyPost]:
+    posts: List[LegacyPost] = []
+    for path in sorted(posts_dir.glob("*.json")):
+        try:
+            data = read_json(path)
+        except json.JSONDecodeError:
+            warn(f"[legacy] failed to parse JSON: {path}")
+            continue
+        if not all(key in data for key in REQUIRED_FIELDS):
+            warn(f"[legacy] missing required fields in {path}")
+            continue
+        posts.append(data)
+    return posts
+
+
+def _dedupe_blocks(blocks: List[Dict[str, Any]]) -> Tuple[List[str], Dict[str, MicroBlock]]:
+    ids: List[str] = []
+    unique: Dict[str, MicroBlock] = {}
+    for block in blocks:
+        block_id = block_id_from_block(block)
+        block_with_id: MicroBlock = {"id": block_id, **block}
+        ids.append(block_id)
+        unique.setdefault(block_id, block_with_id)
+    return ids, unique
+
+
+def legacy_to_micro(legacy: LegacyPost) -> Tuple[MicroEntity, List[MicroBlock]]:
+    blocks: List[Dict[str, Any]] = []
+    render = legacy["render"]
+    if render["kind"] == "html":
+        blocks.append({"type": "RawHtml", "html": render["html"]})
+    elif render["kind"] == "markdown":
+        blocks.append({"type": "Markdown", "source": render["markdown"]})
+
+    cta_label = legacy.get("ctaLabel")
+    cta_href = legacy.get("ctaHref")
+    if cta_label and cta_href:
+        blocks.append({"type": "Link", "label": cta_label, "href": cta_href})
+
+    block_refs, unique_blocks = _dedupe_blocks(blocks)
+
+    meta: Dict[str, Any] = {
+        "title": legacy.get("title"),
+        "summary": legacy.get("summary"),
+        "tags": legacy.get("tags", []),
+    }
+    for extra in ("role", "profile"):
+        if extra in legacy:
+            meta[extra] = legacy[extra]
+
+    entity: MicroEntity = {
+        "id": legacy["contentId"],
+        "variant": legacy["experience"],
+        "type": _to_pascal(legacy["pageType"]),
+        "meta": meta,
+        "body": {"blockRefs": block_refs},
+        "relations": {},
+    }
+    return entity, list(unique_blocks.values())
+
+
+def migrate_legacy_dir(posts_dir: Path, micro_dir: Path) -> None:
+    posts = load_legacy_posts(posts_dir)
+    blocks_dir = micro_dir / "blocks"
+    entities_dir = micro_dir / "entities"
+    blocks_dir.mkdir(parents=True, exist_ok=True)
+    entities_dir.mkdir(parents=True, exist_ok=True)
+
+    all_blocks: Dict[str, MicroBlock] = {}
+    index_entities: List[Dict[str, Any]] = []
+
+    for post in posts:
+        entity, blocks = legacy_to_micro(post)
+        for block in blocks:
+            all_blocks.setdefault(block["id"], block)
+        write_json(entities_dir / f"{entity['id']}.json", entity)
+        index_entities.append(
+            {
+                "id": entity["id"],
+                "variant": entity["variant"],
+                "type": entity["type"],
+                "meta": entity["meta"],
+            }
+        )
+
+    for block in all_blocks.values():
+        write_json(blocks_dir / f"{block['id']}.json", block)
+
+    index = {"entities": index_entities, "blocks": sorted(all_blocks.keys())}
+    write_json(micro_dir / "index.json", index)

--- a/sitegen/types_legacy.py
+++ b/sitegen/types_legacy.py
@@ -1,0 +1,32 @@
+"""Legacy post type definitions."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+class LegacyRenderHtml(TypedDict):
+    kind: Literal["html"]
+    html: str
+
+
+class LegacyRenderMarkdown(TypedDict):
+    kind: Literal["markdown"]
+    markdown: str
+
+
+LegacyRender = LegacyRenderHtml | LegacyRenderMarkdown
+
+
+class LegacyPost(TypedDict, total=False):
+    contentId: str
+    experience: str
+    pageType: str
+    title: str
+    summary: str
+    role: str
+    profile: str
+    ctaLabel: str
+    ctaHref: str
+    tags: list[str]
+    render: LegacyRender

--- a/sitegen/types_micro.py
+++ b/sitegen/types_micro.py
@@ -1,0 +1,95 @@
+"""Micro world type definitions."""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+class InlineText(TypedDict):
+    type: Literal["Text"]
+    text: str
+
+
+class InlineLink(TypedDict):
+    type: Literal["InlineLink"]
+    label: str
+    href: str
+
+
+Inline = InlineText | InlineLink
+
+
+class BaseBlock(TypedDict):
+    id: str
+    type: str
+
+
+class HeadingBlock(BaseBlock):
+    type: Literal["Heading"]
+    level: int
+    text: str
+
+
+class ParagraphBlock(BaseBlock):
+    type: Literal["Paragraph"]
+    inlines: list[Inline]
+
+
+class ImageBlock(BaseBlock):
+    type: Literal["Image"]
+    src: str
+    alt: str
+    caption: str | None
+
+
+class LinkBlock(BaseBlock):
+    type: Literal["Link"]
+    label: str
+    href: str
+
+
+class SectionBlock(BaseBlock):
+    type: Literal["Section"]
+    children: list[str]
+
+
+class RawHtmlBlock(BaseBlock):
+    type: Literal["RawHtml"]
+    html: str
+
+
+class MarkdownBlock(BaseBlock):
+    type: Literal["Markdown"]
+    source: str
+
+
+MicroBlock = (
+    HeadingBlock
+    | ParagraphBlock
+    | ImageBlock
+    | LinkBlock
+    | SectionBlock
+    | RawHtmlBlock
+    | MarkdownBlock
+)
+
+
+class MicroMeta(TypedDict, total=False):
+    title: str
+    summary: str
+    tags: list[str]
+    role: str
+    profile: str
+
+
+class MicroBody(TypedDict):
+    blockRefs: list[str]
+
+
+class MicroEntity(TypedDict):
+    id: str
+    variant: str
+    type: str
+    meta: MicroMeta
+    body: MicroBody
+    relations: dict

--- a/tests/test_blocks_id.py
+++ b/tests/test_blocks_id.py
@@ -1,0 +1,14 @@
+from sitegen.micro_store import block_id_from_block, block_fingerprint
+
+
+def test_block_fingerprint_is_deterministic():
+    block = {"id": "tmp", "type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "extra": None}
+    fp1 = block_fingerprint(block)
+    fp2 = block_fingerprint({"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "extra": None})
+    assert fp1 == fp2
+
+
+def test_block_id_uses_content_hash():
+    block_a = {"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}]}
+    block_b = {"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "id": "ignored"}
+    assert block_id_from_block(block_a) == block_id_from_block(block_b)

--- a/tests/test_compile_legacy.py
+++ b/tests/test_compile_legacy.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from sitegen.compile_pipeline import build_posts
+from sitegen.io_utils import read_json, write_json
+from sitegen.micro_store import block_id_from_block
+
+
+def test_build_posts_outputs_html(tmp_path: Path):
+    micro_dir = tmp_path / "micro"
+    blocks_dir = micro_dir / "blocks"
+    entities_dir = micro_dir / "entities"
+    blocks_dir.mkdir(parents=True)
+    entities_dir.mkdir(parents=True)
+
+    block_content = {"type": "RawHtml", "html": "<p>Hello</p>"}
+    block_id = block_id_from_block(block_content)
+    block = {"id": block_id, **block_content}
+    write_json(blocks_dir / f"{block_id}.json", block)
+
+    entity = {
+        "id": "post1",
+        "variant": "demo",
+        "type": "Story",
+        "meta": {"title": "Post 1", "summary": "Summary", "tags": []},
+        "body": {"blockRefs": [block_id]},
+        "relations": {},
+    }
+    write_json(entities_dir / "post1.json", entity)
+
+    dist_dir = tmp_path / "dist"
+    build_posts(micro_dir, dist_dir)
+
+    result = read_json(dist_dir / "posts" / "post1.json")
+    assert result["render"]["kind"] == "html"
+    assert "<p>Hello</p>" in result["render"]["html"]

--- a/tests/test_migrate_cta.py
+++ b/tests/test_migrate_cta.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from sitegen.migrate_legacy import legacy_to_micro
+
+
+def test_cta_becomes_link_block(tmp_path: Path):
+    legacy = {
+        "contentId": "cta-test",
+        "experience": "demo",
+        "pageType": "story",
+        "title": "Sample",
+        "summary": "Summary",
+        "render": {"kind": "html", "html": "<p>body</p>"},
+        "ctaLabel": "Read more",
+        "ctaHref": "/read",
+    }
+
+    entity, blocks = legacy_to_micro(legacy)
+
+    assert entity["body"]["blockRefs"][-1] in {block["id"] for block in blocks}
+    link_blocks = [b for b in blocks if b["type"] == "Link"]
+    assert len(link_blocks) == 1
+    assert link_blocks[0]["label"] == "Read more"
+    assert link_blocks[0]["href"] == "/read"


### PR DESCRIPTION
## Summary
- add micro world types and IO utilities for micro/legacy structures
- implement migration and compilation pipelines with CLIs for micro world assets
- cover block hashing, CTA conversion, and HTML build with unit tests

## Testing
- pytest tests/test_blocks_id.py tests/test_migrate_cta.py tests/test_compile_legacy.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695507bf7f608333934ece35bba50cb3)