### PR TITLE
chore: run v2 flow for nagi-s2/nagi-s3 and log results

### DIFF
--- a/docs/v2_flow_run_log.md
+++ b/docs/v2_flow_run_log.md
@@ -1,0 +1,650 @@
+# v2 flow run log (nagi-s2 / nagi-s3)
+
+このログは Codex 実行環境上での実行結果（rc/stdout/stderr）と件数集計です。
+
+## OK判定基準
+- pytest が rc=0
+- markdown_to_micro_v2.py --help が rc=0
+- nagi-s2/nagi-s3 の micro 生成が rc=0
+- 各 micro store の blocks と entities が少なくとも 13 件以上（想定は 13）
+- sitegen build（--check）が rc=0
+- build 出力（artifacts/...）に html が 13 件以上、micro.css が存在
+
+
+
+## pwd
+
+### cmd
+```bash
+pwd
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+/workspace/stories
+```
+### stderr
+```text
+
+```
+
+
+## git: root
+
+### cmd
+```bash
+git rev-parse --show-toplevel
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+/workspace/stories
+```
+### stderr
+```text
+
+```
+
+
+## git: branch
+
+### cmd
+```bash
+git branch --show-current
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+work
+```
+### stderr
+```text
+
+```
+
+
+## git: head
+
+### cmd
+```bash
+git rev-parse --short HEAD
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+5b1a8be
+```
+### stderr
+```text
+
+```
+
+
+## git: status(before)
+
+### cmd
+```bash
+git status -sb
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+## work
+?? docs/v2_flow_run_log.md
+```
+### stderr
+```text
+
+```
+
+
+## python: version
+
+### cmd
+```bash
+python --version
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+Python 3.11.12
+```
+### stderr
+```text
+
+```
+
+
+## sitegen: import path check
+
+### cmd
+```bash
+python -c "import sitegen; print(sitegen.__file__)"
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+/workspace/stories/sitegen/__init__.py
+```
+### stderr
+```text
+
+```
+
+
+## pytest: test_markdown_to_micro_v2
+
+### cmd
+```bash
+python -m pytest -q tests/test_markdown_to_micro_v2.py
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+....                                                                     [100%]
+4 passed in 0.31s
+```
+### stderr
+```text
+
+```
+
+
+## markdown_to_micro_v2: --help
+
+### cmd
+```bash
+python scripts/markdown_to_micro_v2.py --help
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+usage: markdown_to_micro_v2.py [-h] --input INPUT --out OUT --season SEASON
+                               [--variant VARIANT]
+                               [--expected-blocks EXPECTED_BLOCKS]
+                               [--tag TAGS] [--force]
+
+Convert markdown fences to micro store (v2)
+
+options:
+  -h, --help            show this help message and exit
+  --input INPUT         Input markdown file with ```text fences
+  --out OUT             Output directory for the generated micro store
+  --season SEASON       Season identifier (e.g., nagi-s2)
+  --variant VARIANT     Variant to embed in entities (default: hina)
+  --expected-blocks EXPECTED_BLOCKS
+                        Number of ```text fences expected in the input
+                        (default: 13)
+  --tag TAGS            Additional meta tags (can be provided multiple times)
+  --force               Overwrite the output directory if it exists
+```
+### stderr
+```text
+
+```
+
+
+## inputs: ls
+
+### cmd
+```bash
+ls -la nagi-s2/nagi-s2.md nagi-s3/nagi-s3.md || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+-rw-r--r-- 1 root root 40680 Jan  1 10:50 nagi-s2/nagi-s2.md
+-rw-r--r-- 1 root root 29186 Jan  1 10:50 nagi-s3/nagi-s3.md
+```
+### stderr
+```text
+
+```
+
+
+## inputs: find nagi md
+
+### cmd
+```bash
+git ls-files | grep -E 'nagi-s[23].*\.md$' || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+nagi-s2/nagi-s2.md
+nagi-s3/nagi-s3.md
+```
+### stderr
+```text
+
+```
+
+
+## micro gen: nagi-s2
+
+### cmd
+```bash
+python scripts/markdown_to_micro_v2.py --input nagi-s2/nagi-s2.md --out content/micro/nagi-s2 --season nagi-s2 --variant hina --expected-blocks 13 --force
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+Wrote micro store to content/micro/nagi-s2
+```
+### stderr
+```text
+
+```
+
+
+## micro gen: nagi-s3
+
+### cmd
+```bash
+python scripts/markdown_to_micro_v2.py --input nagi-s3/nagi-s3.md --out content/micro/nagi-s3 --season nagi-s3 --variant hina --expected-blocks 13 --force
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+Wrote micro store to content/micro/nagi-s3
+```
+### stderr
+```text
+
+```
+
+
+## micro count: nagi-s2 tree
+
+### cmd
+```bash
+find content/micro/nagi-s2 -maxdepth 2 -type f | sort | head -n 50 || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+content/micro/nagi-s2/blocks/blk_0c308c7beb4ee0840ace55f370221c2f366f8bf1.json
+content/micro/nagi-s2/blocks/blk_361d8f9990a3bf63097699b0be0ad0324de768ef.json
+content/micro/nagi-s2/blocks/blk_4261fbc9d754b295c0d7b85b78d13476aecdbcc0.json
+content/micro/nagi-s2/blocks/blk_46707caebd386432ab835855145d90636734494f.json
+content/micro/nagi-s2/blocks/blk_6e64768dff5e58d7cb43ef4c9e1032d96b50bef8.json
+content/micro/nagi-s2/blocks/blk_81e81d880a73e81f6567a39ac915777e3131735f.json
+content/micro/nagi-s2/blocks/blk_9614292a8e8449368f9672fed1e865ad8da2177a.json
+content/micro/nagi-s2/blocks/blk_9961c55312b3e09f6cc0178addb1f4dc72f0355b.json
+content/micro/nagi-s2/blocks/blk_bbd682d73ebcef7bb96aac760ab9ca8ce175518d.json
+content/micro/nagi-s2/blocks/blk_c6e1ad68877a16269c356060c4971f30164622c8.json
+content/micro/nagi-s2/blocks/blk_c9fa9aa54f1df2adc504924e48e2af35e1762077.json
+content/micro/nagi-s2/blocks/blk_e220b2e6aa30a64ec3957912eb56f9dfa499632a.json
+content/micro/nagi-s2/blocks/blk_efe71cf02e675c0fa978b4092240cd764c7111d6.json
+content/micro/nagi-s2/entities/nagi-s2-ep01.json
+content/micro/nagi-s2/entities/nagi-s2-ep02.json
+content/micro/nagi-s2/entities/nagi-s2-ep03.json
+content/micro/nagi-s2/entities/nagi-s2-ep04.json
+content/micro/nagi-s2/entities/nagi-s2-ep05.json
+content/micro/nagi-s2/entities/nagi-s2-ep06.json
+content/micro/nagi-s2/entities/nagi-s2-ep07.json
+content/micro/nagi-s2/entities/nagi-s2-ep08.json
+content/micro/nagi-s2/entities/nagi-s2-ep09.json
+content/micro/nagi-s2/entities/nagi-s2-ep10.json
+content/micro/nagi-s2/entities/nagi-s2-ep11.json
+content/micro/nagi-s2/entities/nagi-s2-ep12.json
+content/micro/nagi-s2/entities/nagi-s2-ep13.json
+content/micro/nagi-s2/index.json
+```
+### stderr
+```text
+
+```
+
+
+## micro count: nagi-s2 blocks
+
+### cmd
+```bash
+find content/micro/nagi-s2/blocks -type f | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+13
+```
+### stderr
+```text
+
+```
+
+
+## micro count: nagi-s2 entities
+
+### cmd
+```bash
+find content/micro/nagi-s2/entities -type f | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+13
+```
+### stderr
+```text
+
+```
+
+
+## micro count: nagi-s3 tree
+
+### cmd
+```bash
+find content/micro/nagi-s3 -maxdepth 2 -type f | sort | head -n 50 || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+content/micro/nagi-s3/blocks/blk_002babcfe58dba6d96db4fa73efbd7754d5761b8.json
+content/micro/nagi-s3/blocks/blk_0d97af971993c89afd17188a47b860c01bdda9cb.json
+content/micro/nagi-s3/blocks/blk_19ba15fc18e7ff559d7138aab545cf6bae4f1dda.json
+content/micro/nagi-s3/blocks/blk_1b358d3aa3b2c5f1645a95a9f4a4bcc55423b123.json
+content/micro/nagi-s3/blocks/blk_354a45ac60b110b2f206e4cf3c4b299fed01e43e.json
+content/micro/nagi-s3/blocks/blk_4db75cd715ed00bae31436d26a3a60bc611bf19d.json
+content/micro/nagi-s3/blocks/blk_50c326b30ba6bf921948ad2370059e19c24f3229.json
+content/micro/nagi-s3/blocks/blk_549fbbad636a45434cde8a6d02135492df216f56.json
+content/micro/nagi-s3/blocks/blk_93d8246510af36b38838045a5605f42dacba9714.json
+content/micro/nagi-s3/blocks/blk_9588b946704e8b8edc7e1809789d4362a7eb27d9.json
+content/micro/nagi-s3/blocks/blk_a5e988454188cf9a4e822880200aef59471f2dc3.json
+content/micro/nagi-s3/blocks/blk_c96902a95bbfbfa7933940212a22494850705ef5.json
+content/micro/nagi-s3/blocks/blk_fc635800a6cf5ee011c0fdb0f9cd38b5391a0596.json
+content/micro/nagi-s3/entities/nagi-s3-ep01.json
+content/micro/nagi-s3/entities/nagi-s3-ep02.json
+content/micro/nagi-s3/entities/nagi-s3-ep03.json
+content/micro/nagi-s3/entities/nagi-s3-ep04.json
+content/micro/nagi-s3/entities/nagi-s3-ep05.json
+content/micro/nagi-s3/entities/nagi-s3-ep06.json
+content/micro/nagi-s3/entities/nagi-s3-ep07.json
+content/micro/nagi-s3/entities/nagi-s3-ep08.json
+content/micro/nagi-s3/entities/nagi-s3-ep09.json
+content/micro/nagi-s3/entities/nagi-s3-ep10.json
+content/micro/nagi-s3/entities/nagi-s3-ep11.json
+content/micro/nagi-s3/entities/nagi-s3-ep12.json
+content/micro/nagi-s3/entities/nagi-s3-ep13.json
+content/micro/nagi-s3/index.json
+```
+### stderr
+```text
+
+```
+
+
+## micro count: nagi-s3 blocks
+
+### cmd
+```bash
+find content/micro/nagi-s3/blocks -type f | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+13
+```
+### stderr
+```text
+
+```
+
+
+## micro count: nagi-s3 entities
+
+### cmd
+```bash
+find content/micro/nagi-s3/entities -type f | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+13
+```
+### stderr
+```text
+
+```
+
+
+## build: nagi-s2 (sitegen --check)
+
+### cmd
+```bash
+python -m sitegen.cli_build_site --micro-store content/micro/nagi-s2 --experiences config/experiences.yaml --src experience_src --out artifacts/nagi-s2_generated_v2 --shared --deterministic --check
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+Built 86 file(s) into /tmp/tmp79u03f_k/run1
+Built 86 file(s) into /tmp/tmp79u03f_k/run2
+Determinism check passed. Output copied to artifacts/nagi-s2_generated_v2
+```
+### stderr
+```text
+
+```
+
+
+## build: nagi-s3 (sitegen --check)
+
+### cmd
+```bash
+python -m sitegen.cli_build_site --micro-store content/micro/nagi-s3 --experiences config/experiences.yaml --src experience_src --out artifacts/nagi-s3_generated_v2 --shared --deterministic --check
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+Built 86 file(s) into /tmp/tmphfd4t9dt/run1
+Built 86 file(s) into /tmp/tmphfd4t9dt/run2
+Determinism check passed. Output copied to artifacts/nagi-s3_generated_v2
+```
+### stderr
+```text
+
+```
+
+
+## out check: nagi-s2 file count
+
+### cmd
+```bash
+find artifacts/nagi-s2_generated_v2 -type f | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+96
+```
+### stderr
+```text
+
+```
+
+
+## out check: nagi-s2 html count
+
+### cmd
+```bash
+find artifacts/nagi-s2_generated_v2 -type f -name '*.html' | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+84
+```
+### stderr
+```text
+
+```
+
+
+## out check: nagi-s2 micro.css
+
+### cmd
+```bash
+find artifacts/nagi-s2_generated_v2 -type f -name 'micro.css' | head -n 5 || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+artifacts/nagi-s2_generated_v2/micro.css
+```
+### stderr
+```text
+
+```
+
+
+## out check: nagi-s3 file count
+
+### cmd
+```bash
+find artifacts/nagi-s3_generated_v2 -type f | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+96
+```
+### stderr
+```text
+
+```
+
+
+## out check: nagi-s3 html count
+
+### cmd
+```bash
+find artifacts/nagi-s3_generated_v2 -type f -name '*.html' | wc -l || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+84
+```
+### stderr
+```text
+
+```
+
+
+## out check: nagi-s3 micro.css
+
+### cmd
+```bash
+find artifacts/nagi-s3_generated_v2 -type f -name 'micro.css' | head -n 5 || true
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+artifacts/nagi-s3_generated_v2/micro.css
+```
+### stderr
+```text
+
+```
+
+
+## git: status(after)
+
+### cmd
+```bash
+git status -sb
+```
+### rc
+```text
+0
+```
+### stdout
+```text
+## work
+?? docs/v2_flow_run_log.md
+```
+### stderr
+```text
+
+```


### PR DESCRIPTION
## Summary
- run the v2 micro generation and sitegen build flows for nagi-s2 and nagi-s3
- capture all command outputs, counts, and OK criteria in docs/v2_flow_run_log.md

## Testing
- python -m pytest -q tests/test_markdown_to_micro_v2.py
- python scripts/markdown_to_micro_v2.py --help
- python scripts/markdown_to_micro_v2.py --input nagi-s2/nagi-s2.md --out content/micro/nagi-s2 --season nagi-s2 --variant hina --expected-blocks 13 --force
- python scripts/markdown_to_micro_v2.py --input nagi-s3/nagi-s3.md --out content/micro/nagi-s3 --season nagi-s3 --variant hina --expected-blocks 13 --force
- python -m sitegen.cli_build_site --micro-store content/micro/nagi-s2 --experiences config/experiences.yaml --src experience_src --out artifacts/nagi-s2_generated_v2 --shared --deterministic --check
- python -m sitegen.cli_build_site --micro-store content/micro/nagi-s3 --experiences config/experiences.yaml --src experience_src --out artifacts/nagi-s3_generated_v2 --shared --deterministic --check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956515fcd8483338329eea85f6f0c1c)