### PR TITLE
test: add markdown_to_micro_v2 robustness suite and input matrix diagnostics

### DIFF
--- a/docs/robustness/matrix/cases/fail_no_fence/input.md
+++ b/docs/robustness/matrix/cases/fail_no_fence/input.md
@@ -1,0 +1,1 @@
+plain markdown only

--- a/docs/robustness/matrix/cases/fail_non_text_fence/input.md
+++ b/docs/robustness/matrix/cases/fail_non_text_fence/input.md
@@ -1,0 +1,3 @@
+```python
+print(1)
+```

--- a/docs/robustness/matrix/cases/ok_blank_lines_before_title/input.md
+++ b/docs/robustness/matrix/cases/ok_blank_lines_before_title/input.md
@@ -1,0 +1,6 @@
+```text
+
+
+Title
+Body
+```

--- a/docs/robustness/matrix/cases/ok_blank_lines_before_title/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
+++ b/docs/robustness/matrix/cases/ok_blank_lines_before_title/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
@@ -1,0 +1,5 @@
+{
+  "id": "blk_5be4b6652f1e8d4fd383b47b25f030492917db07",
+  "source": "Body",
+  "type": "Markdown"
+}

--- a/docs/robustness/matrix/cases/ok_blank_lines_before_title/store/entities/diag-season-ep01.json
+++ b/docs/robustness/matrix/cases/ok_blank_lines_before_title/store/entities/diag-season-ep01.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "blockRefs": [
+      "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+    ]
+  },
+  "id": "diag-season-ep01",
+  "meta": {
+    "summary": "Body",
+    "tags": [
+      "story",
+      "episode",
+      "diag-season"
+    ],
+    "title": "Title"
+  },
+  "relations": {
+    "index": 1,
+    "season": "diag-season"
+  },
+  "type": "story",
+  "variant": "hina"
+}

--- a/docs/robustness/matrix/cases/ok_blank_lines_before_title/store/index.json
+++ b/docs/robustness/matrix/cases/ok_blank_lines_before_title/store/index.json
@@ -1,0 +1,8 @@
+{
+  "block_ids": [
+    "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+  ],
+  "entity_ids": [
+    "diag-season-ep01"
+  ]
+}

--- a/docs/robustness/matrix/cases/ok_minimal/input.md
+++ b/docs/robustness/matrix/cases/ok_minimal/input.md
@@ -1,0 +1,4 @@
+```text
+Title
+Body
+```

--- a/docs/robustness/matrix/cases/ok_minimal/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
+++ b/docs/robustness/matrix/cases/ok_minimal/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
@@ -1,0 +1,5 @@
+{
+  "id": "blk_5be4b6652f1e8d4fd383b47b25f030492917db07",
+  "source": "Body",
+  "type": "Markdown"
+}

--- a/docs/robustness/matrix/cases/ok_minimal/store/entities/diag-season-ep01.json
+++ b/docs/robustness/matrix/cases/ok_minimal/store/entities/diag-season-ep01.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "blockRefs": [
+      "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+    ]
+  },
+  "id": "diag-season-ep01",
+  "meta": {
+    "summary": "Body",
+    "tags": [
+      "story",
+      "episode",
+      "diag-season"
+    ],
+    "title": "Title"
+  },
+  "relations": {
+    "index": 1,
+    "season": "diag-season"
+  },
+  "type": "story",
+  "variant": "hina"
+}

--- a/docs/robustness/matrix/cases/ok_minimal/store/index.json
+++ b/docs/robustness/matrix/cases/ok_minimal/store/index.json
@@ -1,0 +1,8 @@
+{
+  "block_ids": [
+    "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+  ],
+  "entity_ids": [
+    "diag-season-ep01"
+  ]
+}

--- a/docs/robustness/matrix/cases/ok_trailing_spaces_lang/input.md
+++ b/docs/robustness/matrix/cases/ok_trailing_spaces_lang/input.md
@@ -1,0 +1,4 @@
+```text   
+Title
+Body
+```

--- a/docs/robustness/matrix/cases/ok_trailing_spaces_lang/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
+++ b/docs/robustness/matrix/cases/ok_trailing_spaces_lang/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
@@ -1,0 +1,5 @@
+{
+  "id": "blk_5be4b6652f1e8d4fd383b47b25f030492917db07",
+  "source": "Body",
+  "type": "Markdown"
+}

--- a/docs/robustness/matrix/cases/ok_trailing_spaces_lang/store/entities/diag-season-ep01.json
+++ b/docs/robustness/matrix/cases/ok_trailing_spaces_lang/store/entities/diag-season-ep01.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "blockRefs": [
+      "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+    ]
+  },
+  "id": "diag-season-ep01",
+  "meta": {
+    "summary": "Body",
+    "tags": [
+      "story",
+      "episode",
+      "diag-season"
+    ],
+    "title": "Title"
+  },
+  "relations": {
+    "index": 1,
+    "season": "diag-season"
+  },
+  "type": "story",
+  "variant": "hina"
+}

