### PR TITLE
Expose block fingerprint from micro store

### DIFF
--- a/sitegen/micro_store.py
+++ b/sitegen/micro_store.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List
 
 from .io_utils import read_json
-from .micro_ids import block_id_from_block
+from .micro_ids import block_fingerprint, block_id_from_block
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- export the block fingerprint helper from the micro_store module for downstream callers
- keep block ID validation intact while making block hashing utilities reachable

## Testing
- python -m pytest --maxfail=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69560a072450833382eb078541cfd90e)