### PR TITLE
Add deterministic micro snapshot pipeline and round-trip checks

### DIFF
--- a/docs/MICRO_SNAPSHOT_RUNBOOK.md
+++ b/docs/MICRO_SNAPSHOT_RUNBOOK.md
@@ -1,0 +1,25 @@
+# Micro snapshot runbook
+
+## 実行コマンド（生成）
+```
+python -m sitegen.cli_snapshot_micro --posts content/posts --out content/micro
+```
+
+## 実行コマンド（検証 --check）
+```
+python -m sitegen.cli_snapshot_micro --posts content/posts --out content/micro --check
+```
+
+## 実行コマンド（テスト）
+```
+python -m unittest -q
+```
+
+## Git コマンド（差分確認/ステージ/コミット/任意push）
+```
+git status
+git add content/micro
+git commit -m "Add MicroWorld snapshot (content/micro)"
+# 任意:
+# git push origin HEAD
+```

--- a/sitegen/cli_snapshot_micro.py
+++ b/sitegen/cli_snapshot_micro.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from .snapshot_micro import diff_micro_snapshot, legacy_dir_to_micro_snapshot, write_micro_snapshot
+from .snapshot_micro import compare_dirs, legacy_dir_to_micro_snapshot, write_micro_snapshot
 from .verify_roundtrip import verify_roundtrip_all
 
 
@@ -31,11 +31,11 @@ def main() -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             write_micro_snapshot(tmp_path, entities, blocks, index)
-            diff = diff_micro_snapshot(args.out, tmp_path)
+            equal, diff = compare_dirs(args.out, tmp_path)
             ok, errors = verify_roundtrip_all(args.posts)
 
             exit_code = 0
-            if diff:
+            if not equal:
                 sys.stderr.write(diff)
                 exit_code = 1
             if not ok:

--- a/sitegen/micro_ids.py
+++ b/sitegen/micro_ids.py
@@ -1,0 +1,36 @@
+"""Deterministic ID helpers for micro blocks."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict
+
+from .io_utils import stable_json_dumps
+
+
+def normalize_for_fingerprint(obj: Any, *, drop_id: bool = False) -> Any:
+    """Normalize objects for hashing by sorting keys and removing nulls/ids."""
+    if isinstance(obj, dict):
+        items: Dict[str, Any] = {}
+        for key in sorted(obj.keys()):
+            if drop_id and key == "id":
+                continue
+            value = obj[key]
+            if value is None:
+                continue
+            items[key] = normalize_for_fingerprint(value, drop_id=drop_id)
+        return items
+    if isinstance(obj, list):
+        return [normalize_for_fingerprint(item, drop_id=drop_id) for item in obj]
+    return obj
+
+
+def block_fingerprint(block: Dict[str, Any]) -> str:
+    normalized = normalize_for_fingerprint(block, drop_id=True)
+    return stable_json_dumps(normalized)
+
+
+def block_id_from_block(block: Dict[str, Any]) -> str:
+    fingerprint = block_fingerprint(block)
+    digest = hashlib.sha1(fingerprint.encode("utf-8")).hexdigest()
+    return f"blk_{digest}"

--- a/sitegen/micro_store.py
+++ b/sitegen/micro_store.py
@@ -2,39 +2,12 @@
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List
 
-from .io_utils import read_json, stable_json_dumps
-
-
-def _normalize_for_fingerprint(obj: Any, *, drop_id: bool = False) -> Any:
-    if isinstance(obj, dict):
-        items = {}
-        for key in sorted(obj.keys()):
-            if drop_id and key == "id":
-                continue
-            value = obj[key]
-            if value is None:
-                continue
-            items[key] = _normalize_for_fingerprint(value, drop_id=drop_id)
-        return items
-    if isinstance(obj, list):
-        return [_normalize_for_fingerprint(item, drop_id=drop_id) for item in obj]
-    return obj
-
-
-def block_fingerprint(block: Dict[str, Any]) -> str:
-    normalized = _normalize_for_fingerprint(block, drop_id=True)
-    return stable_json_dumps(normalized)
-
-
-def block_id_from_block(block: Dict[str, Any]) -> str:
-    fp = block_fingerprint(block)
-    digest = hashlib.sha1(fp.encode("utf-8")).hexdigest()
-    return f"blk_{digest}"
+from .io_utils import read_json
+from .micro_ids import block_fingerprint, block_id_from_block
 
 
 @dataclass

--- a/sitegen/verify_roundtrip.py
+++ b/sitegen/verify_roundtrip.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from .io_utils import read_json, stable_json_dumps
-from .micro_store import block_id_from_block
+from .micro_ids import block_id_from_block
 from .types_legacy import LegacyPost, LegacyRender
 from .types_micro import MicroBlock, MicroEntity
 
@@ -19,6 +19,8 @@ def legacy_to_micro(legacy: LegacyPost) -> Tuple[MicroEntity, List[MicroBlock]]:
 
     blocks: List[Dict[str, Any]] = []
     if render["kind"] == "html":
+        # Raw HTML blocks are passed through as-is. These snapshots are for a trusted
+        # static site generator pipeline; keep XSS in mind if reused elsewhere.
         blocks.append({"type": "RawHtml", "html": render["html"]})
     elif render["kind"] == "markdown":
         blocks.append({"type": "Markdown", "source": render["markdown"]})

--- a/tests/test_block_id_deterministic.py
+++ b/tests/test_block_id_deterministic.py
@@ -1,8 +1,15 @@
+import unittest
+
 from sitegen.micro_store import block_id_from_block
 
 
-def test_block_id_is_stable_even_with_extra_fields():
-    base = {"type": "RawHtml", "html": "<p>hello</p>", "ignored": None}
-    same_content = {"html": "<p>hello</p>", "type": "RawHtml", "ignored": None, "id": "tmp"}
+class BlockIdDeterminismTest(unittest.TestCase):
+    def test_block_id_is_stable_even_with_extra_fields(self) -> None:
+        base = {"type": "RawHtml", "html": "<p>hello</p>", "ignored": None}
+        same_content = {"html": "<p>hello</p>", "type": "RawHtml", "ignored": None, "id": "tmp"}
 
-    assert block_id_from_block(base) == block_id_from_block(same_content)
+        self.assertEqual(block_id_from_block(base), block_id_from_block(same_content))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_blocks_id.py
+++ b/tests/test_blocks_id.py
@@ -1,14 +1,20 @@
+import unittest
+
 from sitegen.micro_store import block_id_from_block, block_fingerprint
 
 
-def test_block_fingerprint_is_deterministic():
-    block = {"id": "tmp", "type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "extra": None}
-    fp1 = block_fingerprint(block)
-    fp2 = block_fingerprint({"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "extra": None})
-    assert fp1 == fp2
+class BlockFingerprintTest(unittest.TestCase):
+    def test_block_fingerprint_is_deterministic(self) -> None:
+        block = {"id": "tmp", "type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "extra": None}
+        fp1 = block_fingerprint(block)
+        fp2 = block_fingerprint({"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "extra": None})
+        self.assertEqual(fp1, fp2)
+
+    def test_block_id_uses_content_hash(self) -> None:
+        block_a = {"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}]}
+        block_b = {"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "id": "ignored"}
+        self.assertEqual(block_id_from_block(block_a), block_id_from_block(block_b))
 
 
-def test_block_id_uses_content_hash():
-    block_a = {"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}]}
-    block_b = {"type": "Paragraph", "inlines": [{"type": "Text", "text": "hello"}], "id": "ignored"}
-    assert block_id_from_block(block_a) == block_id_from_block(block_b)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roundtrip_equality.py
+++ b/tests/test_roundtrip_equality.py
@@ -1,36 +1,42 @@
+import unittest
+
 from sitegen.verify_roundtrip import legacy_to_micro, micro_to_legacy
 
 
-def test_roundtrip_preserves_html_and_cta():
-    legacy = {
-        "contentId": "legacy-1",
-        "experience": "exp",
-        "pageType": "story",
-        "title": "Title",
-        "summary": "Summary",
-        "profile": "Profile",
-        "role": "Role",
-        "ctaLabel": "Read",
-        "ctaHref": "/read",
-        "tags": ["tag-a", "tag-b"],
-        "render": {"kind": "html", "html": "<p>Hello</p>"},
-    }
+class RoundtripEqualityTest(unittest.TestCase):
+    def test_roundtrip_preserves_html_and_cta(self) -> None:
+        legacy = {
+            "contentId": "legacy-1",
+            "experience": "exp",
+            "pageType": "story",
+            "title": "Title",
+            "summary": "Summary",
+            "profile": "Profile",
+            "role": "Role",
+            "ctaLabel": "Read",
+            "ctaHref": "/read",
+            "tags": ["tag-a", "tag-b"],
+            "render": {"kind": "html", "html": "<p>Hello</p>"},
+        }
 
-    entity, blocks = legacy_to_micro(legacy)
-    restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
+        entity, blocks = legacy_to_micro(legacy)
+        restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
 
-    assert restored == legacy
+        self.assertEqual(restored, legacy)
+
+    def test_roundtrip_preserves_markdown_without_optional_fields(self) -> None:
+        legacy = {
+            "contentId": "legacy-2",
+            "experience": "demo",
+            "pageType": "note",
+            "render": {"kind": "markdown", "markdown": "# heading"},
+        }
+
+        entity, blocks = legacy_to_micro(legacy)
+        restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
+
+        self.assertEqual(restored, legacy)
 
 
-def test_roundtrip_preserves_markdown_without_optional_fields():
-    legacy = {
-        "contentId": "legacy-2",
-        "experience": "demo",
-        "pageType": "note",
-        "render": {"kind": "markdown", "markdown": "# heading"},
-    }
-
-    entity, blocks = legacy_to_micro(legacy)
-    restored = micro_to_legacy(entity, {block["id"]: block for block in blocks})
-
-    assert restored == legacy
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_snapshot_check_mode.py
+++ b/tests/test_snapshot_check_mode.py
@@ -1,5 +1,7 @@
 import subprocess
 import sys
+import tempfile
+import unittest
 from pathlib import Path
 
 from sitegen.io_utils import stable_json_dumps
@@ -9,40 +11,65 @@ def _write_post(path: Path, data: dict) -> None:
     path.write_text(stable_json_dumps(data), encoding="utf-8")
 
 
-def test_cli_check_detects_changes(tmp_path: Path):
-    posts_dir = tmp_path / "posts"
-    posts_dir.mkdir()
-    post = {
-        "contentId": "sample",
-        "experience": "demo",
-        "pageType": "story",
-        "title": "Sample",
-        "summary": "Summary",
-        "render": {"kind": "html", "html": "<p>Hello</p>"},
-    }
-    _write_post(posts_dir / "sample.json", post)
+class SnapshotCheckModeTest(unittest.TestCase):
+    def test_cli_check_detects_changes_end_to_end(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            posts_dir = tmp_path / "posts"
+            posts_dir.mkdir()
+            post = {
+                "contentId": "sample",
+                "experience": "demo",
+                "pageType": "story",
+                "title": "Sample",
+                "summary": "Summary",
+                "render": {"kind": "html", "html": "<p>Hello</p>"},
+            }
+            _write_post(posts_dir / "sample.json", post)
 
-    micro_dir = tmp_path / "micro"
+            micro_dir = tmp_path / "micro"
 
-    subprocess.run(
-        [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir)],
-        check=True,
-    )
+            subprocess.run(
+                [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir)],
+                check=True,
+            )
 
-    result_ok = subprocess.run(
-        [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir), "--check"],
-        capture_output=True,
-        text=True,
-    )
-    assert result_ok.returncode == 0, result_ok.stderr
+            result_ok = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "sitegen.cli_snapshot_micro",
+                    "--posts",
+                    str(posts_dir),
+                    "--out",
+                    str(micro_dir),
+                    "--check",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result_ok.returncode, 0, result_ok.stderr)
 
-    entity_path = micro_dir / "entities" / f"{post['contentId']}.json"
-    entity_path.write_text(entity_path.read_text(encoding="utf-8").replace("Sample", "Changed"), encoding="utf-8")
+            entity_path = micro_dir / "entities" / f"{post['contentId']}.json"
+            entity_path.write_text(entity_path.read_text(encoding="utf-8").replace("Sample", "Changed"), encoding="utf-8")
 
-    result_diff = subprocess.run(
-        [sys.executable, "-m", "sitegen.cli_snapshot_micro", "--posts", str(posts_dir), "--out", str(micro_dir), "--check"],
-        capture_output=True,
-        text=True,
-    )
-    assert result_diff.returncode != 0
-    assert "expected/entities" in result_diff.stderr
+            result_diff = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "sitegen.cli_snapshot_micro",
+                    "--posts",
+                    str(posts_dir),
+                    "--out",
+                    str(micro_dir),
+                    "--check",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result_diff.returncode, 0)
+            self.assertIn(f"{micro_dir.name}/entities", result_diff.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add deterministic micro block ID helpers and snapshot generation/comparison utilities
- ensure legacy-to-micro round-trip preserves HTML/Markdown and CTA data with deterministic ordering
- convert snapshot-related tests to unittest and document required run commands in the runbook

## Testing
- python -m unittest discover -s tests -p 'test*.py' -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955272199788333ab21ae57617802e2)