--- a/docs/robustness/matrix/cases/ok_trailing_spaces_lang/store/index.json
+++ b/docs/robustness/matrix/cases/ok_trailing_spaces_lang/store/index.json
@@ -1,0 +1,8 @@
+{
+  "block_ids": [
+    "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+  ],
+  "entity_ids": [
+    "diag-season-ep01"
+  ]
+}

--- a/docs/robustness/matrix/cases/probe_backticks_in_body/input.md
+++ b/docs/robustness/matrix/cases/probe_backticks_in_body/input.md
@@ -1,0 +1,6 @@
+```text
+Title
+Body
+```
+looks like fence inside
+```

--- a/docs/robustness/matrix/cases/probe_backticks_in_body/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
+++ b/docs/robustness/matrix/cases/probe_backticks_in_body/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
@@ -1,0 +1,5 @@
+{
+  "id": "blk_5be4b6652f1e8d4fd383b47b25f030492917db07",
+  "source": "Body",
+  "type": "Markdown"
+}

--- a/docs/robustness/matrix/cases/probe_backticks_in_body/store/entities/diag-season-ep01.json
+++ b/docs/robustness/matrix/cases/probe_backticks_in_body/store/entities/diag-season-ep01.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "blockRefs": [
+      "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+    ]
+  },
+  "id": "diag-season-ep01",
+  "meta": {
+    "summary": "Body",
+    "tags": [
+      "story",
+      "episode",
+      "diag-season"
+    ],
+    "title": "Title"
+  },
+  "relations": {
+    "index": 1,
+    "season": "diag-season"
+  },
+  "type": "story",
+  "variant": "hina"
+}

--- a/docs/robustness/matrix/cases/probe_backticks_in_body/store/index.json
+++ b/docs/robustness/matrix/cases/probe_backticks_in_body/store/index.json
@@ -1,0 +1,8 @@
+{
+  "block_ids": [
+    "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+  ],
+  "entity_ids": [
+    "diag-season-ep01"
+  ]
+}

--- a/docs/robustness/matrix/cases/probe_bom/input.md
+++ b/docs/robustness/matrix/cases/probe_bom/input.md
@@ -1,0 +1,4 @@
+﻿```text
+Title
+Body
+```

--- a/docs/robustness/matrix/cases/probe_crlf/input.md
+++ b/docs/robustness/matrix/cases/probe_crlf/input.md
@@ -1,0 +1,4 @@
+```text
+Title
+Body
+```

--- a/docs/robustness/matrix/cases/probe_crlf/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
+++ b/docs/robustness/matrix/cases/probe_crlf/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
@@ -1,0 +1,5 @@
+{
+  "id": "blk_5be4b6652f1e8d4fd383b47b25f030492917db07",
+  "source": "Body",
+  "type": "Markdown"
+}

--- a/docs/robustness/matrix/cases/probe_crlf/store/entities/diag-season-ep01.json
+++ b/docs/robustness/matrix/cases/probe_crlf/store/entities/diag-season-ep01.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "blockRefs": [
+      "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+    ]
+  },
+  "id": "diag-season-ep01",
+  "meta": {
+    "summary": "Body",
+    "tags": [
+      "story",
+      "episode",
+      "diag-season"
+    ],
+    "title": "Title"
+  },
+  "relations": {
+    "index": 1,
+    "season": "diag-season"
+  },
+  "type": "story",
+  "variant": "hina"
+}

--- a/docs/robustness/matrix/cases/probe_crlf/store/index.json
+++ b/docs/robustness/matrix/cases/probe_crlf/store/index.json
@@ -1,0 +1,8 @@
+{
+  "block_ids": [
+    "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+  ],
+  "entity_ids": [
+    "diag-season-ep01"
+  ]
+}

--- a/docs/robustness/matrix/cases/probe_indented_fence/input.md
+++ b/docs/robustness/matrix/cases/probe_indented_fence/input.md
@@ -1,0 +1,4 @@
+    ```text
+Title
+Body
+    ```

--- a/docs/robustness/matrix/cases/probe_indented_fence/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
+++ b/docs/robustness/matrix/cases/probe_indented_fence/store/blocks/blk_5be4b6652f1e8d4fd383b47b25f030492917db07.json
@@ -1,0 +1,5 @@
+{
+  "id": "blk_5be4b6652f1e8d4fd383b47b25f030492917db07",
+  "source": "Body",
+  "type": "Markdown"
+}

--- a/docs/robustness/matrix/cases/probe_indented_fence/store/entities/diag-season-ep01.json
+++ b/docs/robustness/matrix/cases/probe_indented_fence/store/entities/diag-season-ep01.json
@@ -1,0 +1,23 @@
+{
+  "body": {
+    "blockRefs": [
+      "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+    ]
+  },
+  "id": "diag-season-ep01",
+  "meta": {
+    "summary": "Body",
+    "tags": [
+      "story",
+      "episode",
+      "diag-season"
+    ],
+    "title": "Title"
+  },
+  "relations": {
+    "index": 1,
+    "season": "diag-season"
+  },
+  "type": "story",
+  "variant": "hina"
+}

--- a/docs/robustness/matrix/cases/probe_indented_fence/store/index.json
+++ b/docs/robustness/matrix/cases/probe_indented_fence/store/index.json
@@ -1,0 +1,8 @@
+{
+  "block_ids": [
+    "blk_5be4b6652f1e8d4fd383b47b25f030492917db07"
+  ],
+  "entity_ids": [
+    "diag-season-ep01"
+  ]
+}

--- a/docs/robustness/matrix/cases/probe_unclosed_fence/input.md
+++ b/docs/robustness/matrix/cases/probe_unclosed_fence/input.md
@@ -1,0 +1,3 @@
+```text
+Title
+Body

--- a/docs/robustness/matrix/cases/probe_uppercase_lang/input.md
+++ b/docs/robustness/matrix/cases/probe_uppercase_lang/input.md
@@ -1,0 +1,4 @@
+```TEXT
+Title
+Body
+```

--- a/docs/robustness/matrix/matrix_report.md
+++ b/docs/robustness/matrix/matrix_report.md
@@ -1,0 +1,240 @@
+# markdown_to_micro_v2 input matrix report
+- script: `/workspace/stories/scripts/markdown_to_micro_v2.py`
+- season: `diag-season`
+- variant: `hina`
+- cases: 11
+
+| case | rc | expected_blocks | blocks | entities | notes |
+|---|---:|---:|---:|---:|---|
+| ok_minimal | 0 | 1 | 1 | 1 | minimal valid fence |
+| ok_trailing_spaces_lang | 0 | 1 | 1 | 1 | trailing spaces after language tag |
+| ok_blank_lines_before_title | 0 | 1 | 1 | 1 | blank lines before title |
+| fail_no_fence | 1 | 1 |  |  | no fences |
+| fail_non_text_fence | 1 | 1 |  |  | non-text fence only |
+| probe_uppercase_lang | 1 | 1 |  |  | is language case-sensitive? (observe) |
+| probe_indented_fence | 0 | 1 | 1 | 1 | indented fence (observe) |
+| probe_unclosed_fence | 1 | 1 |  |  | missing closing fence (observe) |
+| probe_backticks_in_body | 0 | 1 | 1 | 1 | backticks in body (observe) |
+| probe_bom | 1 | 1 |  |  | UTF-8 BOM at file start (observe) |
+| probe_crlf | 0 | 1 | 1 | 1 | CRLF newlines (observe) |
+
+## Detailed logs (truncated)
+
+### ok_minimal
+- notes: minimal valid fence
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/ok_minimal/input.md --out docs/robustness/matrix/cases/ok_minimal/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+0
+```
+**stdout**
+```text
+Wrote micro store to docs/robustness/matrix/cases/ok_minimal/store
+
+```
+**stderr**
+```text
+
+```
+
+### ok_trailing_spaces_lang
+- notes: trailing spaces after language tag
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/ok_trailing_spaces_lang/input.md --out docs/robustness/matrix/cases/ok_trailing_spaces_lang/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+0
+```
+**stdout**
+```text
+Wrote micro store to docs/robustness/matrix/cases/ok_trailing_spaces_lang/store
+
+```
+**stderr**
+```text
+
+```
+
+### ok_blank_lines_before_title
+- notes: blank lines before title
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/ok_blank_lines_before_title/input.md --out docs/robustness/matrix/cases/ok_blank_lines_before_title/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+0
+```
+**stdout**
+```text
+Wrote micro store to docs/robustness/matrix/cases/ok_blank_lines_before_title/store
+
+```
+**stderr**
+```text
+
+```
+
+### fail_no_fence
+- notes: no fences
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/fail_no_fence/input.md --out docs/robustness/matrix/cases/fail_no_fence/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+1
+```
+**stdout**
+```text
+
+```
+**stderr**
+```text
+Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/fail_no_fence/input.md
+
+```
+
+### fail_non_text_fence
+- notes: non-text fence only
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/fail_non_text_fence/input.md --out docs/robustness/matrix/cases/fail_non_text_fence/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+1
+```
+**stdout**
+```text
+
+```
+**stderr**
+```text
+Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/fail_non_text_fence/input.md
+
+```
+
+### probe_uppercase_lang
+- notes: is language case-sensitive? (observe)
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/probe_uppercase_lang/input.md --out docs/robustness/matrix/cases/probe_uppercase_lang/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+1
+```
+**stdout**
+```text
+
+```
+**stderr**
+```text
+Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/probe_uppercase_lang/input.md
+
+```
+
+### probe_indented_fence
+- notes: indented fence (observe)
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/probe_indented_fence/input.md --out docs/robustness/matrix/cases/probe_indented_fence/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+0
+```
+**stdout**
+```text
+Wrote micro store to docs/robustness/matrix/cases/probe_indented_fence/store
+
+```
+**stderr**
+```text
+
+```
+
+### probe_unclosed_fence
+- notes: missing closing fence (observe)
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/probe_unclosed_fence/input.md --out docs/robustness/matrix/cases/probe_unclosed_fence/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+1
+```
+**stdout**
+```text
+
+```
+**stderr**
+```text
+Traceback (most recent call last):
+  File "/workspace/stories/scripts/markdown_to_micro_v2.py", line 237, in <module>
+    main(sys.argv[1:])
+  File "/workspace/stories/scripts/markdown_to_micro_v2.py", line 223, in main
+    build_micro_store(
+  File "/workspace/stories/scripts/markdown_to_micro_v2.py", line 146, in build_micro_store
+    fences = extract_text_fences(markdown)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/workspace/stories/scripts/markdown_to_micro_v2.py", line 78, in extract_text_fences
+    raise ValueError("Unterminated ```text fenced block detected")
+ValueError: Unterminated ```text fenced block detected
+
+```
+
+### probe_backticks_in_body
+- notes: backticks in body (observe)
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/probe_backticks_in_body/input.md --out docs/robustness/matrix/cases/probe_backticks_in_body/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+0
+```
+**stdout**
+```text
+Wrote micro store to docs/robustness/matrix/cases/probe_backticks_in_body/store
+
+```
+**stderr**
+```text
+
+```
+
+### probe_bom
+- notes: UTF-8 BOM at file start (observe)
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/probe_bom/input.md --out docs/robustness/matrix/cases/probe_bom/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+1
+```
+**stdout**
+```text
+
+```
+**stderr**
+```text
+Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/probe_bom/input.md
+
+```
+
+### probe_crlf
+- notes: CRLF newlines (observe)
+```bash
+/root/.pyenv/versions/3.11.12/bin/python /workspace/stories/scripts/markdown_to_micro_v2.py --input docs/robustness/matrix/cases/probe_crlf/input.md --out docs/robustness/matrix/cases/probe_crlf/store --season diag-season --variant hina --expected-blocks 1 --force
+```
+**rc**
+```text
+0
+```
+**stdout**
+```text
+Wrote micro store to docs/robustness/matrix/cases/probe_crlf/store
+
+```
+**stderr**
+```text
+
+```

--- a/docs/robustness/matrix/matrix_summary.json
+++ b/docs/robustness/matrix/matrix_summary.json
@@ -1,0 +1,303 @@
+[
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/ok_minimal/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/ok_minimal/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "counts": {
+      "blocks": 1,
+      "entities": 1
+    },
+    "expected_blocks": 1,
+    "index_keys": [
+      "block_ids",
+      "entity_ids"
+    ],
+    "name": "ok_minimal",
+    "notes": "minimal valid fence",
+    "returncode": 0,
+    "stderr": "",
+    "stdout": "Wrote micro store to docs/robustness/matrix/cases/ok_minimal/store\n"
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/ok_trailing_spaces_lang/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/ok_trailing_spaces_lang/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "counts": {
+      "blocks": 1,
+      "entities": 1
+    },
+    "expected_blocks": 1,
+    "index_keys": [
+      "block_ids",
+      "entity_ids"
+    ],
+    "name": "ok_trailing_spaces_lang",
+    "notes": "trailing spaces after language tag",
+    "returncode": 0,
+    "stderr": "",
+    "stdout": "Wrote micro store to docs/robustness/matrix/cases/ok_trailing_spaces_lang/store\n"
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/ok_blank_lines_before_title/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/ok_blank_lines_before_title/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "counts": {
+      "blocks": 1,
+      "entities": 1
+    },
+    "expected_blocks": 1,
+    "index_keys": [
+      "block_ids",
+      "entity_ids"
+    ],
+    "name": "ok_blank_lines_before_title",
+    "notes": "blank lines before title",
+    "returncode": 0,
+    "stderr": "",
+    "stdout": "Wrote micro store to docs/robustness/matrix/cases/ok_blank_lines_before_title/store\n"
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/fail_no_fence/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/fail_no_fence/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "expected_blocks": 1,
+    "name": "fail_no_fence",
+    "notes": "no fences",
+    "returncode": 1,
+    "stderr": "Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/fail_no_fence/input.md\n",
+    "stdout": ""
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/fail_non_text_fence/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/fail_non_text_fence/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "expected_blocks": 1,
+    "name": "fail_non_text_fence",
+    "notes": "non-text fence only",
+    "returncode": 1,
+    "stderr": "Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/fail_non_text_fence/input.md\n",
+    "stdout": ""
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/probe_uppercase_lang/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/probe_uppercase_lang/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "expected_blocks": 1,
+    "name": "probe_uppercase_lang",
+    "notes": "is language case-sensitive? (observe)",
+    "returncode": 1,
+    "stderr": "Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/probe_uppercase_lang/input.md\n",
+    "stdout": ""
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/probe_indented_fence/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/probe_indented_fence/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "counts": {
+      "blocks": 1,
+      "entities": 1
+    },
+    "expected_blocks": 1,
+    "index_keys": [
+      "block_ids",
+      "entity_ids"
+    ],
+    "name": "probe_indented_fence",
+    "notes": "indented fence (observe)",
+    "returncode": 0,
+    "stderr": "",
+    "stdout": "Wrote micro store to docs/robustness/matrix/cases/probe_indented_fence/store\n"
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/probe_unclosed_fence/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/probe_unclosed_fence/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "expected_blocks": 1,
+    "name": "probe_unclosed_fence",
+    "notes": "missing closing fence (observe)",
+    "returncode": 1,
+    "stderr": "Traceback (most recent call last):\n  File \"/workspace/stories/scripts/markdown_to_micro_v2.py\", line 237, in <module>\n    main(sys.argv[1:])\n  File \"/workspace/stories/scripts/markdown_to_micro_v2.py\", line 223, in main\n    build_micro_store(\n  File \"/workspace/stories/scripts/markdown_to_micro_v2.py\", line 146, in build_micro_store\n    fences = extract_text_fences(markdown)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/workspace/stories/scripts/markdown_to_micro_v2.py\", line 78, in extract_text_fences\n    raise ValueError(\"Unterminated ```text fenced block detected\")\nValueError: Unterminated ```text fenced block detected\n",
+    "stdout": ""
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/probe_backticks_in_body/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/probe_backticks_in_body/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "counts": {
+      "blocks": 1,
+      "entities": 1
+    },
+    "expected_blocks": 1,
+    "index_keys": [
+      "block_ids",
+      "entity_ids"
+    ],
+    "name": "probe_backticks_in_body",
+    "notes": "backticks in body (observe)",
+    "returncode": 0,
+    "stderr": "",
+    "stdout": "Wrote micro store to docs/robustness/matrix/cases/probe_backticks_in_body/store\n"
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/probe_bom/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/probe_bom/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "expected_blocks": 1,
+    "name": "probe_bom",
+    "notes": "UTF-8 BOM at file start (observe)",
+    "returncode": 1,
+    "stderr": "Expected 1 fenced blocks but found 0 in docs/robustness/matrix/cases/probe_bom/input.md\n",
+    "stdout": ""
+  },
+  {
+    "cmd": [
+      "/root/.pyenv/versions/3.11.12/bin/python",
+      "/workspace/stories/scripts/markdown_to_micro_v2.py",
+      "--input",
+      "docs/robustness/matrix/cases/probe_crlf/input.md",
+      "--out",
+      "docs/robustness/matrix/cases/probe_crlf/store",
+      "--season",
+      "diag-season",
+      "--variant",
+      "hina",
+      "--expected-blocks",
+      "1",
+      "--force"
+    ],
+    "counts": {
+      "blocks": 1,
+      "entities": 1
+    },
+    "expected_blocks": 1,
+    "index_keys": [
+      "block_ids",
+      "entity_ids"
+    ],
+    "name": "probe_crlf",
+    "notes": "CRLF newlines (observe)",
+    "returncode": 0,
+    "stderr": "",
+    "stdout": "Wrote micro store to docs/robustness/matrix/cases/probe_crlf/store\n"
+  }
+]

