### PR TITLE
Add MicroWorld snapshot generation and verification

### DIFF
--- a/sitegen/cli_snapshot_micro.py
+++ b/sitegen/cli_snapshot_micro.py
@@ -1,0 +1,52 @@
+"""CLI for generating and verifying MicroWorld snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+from .snapshot_micro import diff_micro_snapshot, legacy_dir_to_micro_snapshot, write_micro_snapshot
+from .verify_roundtrip import verify_roundtrip_all
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate MicroWorld snapshot from legacy posts")
+    parser.add_argument("--posts", type=Path, required=True, help="Path to legacy posts directory")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for micro snapshot")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Regenerate snapshot in a temp dir, compare with existing snapshot, and verify round-trip equality",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    entities, blocks, index = legacy_dir_to_micro_snapshot(args.posts, args.out)
+
+    if args.check:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            write_micro_snapshot(tmp_path, entities, blocks, index)
+            diff = diff_micro_snapshot(args.out, tmp_path)
+            ok, errors = verify_roundtrip_all(args.posts)
+
+            exit_code = 0
+            if diff:
+                sys.stderr.write(diff)
+                exit_code = 1
+            if not ok:
+                sys.stderr.write("\n".join(errors))
+                exit_code = 1
+            if exit_code:
+                sys.exit(exit_code)
+        return
+
+    write_micro_snapshot(args.out, entities, blocks, index)
+
+
+if __name__ == "__main__":
+    main()

--- a/sitegen/io_utils.py
+++ b/sitegen/io_utils.py
@@ -9,8 +9,8 @@ from typing import Any
 
 
 def stable_json_dumps(obj: object) -> str:
-    """Serialize JSON in a stable way for hashing."""
-    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    """Serialize JSON in a stable, human-readable way with a trailing newline."""
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
 
 
 def read_json(path: Path) -> Any:
@@ -19,9 +19,13 @@ def read_json(path: Path) -> Any:
 
 
 def write_json(path: Path, data: Any) -> None:
+    """Deprecated: kept for backward compatibility. Prefer write_json_stable."""
+    write_json_stable(path, data)
+
+
+def write_json_stable(path: Path, data: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    text = json.dumps(data, ensure_ascii=False, sort_keys=True, indent=2)
-    path.write_text(text + "\n", encoding="utf-8")
+    path.write_text(stable_json_dumps(data), encoding="utf-8")
 
 
 def warn(msg: str) -> None:

--- a/sitegen/snapshot_micro.py
+++ b/sitegen/snapshot_micro.py
@@ -1,0 +1,87 @@
+"""Generate and compare MicroWorld snapshots from legacy posts."""
+
+from __future__ import annotations
+
+import difflib
+import shutil
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from .io_utils import read_json, write_json_stable
+from .types_micro import MicroBlock, MicroEntity
+from .verify_roundtrip import legacy_to_micro
+
+
+def _load_posts(posts_dir: Path) -> Iterable[Tuple[str, dict]]:
+    for path in sorted(posts_dir.glob("*.json")):
+        yield path.name, read_json(path)
+
+
+def legacy_dir_to_micro_snapshot(
+    posts_dir: Path, micro_dir: Path
+) -> Tuple[List[MicroEntity], Dict[str, MicroBlock], dict]:
+    entities: List[MicroEntity] = []
+    blocks_by_id: Dict[str, MicroBlock] = {}
+
+    for _, legacy in _load_posts(posts_dir):
+        entity, blocks = legacy_to_micro(legacy)
+        entities.append(entity)
+        for block in blocks:
+            blocks_by_id.setdefault(block["id"], block)
+
+    entities_sorted = sorted(entities, key=lambda e: e["id"])
+    blocks_sorted: Dict[str, MicroBlock] = {bid: blocks_by_id[bid] for bid in sorted(blocks_by_id)}
+
+    index = {
+        "entity_ids": [entity["id"] for entity in entities_sorted],
+        "block_ids": list(blocks_sorted.keys()),
+    }
+    return entities_sorted, blocks_sorted, index
+
+
+def write_micro_snapshot(micro_dir: Path, entities: List[MicroEntity], blocks: Dict[str, MicroBlock], index: dict) -> None:
+    if micro_dir.exists():
+        shutil.rmtree(micro_dir)
+    micro_dir.mkdir(parents=True, exist_ok=True)
+
+    entities_dir = micro_dir / "entities"
+    blocks_dir = micro_dir / "blocks"
+    entities_dir.mkdir(parents=True, exist_ok=True)
+    blocks_dir.mkdir(parents=True, exist_ok=True)
+
+    for entity in entities:
+        write_json_stable(entities_dir / f"{entity['id']}.json", entity)
+    for block_id, block in blocks.items():
+        write_json_stable(blocks_dir / f"{block_id}.json", block)
+    write_json_stable(micro_dir / "index.json", index)
+
+
+def _collect_json_files(directory: Path) -> Dict[str, List[str]]:
+    contents: Dict[str, List[str]] = {}
+    if not directory.exists():
+        return contents
+    for path in sorted(directory.rglob("*.json")):
+        rel = str(path.relative_to(directory))
+        contents[rel] = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    return contents
+
+
+def diff_micro_snapshot(expected_dir: Path, actual_dir: Path) -> str:
+    expected_files = _collect_json_files(expected_dir)
+    actual_files = _collect_json_files(actual_dir)
+    all_paths = sorted(set(expected_files.keys()) | set(actual_files.keys()))
+
+    chunks: List[str] = []
+    for rel in all_paths:
+        expected = expected_files.get(rel, [])
+        actual = actual_files.get(rel, [])
+        if expected == actual:
+            continue
+        diff = difflib.unified_diff(
+            expected,
+            actual,
+            fromfile=f"expected/{rel}",
+            tofile=f"actual/{rel}",
+        )
+        chunks.append("".join(diff))
+    return "".join(chunks)

--- a/sitegen/types_micro.py
+++ b/sitegen/types_micro.py
@@ -74,12 +74,18 @@ MicroBlock = (
 )
 
 
+class MicroMetaCta(TypedDict, total=False):
+    label: str
+    href: str
+
+
 class MicroMeta(TypedDict, total=False):
     title: str
     summary: str
     tags: list[str]
     role: str
     profile: str
+    cta: MicroMetaCta
 
 
 class MicroBody(TypedDict):

--- a/sitegen/verify_roundtrip.py
+++ b/sitegen/verify_roundtrip.py
@@ -1,0 +1,112 @@
+"""Round-trip verification between legacy posts and micro world snapshots."""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from .io_utils import read_json, stable_json_dumps
+from .micro_store import block_id_from_block
+from .types_legacy import LegacyPost, LegacyRender
+from .types_micro import MicroBlock, MicroEntity
+
+
+def legacy_to_micro(legacy: LegacyPost) -> Tuple[MicroEntity, List[MicroBlock]]:
+    render: LegacyRender | None = legacy.get("render")  # type: ignore[assignment]
+    if not render or "kind" not in render:
+        raise ValueError("legacy render is required")
+
+    blocks: List[Dict[str, Any]] = []
+    if render["kind"] == "html":
+        blocks.append({"type": "RawHtml", "html": render["html"]})
+    elif render["kind"] == "markdown":
+        blocks.append({"type": "Markdown", "source": render["markdown"]})
+    else:  # pragma: no cover - defensive guard
+        raise ValueError(f"unsupported render kind: {render['kind']}")
+
+    block_refs: List[str] = []
+    unique_blocks: Dict[str, MicroBlock] = {}
+    for block in blocks:
+        block_id = block_id_from_block(block)
+        block_refs.append(block_id)
+        unique_blocks.setdefault(block_id, {"id": block_id, **block})  # type: ignore[misc]
+
+    meta: Dict[str, Any] = {}
+    for key in ("title", "summary", "tags", "role", "profile"):
+        if key in legacy:
+            meta[key] = legacy[key]
+    if "ctaLabel" in legacy or "ctaHref" in legacy:
+        cta: Dict[str, Any] = {}
+        if "ctaLabel" in legacy:
+            cta["label"] = legacy["ctaLabel"]
+        if "ctaHref" in legacy:
+            cta["href"] = legacy["ctaHref"]
+        meta["cta"] = cta
+
+    entity: MicroEntity = {
+        "id": legacy["contentId"],
+        "variant": legacy["experience"],
+        "type": legacy["pageType"],
+        "meta": meta,
+        "body": {"blockRefs": block_refs},
+        "relations": {},
+    }
+
+    return entity, list(unique_blocks.values())
+
+
+def micro_to_legacy(entity: MicroEntity, blocks_by_id: Dict[str, MicroBlock]) -> LegacyPost:
+    render: LegacyRender | None = None  # type: ignore[assignment]
+    for block_id in entity.get("body", {}).get("blockRefs", []):
+        block = blocks_by_id[block_id]
+        if block["type"] == "RawHtml":
+            render = {"kind": "html", "html": block["html"]}
+            break
+        if block["type"] == "Markdown":
+            render = {"kind": "markdown", "markdown": block["source"]}
+            break
+    if render is None:
+        raise ValueError("micro entity missing render block")
+
+    legacy: LegacyPost = {
+        "contentId": entity["id"],
+        "experience": entity["variant"],
+        "pageType": entity["type"],
+        "render": render,
+    }
+
+    meta = entity.get("meta", {})
+    for key in ("title", "summary", "tags", "role", "profile"):
+        if key in meta:
+            legacy[key] = meta[key]
+
+    cta = meta.get("cta")
+    if isinstance(cta, dict):
+        if "label" in cta:
+            legacy["ctaLabel"] = cta["label"]
+        if "href" in cta:
+            legacy["ctaHref"] = cta["href"]
+
+    return legacy
+
+
+def _pretty_json(obj: Any) -> List[str]:
+    return stable_json_dumps(obj).splitlines(keepends=True)
+
+
+def verify_roundtrip_all(posts_dir: Path) -> Tuple[bool, List[str]]:
+    errors: List[str] = []
+    for path in sorted(posts_dir.glob("*.json")):
+        legacy = read_json(path)
+        entity, blocks = legacy_to_micro(legacy)
+        restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
+        if legacy != restored:
+            diff = difflib.unified_diff(
+                _pretty_json(legacy),
+                _pretty_json(restored),
+                fromfile=f"legacy/{path.name}",
+                tofile=f"roundtrip/{path.name}",
+            )
+            errors.append("".join(diff))
+    return not errors, errors

--- a/tests/test_block_id_deterministic.py
+++ b/tests/test_block_id_deterministic.py
@@ -1,0 +1,8 @@
+from sitegen.micro_store import block_id_from_block
+
+
+def test_block_id_is_stable_even_with_extra_fields():
+    base = {"type": "RawHtml", "html": "<p>hello</p>", "ignored": None}
+    same_content = {"html": "<p>hello</p>", "type": "RawHtml", "ignored": None, "id": "tmp"}
+
+    assert block_id_from_block(base) == block_id_from_block(same_content)

--- a/tests/test_roundtrip_equality.py
+++ b/tests/test_roundtrip_equality.py
@@ -1,0 +1,36 @@
+from sitegen.verify_roundtrip import legacy_to_micro, micro_to_legacy
+
+
+def test_roundtrip_preserves_html_and_cta():
+    legacy = {
+        "contentId": "legacy-1",
+        "experience": "exp",
+        "pageType": "story",
+        "title": "Title",
+        "summary": "Summary",
+        "profile": "Profile",
+        "role": "Role",
+        "ctaLabel": "Read",
+        "ctaHref": "/read",
+        "tags": ["tag-a", "tag-b"],
+        "render": {"kind": "html", "html": "<p>Hello</p>"},
+    }
+
+    entity, blocks = legacy_to_micro(legacy)
+    restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
+
+    assert restored == legacy
+
+
+def test_roundtrip_preserves_markdown_without_optional_fields():
+    legacy = {
+        "contentId": "legacy-2",
+        "experience": "demo",
+        "pageType": "note",
+        "render": {"kind": "markdown", "markdown": "# heading"},
+    }
+
+    entity, blocks = legacy_to_micro(legacy)
+    restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
+
+    assert restored == legacy

--- a/tests/test_snapshot_check_mode.py
+++ b/tests/test_snapshot_check_mode.py
@@ -1,0 +1,48 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from sitegen.io_utils import stable_json_dumps
+
+
+def _write_post(path: Path, data: dict) -> None:
+    path.write_text(stable_json_dumps(data), encoding="utf-8")
+
+
+def test_cli_check_detects_changes(tmp_path: Path):
+    posts_dir = tmp_path / "posts"
+    posts_dir.mkdir()
+    post = {
+        "contentId": "sample",
+        "experience": "demo",
+        "pageType": "story",
+        "title": "Sample",
+        "summary": "Summary",
+        "render": {"kind": "html", "html": "<p>Hello</p>"},
+    }
+    _write_post(posts_dir / "sample.json", post)
+
+    micro_dir = tmp_path / "micro"
+
+    subprocess.run(
+        [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir)],
+        check=True,
+    )
+
+    result_ok = subprocess.run(
+        [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert result_ok.returncode == 0, result_ok.stderr
+
+    entity_path = micro_dir / "entities" / f"{post['contentId']}.json"
+    entity_path.write_text(entity_path.read_text(encoding="utf-8").replace("Sample", "Changed"), encoding="utf-8")
+
+    result_diff = subprocess.run(
+        [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert result_diff.returncode != 0
+    assert "expected/entities" in result_diff.stderr


### PR DESCRIPTION
## Summary
- add utilities to generate MicroWorld snapshots from legacy posts and verify round-trip consistency
- provide stable JSON helpers for deterministic block IDs and snapshot output
- add CLI and tests covering block ID stability, round-trip equality, and snapshot check mode

## Testing
- pytest tests/test_roundtrip_equality.py tests/test_block_id_deterministic.py tests/test_snapshot_check_mode.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69551120e9bc83339d55d8c3f432e5e9)