### PR TITLE
Add sitegen v2 diagnosis script and report

### DIFF
--- a/docs/codex_sitegen_diagnosis_v2.md
+++ b/docs/codex_sitegen_diagnosis_v2.md
@@ -1,0 +1,304 @@
+# Sitegen v2 diagnosis report
+
+## A) Baseline
+- `git rev-parse --show-toplevel` (exit code: 0)
+  - stdout:
+``````
+/workspace/stories
+
+``````
+- `git branch --show-current` (exit code: 0)
+  - stdout:
+``````
+work
+
+``````
+- `git rev-parse --short HEAD` (exit code: 0)
+  - stdout:
+``````
+0cb118e
+
+``````
+- `git status -sb` (exit code: 0)
+  - stdout:
+``````
+## work
+?? scripts/codex_sitegen_diagnose_v2.py
+
+``````
+- `cat .gitignore` (exit code: 0)
+  - stdout:
+``````
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+node_modules/
+artifacts/
+playwright-report/
+test-results/
+artifacts_bundle.zip
+
+``````
+- `git config --get core.excludesfile` (exit code: 1)
+- `cat .git/info/exclude` (exit code: 0)
+  - stdout:
+``````
+# git ls-files --others --exclude-from=.git/info/exclude
+# Lines that start with '#' are comments.
+# For a project mostly in C, the following would be a good set of
+# exclude patterns (uncomment them if you want to use them):
+# *.[oa]
+# *~
+
+``````
+- `git status --ignored` (exit code: 0)
+  - stdout:
+``````
+On branch work
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	scripts/codex_sitegen_diagnose_v2.py
+
+Ignored files:
+  (use "git add -f <file>..." to include in what will be committed)
+	node_modules/
+
+nothing added to commit but untracked files present (use "git add" to track)
+
+``````
+
+## B) 入力Markdownの実在とフェンス数
+- `git ls-files | grep -E "nagi-s[23].*\.md$"` (exit code: 0)
+  - stdout:
+``````
+nagi-s2/nagi-s2.md
+nagi-s3/nagi-s3.md
+
+``````
+- nagi-s2/nagi-s2.md
+  - ```text フェンス数: 13 (expected 13, delta 0)
+  - 先頭タイトル例:
+    - 第1話「涙川ひかり、ぽんこつQA見習いとして爆誕」
+    - 第2話「環境構築で即死。でも優しさスクリプトが走る」
+- nagi-s3/nagi-s3.md
+  - ```text フェンス数: 13 (expected 13, delta 0)
+  - 先頭タイトル例:
+    - 第1話「炎上テストスイートに降臨するアーキテクト」
+    - 第2話「『今まで通りでいい』軍 vs テストピラミッド」
+
+## C) 既存スクリプト/仕様の確認
+- scripts/markdown_to_micro_v2.py exists: True
+- `python scripts/markdown_to_micro_v2.py --help` (exit code: 1)
+  - stderr:
+``````
+Traceback (most recent call last):
+  File "/workspace/stories/scripts/markdown_to_micro_v2.py", line 19, in <module>
+    from sitegen.io_utils import write_json_stable
+ModuleNotFoundError: No module named 'sitegen'
+
+``````
+- docs/micro_flow_spec_v2.md exists: True
+- スキーマ説明っぽい行 (最大40行):
+  - L23: - `--experience <key>` を複数指定すると対象体験を絞り込める。
+
+## D) micro store の実態
+- index.json: {'path': 'content/micro/index.json', 'keys': ['block_ids', 'entity_ids']}
+- entities (最大5件):
+  - {"path": "content/micro/entities/about-世界観.json", "keys": ["body", "id", "meta", "relations", "type", "variant"], "has_meta": true, "has_relations": true, "has_body": true}
+  - {"path": "content/micro/entities/about-読みどころ.json", "keys": ["body", "id", "meta", "relations", "type", "variant"], "has_meta": true, "has_relations": true, "has_body": true}
+  - {"path": "content/micro/entities/character-サキュバスメイド喫茶∞.json", "keys": ["body", "id", "meta", "relations", "type", "variant"], "has_meta": true, "has_relations": true, "has_body": true}
+  - {"path": "content/micro/entities/character-バルハ.json", "keys": ["body", "id", "meta", "relations", "type", "variant"], "has_meta": true, "has_relations": true, "has_body": true}
+  - {"path": "content/micro/entities/character-神崎ナギ.json", "keys": ["body", "id", "meta", "relations", "type", "variant"], "has_meta": true, "has_relations": true, "has_body": true}
+- blocks (最大5件):
+  - {"path": "content/micro/blocks/blk_1e78e99922d794566e3aaf70bded0e24c815d618.json", "keys": ["html", "id", "type"], "has_meta": false, "has_relations": false, "has_body": false}
+  - {"path": "content/micro/blocks/blk_3cdb10bc0c05c0ff06e974d2afc21e78c7a83e0e.json", "keys": ["id", "source", "type"], "has_meta": false, "has_relations": false, "has_body": false}
+  - {"path": "content/micro/blocks/blk_560f0674a5713313bd9040ddfdbc86e27a45f2e9.json", "keys": ["id", "source", "type"], "has_meta": false, "has_relations": false, "has_body": false}
+  - {"path": "content/micro/blocks/blk_5b98026ac65cbbc96d89da5d1cf4ace19c630ece.json", "keys": ["id", "source", "type"], "has_meta": false, "has_relations": false, "has_body": false}
+  - {"path": "content/micro/blocks/blk_6ea791793bd4c34bd86f39c563375e9e53398abf.json", "keys": ["html", "id", "type"], "has_meta": false, "has_relations": false, "has_body": false}
+
+## E) sitegen build スモークテスト
+- `python -m sitegen --help` (exit code: 0)
+  - stdout:
+``````
+usage: sitegen [-h] [--version]
+               {plan,ia,validate,scaffold,gen-manifests,build} ...
+
+Static site generation utilities
+
+positional arguments:
+  {plan,ia,validate,scaffold,gen-manifests,build}
+    plan                Experiment plan utilities
+    ia                  Information architecture utilities
+    validate            Validate experiences.yaml and content posts.
+    scaffold            Create scaffolding for generated experiences.
+    gen-manifests       Generate manifest.json files for generated
+                        experiences.
+    build               Build generated experiences.
+
+options:
+  -h, --help            show this help message and exit
+  --version             Show the sitegen version and exit.
+
+``````
+- `python -m sitegen build --help` (exit code: 0)
+  - stdout:
+``````
+usage: sitegen build [-h] [--experiences EXPERIENCES] [--src SRC] [--out OUT]
+                     [--content CONTENT] [--routes-filename ROUTES_FILENAME]
+                     [--shared] [--all] [--deterministic]
+                     [--build-label BUILD_LABEL] [--legacy-base LEGACY_BASE]
+
+Render generated experience templates into output directories.
+
+options:
+  -h, --help            show this help message and exit
+  --experiences EXPERIENCES
+                        Path to experiences.yaml.
+  --src SRC             Base directory containing experience source templates.
+  --out OUT             Directory to write rendered output.
+  --content CONTENT     Directory containing content JSON files.
+  --routes-filename ROUTES_FILENAME
+                        Filename for routes JSON used to compute data-routes-
+                        href.
+  --shared              Generate shared assets (e.g., feature bootstrap
+                        scripts).
+  --all                 Build generated experiences and refresh routes,
+                        switchers, and legacy pages.
+  --deterministic       Use SOURCE_DATE_EPOCH (or 0) for timestamps to
+                        stabilize build outputs.
+  --build-label BUILD_LABEL
+                        Override the build label appended to outputs (default
+                        combines timestamp and git SHA).
+  --legacy-base LEGACY_BASE
+                        Base directory for patching legacy HTML when --all is
+                        set (defaults to the season1 root).
+
+``````
+- `python -m sitegen.cli_build_site --help` (exit code: 0)
+  - stdout:
+``````
+usage: cli_build_site.py [-h] --micro-store MICRO_STORE
+                         [--experiences EXPERIENCES] [--src SRC] --out OUT
+                         [--routes-filename ROUTES_FILENAME]
+                         [--experience EXPERIENCE_KEYS] [--deterministic]
+                         [--build-label BUILD_LABEL] [--shared] [--all]
+                         [--legacy-base LEGACY_BASE] [--check]
+
+Build site directly from micro store (v2).
+
+options:
+  -h, --help            show this help message and exit
+  --micro-store MICRO_STORE
+                        Path to micro store root directory
+  --experiences EXPERIENCES
+                        Path to experiences.yaml
+  --src SRC             Template source root
+  --out OUT             Output directory for rendered site
+  --routes-filename ROUTES_FILENAME
+                        Filename for routes JSON used to compute data-routes-
+                        href.
+  --experience EXPERIENCE_KEYS
+                        Limit rendering to one or more experience keys
+                        (repeatable).
+  --deterministic       Use SOURCE_DATE_EPOCH (or 0) for timestamps when
+                        composing build labels.
+  --build-label BUILD_LABEL
+                        Override build label (default combines timestamp and
+                        git SHA).
+  --shared              Generate shared assets (e.g., feature bootstrap)
+                        alongside HTML output.
+  --all                 Generate shared assets, switcher routes, and patch
+                        legacy pages.
+  --legacy-base LEGACY_BASE
+                        Base directory for patching legacy HTML when --all is
+                        set.
+  --check               Run two builds into temporary directories and fail if
+                        outputs differ.
+
+``````
+- READMEの v2 コマンド実行:
+- `python -m sitegen.cli_build_site --micro-store content/micro --experiences config/experiences.yaml --src experience_src --out artifacts/_probe_build_out --shared --deterministic --check` (exit code: 0)
+  - stdout:
+``````
+Built 128 file(s) into /tmp/tmpfzgm55_h/run1
+Built 128 file(s) into /tmp/tmpfzgm55_h/run2
+Determinism check passed. Output copied to artifacts/_probe_build_out
+
+``````
+- 出力先 artifacts/_probe_build_out: {"exists": true, "total_files": 138, "total_size": 523825, "top_files": ["artifacts/_probe_build_out/_buildinfo.json", "artifacts/_probe_build_out/hina/assets/base.css", "artifacts/_probe_build_out/hina/assets/components.css", "artifacts/_probe_build_out/hina/assets/tokens.css", "artifacts/_probe_build_out/hina/index.html", "artifacts/_probe_build_out/hina/list/index.html", "artifacts/_probe_build_out/hina/posts/about-世界観.html", "artifacts/_probe_build_out/hina/posts/about-世界観/index.html", "artifacts/_probe_build_out/hina/posts/about-読みどころ.html", "artifacts/_probe_build_out/hina/posts/about-読みどころ/index.html", "artifacts/_probe_build_out/hina/posts/character-サキュバスメイド喫茶∞.html", "artifacts/_probe_build_out/hina/posts/character-サキュバスメイド喫茶∞/index.html", "artifacts/_probe_build_out/hina/posts/character-バルハ.html", "artifacts/_probe_build_out/hina/posts/character-バルハ/index.html", "artifacts/_probe_build_out/hina/posts/character-神崎ナギ.html", "artifacts/_probe_build_out/hina/posts/character-神崎ナギ/index.html", "artifacts/_probe_build_out/hina/posts/character-結城ユイ.html", "artifacts/_probe_build_out/hina/posts/character-結城ユイ/index.html", "artifacts/_probe_build_out/hina/posts/ep01.html", "artifacts/_probe_build_out/hina/posts/ep01/index.html", "artifacts/_probe_build_out/hina/posts/ep02.html", "artifacts/_probe_build_out/hina/posts/ep02/index.html", "artifacts/_probe_build_out/hina/posts/ep03.html", "artifacts/_probe_build_out/hina/posts/ep03/index.html", "artifacts/_probe_build_out/hina/posts/ep04.html", "artifacts/_probe_build_out/hina/posts/ep04/index.html", "artifacts/_probe_build_out/hina/posts/ep05.html", "artifacts/_probe_build_out/hina/posts/ep05/index.html", "artifacts/_probe_build_out/hina/posts/ep06.html", "artifacts/_probe_build_out/hina/posts/ep06/index.html", "artifacts/_probe_build_out/hina/posts/ep07.html", "artifacts/_probe_build_out/hina/posts/ep07/index.html", "artifacts/_probe_build_out/hina/posts/ep08.html", "artifacts/_probe_build_out/hina/posts/ep08/index.html", "artifacts/_probe_build_out/hina/posts/ep09.html", "artifacts/_probe_build_out/hina/posts/ep09/index.html", "artifacts/_probe_build_out/hina/posts/ep10.html", "artifacts/_probe_build_out/hina/posts/ep10/index.html", "artifacts/_probe_build_out/hina/posts/ep11.html", "artifacts/_probe_build_out/hina/posts/ep11/index.html", "artifacts/_probe_build_out/hina/posts/ep12.html", "artifacts/_probe_build_out/hina/posts/ep12/index.html", "artifacts/_probe_build_out/hina/posts/site-meta.html", "artifacts/_probe_build_out/hina/posts/site-meta/index.html", "artifacts/_probe_build_out/hina/posts/welcome-post.html", "artifacts/_probe_build_out/hina/posts/welcome-post/index.html", "artifacts/_probe_build_out/immersive/assets/base.css", "artifacts/_probe_build_out/immersive/assets/components.css", "artifacts/_probe_build_out/immersive/assets/tokens.css", "artifacts/_probe_build_out/immersive/index.html"], "note": "showing first 50 files of 138"}
+- `git check-ignore -v artifacts/_probe_build_out` (exit code: 0)
+  - stdout:
+``````
+.gitignore:7:artifacts/	artifacts/_probe_build_out
+
+``````
+
+## F) 出力先の対照実験 (trackable)
+- `python -m sitegen.cli_build_site --micro-store content/micro --experiences config/experiences.yaml --src experience_src --out _probe_build_out_trackable --shared --deterministic --check` (exit code: 0)
+  - stdout:
+``````
+Built 128 file(s) into /tmp/tmpf1z18qo6/run1
+Built 128 file(s) into /tmp/tmpf1z18qo6/run2
+Determinism check passed. Output copied to _probe_build_out_trackable
+
+``````
+- `git check-ignore -v _probe_build_out_trackable` (exit code: 1)
+- `git status -sb` (exit code: 0)
+  - stdout:
+``````
+## work
+?? _probe_build_out_trackable/
+?? scripts/codex_sitegen_diagnose_v2.py
+
+``````
+
+## G) テスト実行
+- `python -m pytest -q tests/test_micro_build_site_v2.py` (exit code: 0)
+  - stdout:
+``````
+.                                                                        [100%]
+1 passed in 3.41s
+
+``````
+- `python -m pytest -q tests/test_micro_flow_e2e.py` (exit code: 0)
+  - stdout:
+``````
+.                                                                        [100%]
+1 passed in 4.52s
+
+``````
+- `python -m pytest -q tests/test_snapshot_check_mode.py` (exit code: 0)
+  - stdout:
+``````
+.                                                                        [100%]
+1 passed in 0.36s
+
+``````
+- `python -m pytest -q` (exit code: 0)
+  - stdout:
+``````
+...........................                                              [100%]
+27 passed in 10.59s
+
+``````
+- `bash scripts/verify_sitegen_flow.sh` (exit code: 0)
+  - stdout:
+``````
+[08:17:33] Working directory: /tmp/sitegen-flow.7LvegE
+[08:17:33] Generating micro snapshot
+[08:17:33] Verifying snapshot (--check)
+[08:17:33] Compiling micro store to dist
+[08:17:33] Rendering HTML from dist posts
+Built 132 file(s) for 3 experience(s) into /tmp/sitegen-flow.7LvegE/work_generated.
+[08:17:35] Generating micro snapshot
+[08:17:35] Verifying snapshot (--check)
+[08:17:35] Compiling micro store to dist
+[08:17:36] Rendering HTML from dist posts
+Built 132 file(s) for 3 experience(s) into /tmp/sitegen-flow.7LvegE/work_generated.
+[08:17:37] Comparing run1 vs run2 outputs for determinism
+[08:17:38] All checks passed.
+
+``````
+- 生成物カウント: {"playwright_report_files": 0, "test_results_files": 0}