--- a/docs/robustness/run_log.md
+++ b/docs/robustness/run_log.md
@@ -1,0 +1,137 @@
+# markdown_to_micro_v2 robustness suite run log
+
+このログは Codex codespace 上で pytest と入力マトリクス診断を実行した結果です。
+（stdout/stderr は長すぎる場合切り詰めています）
+
+
+
+## python --version
+
+### cmd
+```bash
+/root/.pyenv/versions/3.11.12/bin/python --version
+```
+
+### rc
+```text
+0
+```
+
+### stdout
+```text
+Python 3.11.12
+
+```
+
+### stderr
+```text
+
+```
+
+
+## sitegen import path check
+
+### cmd
+```bash
+/root/.pyenv/versions/3.11.12/bin/python -c import sitegen; print(sitegen.__file__)
+```
+
+### rc
+```text
+0
+```
+
+### stdout
+```text
+/workspace/stories/sitegen/__init__.py
+
+```
+
+### stderr
+```text
+
+```
+
+
+## pytest: existing + robustness
+
+### cmd
+```bash
+/root/.pyenv/versions/3.11.12/bin/python -m pytest -q tests/test_markdown_to_micro_v2.py tests/test_markdown_to_micro_v2_robustness.py
+```
+
+### rc
+```text
+0
+```
+
+### stdout
+```text
+............                                                             [100%]
+12 passed in 1.30s
+
+```
+
+### stderr
+```text
+
+```
+
+
+## matrix diagnose (writes docs/robustness/matrix/*)
+
+### cmd
+```bash
+/root/.pyenv/versions/3.11.12/bin/python scripts/diagnose_markdown_to_micro_v2_matrix.py --out docs/robustness/matrix --season diag-season --variant hina
+```
+
+### rc
+```text
+0
+```
+
+### stdout
+```text
+[OK] wrote docs/robustness/matrix/matrix_report.md
+[OK] wrote docs/robustness/matrix/matrix_summary.json
+
+```
+
+### stderr
+```text
+
+```
+
+
+## git status (after)
+
+### cmd
+```bash
+git status -sb
+```
+
+### rc
+```text
+0
+```
+
+### stdout
+```text
+## work
+?? docs/robustness/
+?? scripts/diagnose_markdown_to_micro_v2_matrix.py
+?? scripts/run_markdown_to_micro_v2_robustness_suite.py
+?? tests/test_markdown_to_micro_v2_robustness.py
+
+```
+
+### stderr
+```text
+
+```
+
+
+## Outputs
+- `docs/robustness/run_log.md`
+- `docs/robustness/matrix/matrix_report.md`
+- `docs/robustness/matrix/matrix_summary.json`

