### PR TITLE
Add deterministic micro flow verification

### DIFF
--- a/.github/workflows/sitegen-flow.yml
+++ b/.github/workflows/sitegen-flow.yml
@@ -1,0 +1,28 @@
+name: Verify sitegen micro flow
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Verify sitegen flow script
+        run: bash scripts/verify_sitegen_flow.sh
+
+      - name: Run tests
+        run: python -m pytest

--- a/scripts/verify_sitegen_flow.sh
+++ b/scripts/verify_sitegen_flow.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end verifier for:
+# legacy JSON -> micro snapshot -> dist (legacy-compatible) -> Jinja-rendered HTML
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTENT_DIR="${CONTENT_DIR:-$ROOT/content/posts}"
+EXPERIENCES="${EXPERIENCES:-$ROOT/config/experiences.yaml}"
+SRC_ROOT="${SRC_ROOT:-$ROOT/experience_src}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/sitegen-flow.XXXXXX")}"
+
+MICRO_WORK="$WORK_DIR/work_micro"
+DIST_WORK="$WORK_DIR/work_dist"
+GENERATED_WORK="$WORK_DIR/work_generated"
+
+RUN1="$WORK_DIR/run1"
+RUN2="$WORK_DIR/run2"
+LEGACY_BASE="$WORK_DIR/legacy_patch"
+mkdir -p "$LEGACY_BASE"
+
+log() {
+  echo "[$(date +'%H:%M:%S')] $*"
+}
+
+hash_dir() {
+  python - "$1" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+fingerprints = {}
+for path in sorted(root.rglob("*")):
+    if path.is_file():
+        rel = path.relative_to(root)
+        fingerprints[str(rel)] = hashlib.sha256(path.read_bytes()).hexdigest()
+print(fingerprints)
+PY
+}
+
+compare_dirs() {
+  local left="$1"
+  local right="$2"
+
+  local left_hashes
+  local right_hashes
+  left_hashes="$(hash_dir "$left")"
+  right_hashes="$(hash_dir "$right")"
+
+  if [[ "$left_hashes" != "$right_hashes" ]]; then
+    echo "Mismatch between $left and $right"
+    diff <(echo "$left_hashes") <(echo "$right_hashes") || true
+    return 1
+  fi
+}
+
+copy_dir() {
+  python - "$1" "$2" <<'PY'
+import shutil
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+dest = Path(sys.argv[2])
+if dest.exists():
+    shutil.rmtree(dest)
+shutil.copytree(src, dest)
+PY
+}
+
+run_flow_once() {
+  local snapshot_out="$1"
+  local dist_out="$2"
+  local generated_out="$3"
+
+  rm -rf "$MICRO_WORK" "$DIST_WORK" "$GENERATED_WORK"
+
+  log "Generating micro snapshot"
+  python -m sitegen.cli_snapshot_micro --posts "$CONTENT_DIR" --out "$MICRO_WORK"
+
+  log "Verifying snapshot (--check)"
+  python -m sitegen.cli_snapshot_micro --posts "$CONTENT_DIR" --out "$MICRO_WORK" --check
+
+  log "Compiling micro store to dist"
+  python -m sitegen.cli_build_posts --micro "$MICRO_WORK" --out "$DIST_WORK"
+
+  log "Rendering HTML from dist posts"
+  SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-0}" python -m sitegen build \
+    --experiences "$EXPERIENCES" \
+    --src "$SRC_ROOT" \
+    --content "$DIST_WORK/posts" \
+    --out "$GENERATED_WORK" \
+    --shared \
+    --all \
+    --deterministic \
+    --build-label "sitegen-flow" \
+    --legacy-base "$LEGACY_BASE"
+
+  mkdir -p "$snapshot_out" "$dist_out" "$generated_out"
+  copy_dir "$MICRO_WORK" "$snapshot_out"
+  copy_dir "$DIST_WORK" "$dist_out"
+  copy_dir "$GENERATED_WORK" "$generated_out"
+}
+
+log "Working directory: $WORK_DIR"
+run_flow_once "$RUN1/micro" "$RUN1/dist" "$RUN1/generated"
+run_flow_once "$RUN2/micro" "$RUN2/dist" "$RUN2/generated"
+
+log "Comparing run1 vs run2 outputs for determinism"
+compare_dirs "$RUN1/micro" "$RUN2/micro"
+compare_dirs "$RUN1/dist" "$RUN2/dist"
+compare_dirs "$RUN1/generated" "$RUN2/generated"
+
+log "All checks passed."

--- a/sitegen/compile_pipeline.py
+++ b/sitegen/compile_pipeline.py
@@ -146,6 +146,8 @@ def emit_legacy(entity: Dict[str, Any], html_text: str) -> Dict[str, Any]:
     for extra in ("role", "profile"):
         if extra in entity.get("meta", {}):
             legacy[extra] = entity["meta"][extra]