--- a/scripts/codex_sitegen_diagnose_v2.py
+++ b/scripts/codex_sitegen_diagnose_v2.py
@@ -1,0 +1,450 @@
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+def run_command(command, cwd: Optional[Path] = None, limit_lines: Optional[int] = None) -> Dict[str, object]:
+    shell = isinstance(command, str)
+    display = command if shell else " ".join(shlex.quote(str(part)) for part in command)
+    try:
+        completed = subprocess.run(
+            command,
+            shell=shell,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as exc:  # pragma: no cover
+        return {
+            "command": display,
+            "exit_code": None,
+            "stdout": "",
+            "stderr": f"{type(exc).__name__}: {exc}",
+        }
+
+    stdout, stdout_note = truncate_lines(completed.stdout or "", limit_lines)
+    stderr, stderr_note = truncate_lines(completed.stderr or "", limit_lines)
+    result: Dict[str, object] = {
+        "command": display,
+        "exit_code": completed.returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if stdout_note:
+        result["stdout_note"] = stdout_note
+    if stderr_note:
+        result["stderr_note"] = stderr_note
+    return result
+
+
+def truncate_lines(text: str, limit: Optional[int]) -> Tuple[str, Optional[str]]:
+    if limit is None:
+        return text, None
+    lines = text.splitlines()
+    if len(lines) <= limit:
+        return text, None
+    truncated = "\n".join(lines[:limit])
+    note = f"truncated to first {limit} lines (of {len(lines)})"
+    return truncated, note
+
+
+def parse_text_fences(content: str) -> Tuple[int, List[str]]:
+    lines = content.splitlines()
+    i = 0
+    fences: List[List[str]] = []
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("```text"):
+            i += 1
+            block: List[str] = []
+            while i < len(lines) and not lines[i].startswith("```"):
+                block.append(lines[i])
+                i += 1
+            fences.append(block)
+        else:
+            i += 1
+
+    titles: List[str] = []
+    for block in fences:
+        title = next((ln.strip() for ln in block if ln.strip()), "")
+        if title:
+            titles.append(title)
+    return len(fences), titles
+
+
+def read_json(path: Path) -> Tuple[Optional[object], Optional[str]]:
+    try:
+        return json.loads(path.read_text()), None
+    except Exception as exc:  # pragma: no cover
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def describe_output_dir(path: Path, top_n: int = 50) -> Dict[str, object]:
+    if not path.exists():
+        return {"exists": False}
+
+    files = sorted([p for p in path.rglob("*") if p.is_file()], key=lambda p: str(p))
+    total_size = 0
+    entries: List[str] = []
+    for file_path in files:
+        try:
+            size = file_path.stat().st_size
+        except OSError:
+            size = 0
+        total_size += size
+        entries.append(str(file_path))
+
+    top_files = entries[:top_n]
+    summary: Dict[str, object] = {
+        "exists": True,
+        "total_files": len(files),
+        "total_size": total_size,
+        "top_files": top_files,
+    }
+    if len(entries) > top_n:
+        summary["note"] = f"showing first {top_n} files of {len(entries)}"
+    return summary
+
+
+def collect_baseline() -> Dict[str, object]:
+    commands = [
+        ("git rev-parse --show-toplevel", ["git", "rev-parse", "--show-toplevel"], None),
+        ("git branch --show-current", ["git", "branch", "--show-current"], None),
+        ("git rev-parse --short HEAD", ["git", "rev-parse", "--short", "HEAD"], None),
+        ("git status -sb", ["git", "status", "-sb"], None),
+        ("cat .gitignore", ["cat", ".gitignore"], None),
+        ("git config --get core.excludesfile", ["git", "config", "--get", "core.excludesfile"], None),
+        ("cat .git/info/exclude", ["cat", ".git/info/exclude"], None),
+        ("git status --ignored", ["git", "status", "--ignored"], 200),
+    ]
+    results = []
+    for _, cmd, limit in commands:
+        results.append(run_command(cmd, limit_lines=limit))
+    return {"commands": results}
+
+
+def collect_markdown_checks() -> Dict[str, object]:
+    default_paths = [Path("nagi-s2/nagi-s2.md"), Path("nagi-s3/nagi-s3.md")]
+    found: List[Path] = []
+    for candidate in default_paths:
+        if candidate.exists():
+            found.append(candidate)
+
+    search_command = "git ls-files | grep -E \"nagi-s[23].*\\.md$\""
+    search_result = run_command(search_command)
+    if search_result.get("stdout"):
+        for line in search_result["stdout"].splitlines():
+            path = Path(line.strip())
+            if path.exists() and path not in found:
+                found.append(path)
+
+    analyses = []
+    for path in found:
+        try:
+            content = path.read_text()
+        except Exception as exc:  # pragma: no cover
+            analyses.append({"path": str(path), "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        count, titles = parse_text_fences(content)
+        analyses.append(
+            {
+                "path": str(path),
+                "fence_count": count,
+                "example_titles": titles[:2],
+                "delta_from_expected": count - 13,
+            }
+        )
+
+    return {
+        "search_command": search_result,
+        "files": analyses,
+    }
+
+
+def collect_script_and_spec_checks() -> Dict[str, object]:
+    markdown_script = Path("scripts/markdown_to_micro_v2.py")
+    help_result = run_command(["python", "scripts/markdown_to_micro_v2.py", "--help"])
+
+    spec_path = Path("docs/micro_flow_spec_v2.md")
+    schema_lines: List[Tuple[int, str]] = []
+    if spec_path.exists():
+        try:
+            lines = spec_path.read_text().splitlines()
+            keywords = ["schema", "Schema", "SCHEMA", "スキーマ", "キー", "key", "fields", "フィールド"]
+            for idx, line in enumerate(lines, start=1):
+                if any(keyword in line for keyword in keywords):
+                    schema_lines.append((idx, line))
+                if len(schema_lines) >= 40:
+                    break
+        except Exception as exc:  # pragma: no cover
+            schema_lines = [(-1, f"{type(exc).__name__}: {exc}")]
+    return {
+        "script_exists": markdown_script.exists(),
+        "help_result": help_result,
+        "spec_path_exists": spec_path.exists(),
+        "spec_schema_lines": schema_lines,
+    }
+
+
+def collect_micro_store_info() -> Dict[str, object]:
+    root = Path("content/micro")
+    index_info: Dict[str, object] = {"path": str(root / "index.json")}
+    if (root / "index.json").exists():
+        data, error = read_json(root / "index.json")
+        if error:
+            index_info["error"] = error
+        else:
+            index_info["keys"] = sorted(data.keys()) if isinstance(data, dict) else f"unexpected type: {type(data).__name__}"
+    else:
+        index_info["error"] = "missing"
+
+    def summarize_json_dir(path: Path) -> List[Dict[str, object]]:
+        if not path.exists():
+            return [{"path": str(path), "error": "missing"}]
+        summaries: List[Dict[str, object]] = []
+        files = sorted(path.rglob("*.json"), key=lambda p: str(p))
+        for file_path in files[:5]:
+            entry: Dict[str, object] = {"path": str(file_path)}
+            data, error = read_json(file_path)
+            if error:
+                entry["error"] = error
+            elif isinstance(data, dict):
+                entry["keys"] = sorted(data.keys())
+                entry["has_meta"] = "meta" in data
+                entry["has_relations"] = "relations" in data
+                entry["has_body"] = "body" in data
+            else:
+                entry["error"] = f"unexpected type: {type(data).__name__}"
+            summaries.append(entry)
+        return summaries
+
+    entities_info = summarize_json_dir(root / "entities")
+    blocks_info = summarize_json_dir(root / "blocks")
+    return {"index": index_info, "entities": entities_info, "blocks": blocks_info}
+
+
+def collect_sitegen_checks() -> Dict[str, object]:
+    help_commands = [
+        ["python", "-m", "sitegen", "--help"],
+        ["python", "-m", "sitegen", "build", "--help"],
+        ["python", "-m", "sitegen.cli_build_site", "--help"],
+    ]
+    help_results = [run_command(cmd) for cmd in help_commands]
+
+    probe_dir = Path("artifacts/_probe_build_out")
+    trackable_dir = Path("_probe_build_out_trackable")
+    for path in [probe_dir, trackable_dir]:
+        if path.exists():
+            import shutil
+
+            shutil.rmtree(path, ignore_errors=True)
+
+    build_command = [
+        "python",
+        "-m",
+        "sitegen.cli_build_site",
+        "--micro-store",
+        "content/micro",
+        "--experiences",
+        "config/experiences.yaml",
+        "--src",
+        "experience_src",
+        "--out",
+        str(probe_dir),
+        "--shared",
+        "--deterministic",
+        "--check",
+    ]
+    probe_build_result = run_command(build_command)
+    probe_dir_summary = describe_output_dir(probe_dir)
+    probe_check_ignore = run_command(["git", "check-ignore", "-v", str(probe_dir)])
+
+    trackable_command = build_command.copy()
+    trackable_command[-4] = str(trackable_dir)
+    trackable_build_result = run_command(trackable_command)
+    trackable_check_ignore = run_command(["git", "check-ignore", "-v", str(trackable_dir)])
+    trackable_status = run_command(["git", "status", "-sb"])
+
+    if trackable_dir.exists():
+        import shutil
+
+        shutil.rmtree(trackable_dir, ignore_errors=True)
+
+    return {
+        "help_results": help_results,
+        "probe_build": probe_build_result,
+        "probe_dir_summary": probe_dir_summary,
+        "probe_check_ignore": probe_check_ignore,
+        "trackable_build": trackable_build_result,
+        "trackable_check_ignore": trackable_check_ignore,
+        "trackable_status": trackable_status,
+    }
+
+
+def collect_tests() -> Dict[str, object]:
+    commands = [
+        ["python", "-m", "pytest", "-q", "tests/test_micro_build_site_v2.py"],
+        ["python", "-m", "pytest", "-q", "tests/test_micro_flow_e2e.py"],
+        ["python", "-m", "pytest", "-q", "tests/test_snapshot_check_mode.py"],
+        ["python", "-m", "pytest", "-q"],
+    ]
+    results = [run_command(cmd) for cmd in commands]
+
+    verify_script = Path("scripts/verify_sitegen_flow.sh")
+    verify_result = None
+    if verify_script.exists():
+        verify_result = run_command(["bash", str(verify_script)])
+
+    failure_summary: List[Dict[str, object]] = []
+    for res in results:
+        if res.get("exit_code") not in (0, None):
+            failure_summary.extend(extract_failure_lines(res))
+    if verify_result and verify_result.get("exit_code") not in (0, None):
+        failure_summary.extend(extract_failure_lines(verify_result))
+
+    artifacts = summarize_test_artifacts()
+    return {
+        "pytest_results": results,
+        "verify_result": verify_result,
+        "failures": failure_summary,
+        "artifacts": artifacts,
+    }
+
+
+def extract_failure_lines(result: Dict[str, object]) -> List[Dict[str, str]]:
+    combined = f"{result.get('stdout', '')}\n{result.get('stderr', '')}"
+    lines = combined.splitlines()
+    picked: List[str] = []
+    for line in lines:
+        if line.startswith("FAILED") or line.startswith("E   ") or "FAILED" in line or "ERROR" in line:
+            picked.append(line)
+        if len(picked) >= 20:
+            break
+    return [{"command": result.get("command", ""), "line": text} for text in picked]
+
+
+def summarize_test_artifacts() -> Dict[str, object]:
+    def count_files(path: Path) -> int:
+        return sum(1 for _ in path.rglob("*")) if path.exists() else 0
+
+    return {
+        "playwright_report_files": count_files(Path("playwright-report")),
+        "test_results_files": count_files(Path("test-results")),
+    }
+
+
+def render_command_result(result: Dict[str, object]) -> str:
+    parts = [f"- `{result.get('command', '')}` (exit code: {result.get('exit_code')})"]
+    if result.get("stdout"):
+        parts.append("  - stdout:\n``````\n" + result["stdout"] + "\n``````")
+    if result.get("stderr"):
+        parts.append("  - stderr:\n``````\n" + result["stderr"] + "\n``````")
+    if result.get("stdout_note"):
+        parts.append(f"  - note: {result['stdout_note']}")
+    if result.get("stderr_note"):
+        parts.append(f"  - note: {result['stderr_note']}")
+    return "\n".join(parts)
+
+
+def render_markdown(data: Dict[str, object]) -> str:
+    lines: List[str] = []
+    lines.append("# Sitegen v2 diagnosis report")
+
+    lines.append("\n## A) Baseline")
+    for result in data["baseline"]["commands"]:
+        lines.append(render_command_result(result))
+
+    lines.append("\n## B) 入力Markdownの実在とフェンス数")
+    search_command = data["markdown"]["search_command"]
+    lines.append(render_command_result(search_command))
+    for entry in data["markdown"]["files"]:
+        lines.append(f"- {entry['path']}")
+        if "error" in entry:
+            lines.append(f"  - error: {entry['error']}")
+            continue
+        lines.append(f"  - ```text フェンス数: {entry['fence_count']} (expected 13, delta {entry['delta_from_expected']})")
+        if entry.get("example_titles"):
+            lines.append("  - 先頭タイトル例:")
+            for title in entry["example_titles"]:
+                lines.append(f"    - {title}")
+
+    lines.append("\n## C) 既存スクリプト/仕様の確認")
+    script_spec = data["script_spec"]
+    lines.append(f"- scripts/markdown_to_micro_v2.py exists: {script_spec['script_exists']}")
+    lines.append(render_command_result(script_spec["help_result"]))
+    lines.append(f"- docs/micro_flow_spec_v2.md exists: {script_spec['spec_path_exists']}")
+    if script_spec["spec_schema_lines"]:
+        lines.append("- スキーマ説明っぽい行 (最大40行):")
+        for idx, line in script_spec["spec_schema_lines"]:
+            lines.append(f"  - L{idx}: {line}")
+
+    lines.append("\n## D) micro store の実態")
+    micro = data["micro_store"]
+    lines.append(f"- index.json: {micro['index']}")
+    lines.append("- entities (最大5件):")
+    for entry in micro["entities"]:
+        lines.append(f"  - {json.dumps(entry, ensure_ascii=False)}")
+    lines.append("- blocks (最大5件):")
+    for entry in micro["blocks"]:
+        lines.append(f"  - {json.dumps(entry, ensure_ascii=False)}")
+
+    lines.append("\n## E) sitegen build スモークテスト")
+    for help_result in data["sitegen"]["help_results"]:
+        lines.append(render_command_result(help_result))
+    lines.append("- READMEの v2 コマンド実行:")
+    lines.append(render_command_result(data["sitegen"]["probe_build"]))
+    lines.append(f"- 出力先 artifacts/_probe_build_out: {json.dumps(data['sitegen']['probe_dir_summary'], ensure_ascii=False)}")
+    lines.append(render_command_result(data["sitegen"]["probe_check_ignore"]))
+
+    lines.append("\n## F) 出力先の対照実験 (trackable)")
+    lines.append(render_command_result(data["sitegen"]["trackable_build"]))
+    lines.append(render_command_result(data["sitegen"]["trackable_check_ignore"]))
+    lines.append(render_command_result(data["sitegen"]["trackable_status"]))
+
+    lines.append("\n## G) テスト実行")
+    for result in data["tests"]["pytest_results"]:
+        lines.append(render_command_result(result))
+    if data["tests"]["verify_result"]:
+        lines.append(render_command_result(data["tests"]["verify_result"]))
+    if data["tests"]["failures"]:
+        lines.append("- 失敗テスト要約:")
+        for failure in data["tests"]["failures"]:
+            lines.append(f"  - {failure['command']}: {failure['line']}")
+    lines.append(f"- 生成物カウント: {json.dumps(data['tests']['artifacts'], ensure_ascii=False)}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    baseline = collect_baseline()
+    markdown_checks = collect_markdown_checks()
+    script_spec = collect_script_and_spec_checks()
+    micro_store = collect_micro_store_info()
+    sitegen = collect_sitegen_checks()
+    tests = collect_tests()
+
+    md = render_markdown(
+        {
+            "baseline": baseline,
+            "markdown": markdown_checks,
+            "script_spec": script_spec,
+            "micro_store": micro_store,
+            "sitegen": sitegen,
+            "tests": tests,
+        }
+    )
+
+    docs_dir = Path("docs")
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    output_path = docs_dir / "codex_sitegen_diagnosis_v2.md"
+    output_path.write_text(md)
+    sys.stdout.write(f"wrote {output_path}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a standard-library diagnostic tool to capture sitegen v2 baseline, inputs, micro store shape, build behavior, and tests
- run the diagnostic to generate the report docs/codex_sitegen_diagnosis_v2.md for investigation

## Testing
- python scripts/codex_sitegen_diagnose_v2.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69562d2ecbc88333b2a404e3387a5ce3)