--- a/scripts/diagnose_markdown_to_micro_v2_matrix.py
+++ b/scripts/diagnose_markdown_to_micro_v2_matrix.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DEFAULT = REPO_ROOT / "scripts" / "markdown_to_micro_v2.py"
+
+MAX_CAPTURE = 4000  # truncate stdout/stderr for commit-friendly logs
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    markdown: str
+    expected_blocks: int
+    notes: str
+
+
+def trunc(s: str) -> str:
+    s = s or ""
+    if len(s) <= MAX_CAPTURE:
+        return s
+    return s[:MAX_CAPTURE] + "\n...<truncated>...\n"
+
+
+def run_case(script: Path, season: str, variant: str, work_dir: Path, case: Case) -> dict[str, Any]:
+    case_dir = work_dir / case.name
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    inp = case_dir / "input.md"
+    inp.write_text(case.markdown, encoding="utf-8")
+
+    out_dir = case_dir / "store"
+    cmd = [
+        sys.executable, str(script),
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", variant,
+        "--expected-blocks", str(case.expected_blocks),
+        "--force",
+    ]
+    proc = subprocess.run(cmd, cwd=str(REPO_ROOT), text=True, capture_output=True)
+
+    res: dict[str, Any] = {
+        "name": case.name,
+        "notes": case.notes,
+        "expected_blocks": case.expected_blocks,
+        "cmd": cmd,
+        "returncode": proc.returncode,
+        "stdout": trunc(proc.stdout),
+        "stderr": trunc(proc.stderr),
+    }
+
+    if proc.returncode == 0:
+        blocks_dir = out_dir / "blocks"
+        entities_dir = out_dir / "entities"
+        res["counts"] = {
+            "blocks": len(list(blocks_dir.glob("*.json"))) if blocks_dir.exists() else 0,
+            "entities": len(list(entities_dir.glob("*.json"))) if entities_dir.exists() else 0,
+        }
+        idx = out_dir / "index.json"
+        if idx.exists():
+            try:
+                j = json.loads(idx.read_text(encoding="utf-8"))
+                res["index_keys"] = sorted(j.keys()) if isinstance(j, dict) else []
+            except Exception as e:
+                res["index_parse_error"] = repr(e)
+
+    return res
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="docs/robustness/matrix", help="Output directory (tracked).")
+    ap.add_argument("--season", default="diag-season")
+    ap.add_argument("--variant", default="hina")
+    ap.add_argument("--script", default=str(SCRIPT_DEFAULT))
+    args = ap.parse_args()
+
+    script = Path(args.script)
+    if not script.exists():
+        print(f"[FATAL] missing script: {script}", file=sys.stderr)
+        return 2
+
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+    work_dir = out_root / "cases"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    def fence_text(content: str) -> str:
+        return "```text\n" + content.rstrip("\n") + "\n```\n"
+
+    cases: list[Case] = [
+        Case("ok_minimal", fence_text("Title\nBody"), 1, "minimal valid fence"),
+        Case("ok_trailing_spaces_lang", "```text   \nTitle\nBody\n```\n", 1, "trailing spaces after language tag"),
+        Case("ok_blank_lines_before_title", "```text\n\n\nTitle\nBody\n```\n", 1, "blank lines before title"),
+        Case("fail_no_fence", "plain markdown only\n", 1, "no fences"),
+        Case("fail_non_text_fence", "```python\nprint(1)\n```\n", 1, "non-text fence only"),
+        Case("probe_uppercase_lang", "```TEXT\nTitle\nBody\n```\n", 1, "is language case-sensitive? (observe)"),
+        Case("probe_indented_fence", "    ```text\nTitle\nBody\n    ```\n", 1, "indented fence (observe)"),
+        Case("probe_unclosed_fence", "```text\nTitle\nBody\n", 1, "missing closing fence (observe)"),
+        Case("probe_backticks_in_body", fence_text("Title\nBody\n```\nlooks like fence inside\n"), 1, "backticks in body (observe)"),
+        Case("probe_bom", "\ufeff" + fence_text("Title\nBody"), 1, "UTF-8 BOM at file start (observe)"),
+        Case("probe_crlf", "```text\r\nTitle\r\nBody\r\n```\r\n", 1, "CRLF newlines (observe)"),
+    ]
+
+    results: list[dict[str, Any]] = []
+    for c in cases:
+        results.append(run_case(script, args.season, args.variant, work_dir, c))
+
+    # Write machine-readable summary (truncated outputs)
+    (out_root / "matrix_summary.json").write_text(
+        json.dumps(results, ensure_ascii=False, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    # Write markdown report
+    lines: list[str] = []
+    lines.append("# markdown_to_micro_v2 input matrix report\n")
+    lines.append(f"- script: `{script}`\n")
+    lines.append(f"- season: `{args.season}`\n")
+    lines.append(f"- variant: `{args.variant}`\n")
+    lines.append(f"- cases: {len(cases)}\n\n")
+    lines.append("| case | rc | expected_blocks | blocks | entities | notes |\n")
+    lines.append("|---|---:|---:|---:|---:|---|\n")
+
+    for r in results:
+        counts = r.get("counts") or {}
+        lines.append(
+            f"| {r['name']} | {r['returncode']} | {r['expected_blocks']} | "
+            f"{counts.get('blocks','')} | {counts.get('entities','')} | {r['notes']} |\n"
+        )
+
+    lines.append("\n## Detailed logs (truncated)\n")
+    for r in results:
+        lines.append(f"\n### {r['name']}\n")
+        lines.append(f"- notes: {r['notes']}\n")
+        lines.append("```bash\n" + " ".join(map(str, r["cmd"])) + "\n```\n")
+        lines.append("**rc**\n```text\n" + str(r["returncode"]) + "\n```\n")
+        lines.append("**stdout**\n```text\n" + (r.get("stdout") or "") + "\n```\n")
+        lines.append("**stderr**\n```text\n" + (r.get("stderr") or "") + "\n```\n")
+
+    (out_root / "matrix_report.md").write_text("".join(lines), encoding="utf-8")
+
+    print(f"[OK] wrote {out_root/'matrix_report.md'}")
+    print(f"[OK] wrote {out_root/'matrix_summary.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_markdown_to_micro_v2_robustness_suite.py
+++ b/scripts/run_markdown_to_micro_v2_robustness_suite.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUT = REPO_ROOT / "docs" / "robustness" / "run_log.md"
+OUT.parent.mkdir(parents=True, exist_ok=True)
+
+MAX_CAPTURE = 8000  # keep enough context for failures
+
+
+def trunc(s: str) -> str:
+    s = s or ""
+    if len(s) <= MAX_CAPTURE:
+        return s
+    return s[:MAX_CAPTURE] + "\n...<truncated>...\n"
+
+
+def run(cmd: list[str]) -> tuple[int, str, str]:
+    p = subprocess.run(cmd, cwd=str(REPO_ROOT), text=True, capture_output=True)
+    return p.returncode, trunc(p.stdout), trunc(p.stderr)
+
+
+def write_section(title: str, cmd: list[str], rc: int, out: str, err: str) -> None:
+    with OUT.open("a", encoding="utf-8") as f:
+        f.write(f"\n\n## {title}\n")
+        f.write("\n### cmd\n```bash\n" + " ".join(cmd) + "\n```\n")
+        f.write("\n### rc\n```text\n" + str(rc) + "\n```\n")
+        f.write("\n### stdout\n```text\n" + out + "\n```\n")
+        f.write("\n### stderr\n```text\n" + err + "\n```\n")
+
+
+def main() -> int:
+    OUT.write_text(
+        "# markdown_to_micro_v2 robustness suite run log\n\n"
+        "このログは Codex codespace 上で pytest と入力マトリクス診断を実行した結果です。\n"
+        "（stdout/stderr は長すぎる場合切り詰めています）\n\n",
+        encoding="utf-8",
+    )
+
+    steps: list[tuple[str, list[str]]] = [
+        ("python --version", [sys.executable, "--version"]),
+        ("sitegen import path check", [sys.executable, "-c", "import sitegen; print(sitegen.__file__)"]),
+        ("pytest: existing + robustness", [sys.executable, "-m", "pytest", "-q",
+                                          "tests/test_markdown_to_micro_v2.py",
+                                          "tests/test_markdown_to_micro_v2_robustness.py"]),
+        ("matrix diagnose (writes docs/robustness/matrix/*)", [sys.executable, "scripts/diagnose_markdown_to_micro_v2_matrix.py",
+                                                               "--out", "docs/robustness/matrix",
+                                                               "--season", "diag-season",
+                                                               "--variant", "hina"]),
+        ("git status (after)", ["git", "status", "-sb"]),
+    ]
+
+    overall_rc = 0
+    for title, cmd in steps:
+        rc, out, err = run(cmd)
+        write_section(title, cmd, rc, out, err)
+        if title.startswith("pytest") and rc != 0:
+            overall_rc = 1
+        if title.startswith("matrix") and rc != 0:
+            overall_rc = 1
+
+    # Also write quick pointers
+    with OUT.open("a", encoding="utf-8") as f:
+        f.write("\n\n## Outputs\n")
+        f.write("- `docs/robustness/run_log.md`\n")
+        f.write("- `docs/robustness/matrix/matrix_report.md`\n")
+        f.write("- `docs/robustness/matrix/matrix_summary.json`\n")
+
+    print(f"[DONE] wrote {OUT}")
+    return overall_rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_markdown_to_micro_v2_robustness.py
+++ b/tests/test_markdown_to_micro_v2_robustness.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "markdown_to_micro_v2.py"
+
+BLK_PREFIX = "blk_"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    assert SCRIPT.exists(), f"missing: {SCRIPT}"
+    cmd = [sys.executable, str(SCRIPT), *args]
+    return subprocess.run(cmd, cwd=str(REPO_ROOT), text=True, capture_output=True)
+
+
+def _read_json(p: Path) -> dict:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _make_md_text_fences(blocks: list[str]) -> str:
+    out: list[str] = []
+    for b in blocks:
+        out.append("```text\n" + b.rstrip("\n") + "\n```\n")
+    return "\n".join(out)
+
+
+def _dir_digest(root: Path) -> str:
+    h = hashlib.sha256()
+    files = sorted([p for p in root.rglob("*") if p.is_file()])
+    for p in files:
+        rel = p.relative_to(root).as_posix().encode("utf-8")
+        h.update(rel)
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def test_help_exits_successfully() -> None:
+    proc = _run_cli("--help")
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    # keep help informative
+    assert "--input" in proc.stdout
+    assert "--out" in proc.stdout
+    assert "--season" in proc.stdout
+    assert "--expected-blocks" in proc.stdout
+
+
+def test_basic_valid_input_generates_store(tmp_path: Path) -> None:
+    season = "test-season"
+    blocks = [
+        "Title A\nHello world.\nLine2",
+        "Title B\n\nBody B line 1\nBody B line 2",
+    ]
+    md = _make_md_text_fences(blocks)
+    inp = tmp_path / "input.md"
+    inp.write_text(md, encoding="utf-8")
+
+    out_dir = tmp_path / "store"
+    proc = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "2",
+        "--tag", "extra1",
+        "--tag", "extra2",
+        "--force",
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+
+    assert (out_dir / "blocks").is_dir()
+    assert (out_dir / "entities").is_dir()
+    assert (out_dir / "index.json").is_file()
+
+    blocks_dir = out_dir / "blocks"
+    entities_dir = out_dir / "entities"
+
+    # entities should be numbered
+    assert (entities_dir / f"{season}-ep01.json").is_file()
+    assert (entities_dir / f"{season}-ep02.json").is_file()
+
+    ent1 = _read_json(entities_dir / f"{season}-ep01.json")
+    assert ent1.get("id") == f"{season}-ep01"
+    assert ent1.get("variant") == "hina"
+
+    meta = ent1.get("meta") or {}
+    assert meta.get("title") == "Title A"
+    summary = meta.get("summary")
+    assert isinstance(summary, str)
+    assert 0 < len(summary) <= 140
+    assert "\n" not in summary
+
+    tags = meta.get("tags")
+    assert isinstance(tags, list)
+    for required in ("story", "episode", season, "extra1", "extra2"):
+        assert required in tags
+
+    relations = ent1.get("relations") or {}
+    assert relations.get("season") == season
+    assert relations.get("index") == 1
+
+    body = ent1.get("body") or {}
+    refs = body.get("blockRefs")
+    assert isinstance(refs, list) and len(refs) == 1
+    blk_id = refs[0]
+    assert isinstance(blk_id, str) and blk_id.startswith(BLK_PREFIX) and len(blk_id) == 44
+
+    blk_path = blocks_dir / f"{blk_id}.json"
+    assert blk_path.is_file()
+
+    blk = _read_json(blk_path)
+    assert blk.get("id") == blk_id
+    # schema flexibility: either source or html should exist
+    assert ("source" in blk) or ("html" in blk)
+
+
+def test_title_extraction_skips_leading_blank_lines(tmp_path: Path) -> None:
+    season = "test-season"
+    md = "```text\n\n\n  \t\nReal Title\nBody\n```\n"
+    inp = tmp_path / "input.md"
+    inp.write_text(md, encoding="utf-8")
+
+    out_dir = tmp_path / "store"
+    proc = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "1",
+        "--force",
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    ent = _read_json(out_dir / "entities" / f"{season}-ep01.json")
+    assert (ent.get("meta") or {}).get("title") == "Real Title"
+
+
+def test_expected_blocks_mismatch_is_error(tmp_path: Path) -> None:
+    season = "test-season"
+    md = _make_md_text_fences(["Title\nBody"])
+    inp = tmp_path / "input.md"
+    inp.write_text(md, encoding="utf-8")
+
+    out_dir = tmp_path / "store"
+    proc = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "2",  # mismatch
+        "--force",
+    )
+    assert proc.returncode != 0
+    msg = (proc.stdout + "\n" + proc.stderr).lower()
+    assert msg.strip() != ""
+
+
+def test_no_text_fences_is_error(tmp_path: Path) -> None:
+    season = "test-season"
+    inp = tmp_path / "input.md"
+    inp.write_text("no fences here\n", encoding="utf-8")
+    out_dir = tmp_path / "store"
+
+    proc = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "1",
+        "--force",
+    )
+    assert proc.returncode != 0
+    msg = (proc.stdout + "\n" + proc.stderr).lower()
+    assert msg.strip() != ""
+
+
+def test_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    season = "test-season"
+    md = _make_md_text_fences(["Title\nBody"])
+    inp = tmp_path / "input.md"
+    inp.write_text(md, encoding="utf-8")
+    out_dir = tmp_path / "store"
+
+    proc1 = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "1",
+        "--force",
+    )
+    assert proc1.returncode == 0
+
+    proc2 = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "1",
+        # no --force
+    )
+    assert proc2.returncode != 0
+    msg = (proc2.stdout + "\n" + proc2.stderr).lower()
+    assert msg.strip() != ""
+
+
+def test_deterministic_output_for_same_input(tmp_path: Path) -> None:
+    season = "test-season"
+    blocks = ["Title A\nBody A", "Title B\nBody B"]
+    md = _make_md_text_fences(blocks)
+    inp = tmp_path / "input.md"
+    inp.write_text(md, encoding="utf-8")
+
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+
+    p1 = _run_cli(
+        "--input", str(inp),
+        "--out", str(out1),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "2",
+        "--force",
+    )
+    assert p1.returncode == 0, f"{p1.stdout}\n{p1.stderr}"
+
+    p2 = _run_cli(
+        "--input", str(inp),
+        "--out", str(out2),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "2",
+        "--force",
+    )
+    assert p2.returncode == 0, f"{p2.stdout}\n{p2.stderr}"
+
+    assert _dir_digest(out1) == _dir_digest(out2)
+
+
+def test_crlf_input_does_not_crash(tmp_path: Path) -> None:
+    season = "test-season"
+    md = "```text\r\nTitle\r\nBody line 1\r\nBody line 2\r\n```\r\n"
+    inp = tmp_path / "input.md"
+    inp.write_bytes(md.encode("utf-8"))
+
+    out_dir = tmp_path / "store"
+    proc = _run_cli(
+        "--input", str(inp),
+        "--out", str(out_dir),
+        "--season", season,
+        "--variant", "hina",
+        "--expected-blocks", "1",
+        "--force",
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"


### PR DESCRIPTION
## Summary
- add a dedicated pytest suite to check markdown_to_micro_v2 CLI robustness and determinism
- introduce an input-matrix diagnostic script and runnable suite wrapper that captures stdout/stderr
- record the generated robustness run logs and matrix reports under docs/robustness

## Testing
- python scripts/run_markdown_to_micro_v2_robustness_suite.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956bc64819c8333849f72ca80d62d35)