+    if "dataHref" in entity.get("meta", {}):
+        legacy["dataHref"] = entity["meta"]["dataHref"]
     return legacy
 
 

--- a/sitegen/verify_roundtrip.py
+++ b/sitegen/verify_roundtrip.py
@@ -35,7 +35,7 @@ def legacy_to_micro(legacy: LegacyPost) -> Tuple[MicroEntity, List[MicroBlock]]:
         unique_blocks.setdefault(block_id, {"id": block_id, **block})  # type: ignore[misc]
 
     meta: Dict[str, Any] = {}
-    for key in ("title", "summary", "tags", "role", "profile"):
+    for key in ("title", "summary", "tags", "role", "profile", "dataHref"):
         if key in legacy:
             meta[key] = legacy[key]
     if "ctaLabel" in legacy or "ctaHref" in legacy:
@@ -79,7 +79,7 @@ def micro_to_legacy(entity: MicroEntity, blocks_by_id: Dict[str, MicroBlock]) ->
     }
 
     meta = entity.get("meta", {})
-    for key in ("title", "summary", "tags", "role", "profile"):
+    for key in ("title", "summary", "tags", "role", "profile", "dataHref"):
         if key in meta:
             legacy[key] = meta[key]
 

--- a/tests/test_micro_flow_e2e.py
+++ b/tests/test_micro_flow_e2e.py
@@ -1,0 +1,133 @@
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _hash_dir(root: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(root)
+            hashes[str(rel)] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return hashes
+
+
+def _run_flow(work_dir: Path) -> tuple[Path, Path, Path]:
+    """Run legacy -> micro snapshot -> dist -> generated pipeline."""
+
+    micro_dir = work_dir / "micro"
+    dist_dir = work_dir / "dist"
+    generated_dir = work_dir / "generated"
+    legacy_base = work_dir / "legacy_patch"
+    legacy_base.mkdir(exist_ok=True)
+
+    for path in (micro_dir, dist_dir, generated_dir):
+        if path.exists():
+            shutil.rmtree(path)
+
+    env = os.environ.copy()
+    env.setdefault("SOURCE_DATE_EPOCH", "0")
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sitegen.cli_snapshot_micro",
+            "--posts",
+            "content/posts",
+            "--out",
+            str(micro_dir),
+        ],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sitegen.cli_snapshot_micro",
+            "--posts",
+            "content/posts",
+            "--out",
+            str(micro_dir),
+            "--check",
+        ],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sitegen.cli_build_posts",
+            "--micro",
+            str(micro_dir),
+            "--out",
+            str(dist_dir),
+        ],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sitegen",
+            "build",
+            "--experiences",
+            "config/experiences.yaml",
+            "--src",
+            "experience_src",
+            "--content",
+            str(dist_dir / "posts"),
+            "--out",
+            str(generated_dir),
+            "--shared",
+            "--all",
+            "--deterministic",
+            "--build-label",
+            "test-flow",
+            "--legacy-base",
+            str(legacy_base),
+        ],
+        check=True,
+        env=env,
+    )
+
+    return micro_dir, dist_dir, generated_dir
+
+
+def _copy_output(src: Path, dest: Path) -> None:
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+
+
+def _assert_same_dir(left: Path, right: Path) -> None:
+    assert _hash_dir(left) == _hash_dir(right), f"{left} and {right} differ"
+
+
+def test_micro_flow_is_reproducible(tmp_path: Path) -> None:
+    """Full end-to-end micro flow should be reproducible between runs."""
+
+    work_dir = tmp_path / "work"
+    run1_dir = tmp_path / "run1"
+    run2_dir = tmp_path / "run2"
+    work_dir.mkdir()
+
+    micro1, dist1, generated1 = _run_flow(work_dir)
+    _copy_output(micro1, run1_dir / "micro")
+    _copy_output(dist1, run1_dir / "dist")
+    _copy_output(generated1, run1_dir / "generated")
+
+    micro2, dist2, generated2 = _run_flow(work_dir)
+    _copy_output(micro2, run2_dir / "micro")
+    _copy_output(dist2, run2_dir / "dist")
+    _copy_output(generated2, run2_dir / "generated")
+
+    _assert_same_dir(run1_dir / "micro", run2_dir / "micro")
+    _assert_same_dir(run1_dir / "dist", run2_dir / "dist")
+    _assert_same_dir(run1_dir / "generated", run2_dir / "generated")


### PR DESCRIPTION
## Summary
- ensure legacy dataHref fields survive micro round-trips and compiled outputs
- add deterministic build options plus an end-to-end reproducibility test and shell verifier
- document the micro flow commands and run the flow in GitHub Actions CI

## Testing
- bash scripts/verify_sitegen_flow.sh
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ce9d18f08333bb1b94a777b68d81)