### PR TITLE
Enhance QA flow analysis and guided explore coverage

### DIFF
--- a/.qa/tests/flow/flow-analyze.spec.ts
+++ b/.qa/tests/flow/flow-analyze.spec.ts
@@ -5,6 +5,13 @@ import { qa } from "../../qa.config";
 
 type Edge = { from: string; to: string };
 type Broken = { from: string; href: string; reason: string };
+type AggregatedBroken = {
+  target: string;
+  hrefSamples: string[];
+  reasons: string[];
+  inbound: string[];
+  suggestions: string[];
+};
 
 function normalizePath(input: string): string {
   const s = (input || "").trim();
@@ -126,6 +133,61 @@ function suggestSources(
   return suggestions.slice(0, 6);
 }
 
+function buildInbound(edges: Edge[]): Map<string, Set<string>> {
+  const inbound = new Map<string, Set<string>>();
+  for (const e of edges) {
+    const from = normalizePath(e.from);
+    const to = normalizePath(e.to);
+    if (!inbound.has(to)) inbound.set(to, new Set());
+    inbound.get(to)!.add(from);
+  }
+  return inbound;
+}
+
+function aggregateCounts(items: string[]): Array<{ value: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const raw of items ?? []) {
+    const key = (raw || "").trim();
+    if (!key) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return Array.from(counts.entries())
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+}
+
+function commonSuffixLength(a: string[], b: string[]): number {
+  let i = 0;
+  while (i < a.length && i < b.length) {
+    if (a[a.length - 1 - i] !== b[b.length - 1 - i]) break;
+    i += 1;
+  }
+  return i;
+}
+
+function suggestReplacements(target: string, flowPages: Set<string>, limit = 5): string[] {
+  const t = normalizePath(target);
+  const tSegs = t.split("/").filter(Boolean);
+  if (tSegs.length === 0) return [];
+
+  const scored: Array<{ page: string; score: number }> = [];
+  for (const page of flowPages) {
+    if (page === t) continue;
+    const segs = page.split("/").filter(Boolean);
+    const suffix = commonSuffixLength(tSegs, segs);
+    if (suffix === 0) continue;
+
+    const sameRoot = tSegs[0] === segs[0];
+    const score = suffix * 2 + (sameRoot ? 1 : 0) + (segs.length === tSegs.length ? 0.5 : 0);
+    scored.push({ page, score });
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score || a.page.localeCompare(b.page))
+    .slice(0, limit)
+    .map((s) => s.page);
+}
+
 test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) => {
   test.setTimeout(5 * 60 * 1000);
 
@@ -156,6 +218,38 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
 
   const flowPages = new Set<string>((flow.pages ?? []).map(normalizePath));
   const edges = (flow.edges ?? []).map((e) => ({ from: normalizePath(e.from), to: normalizePath(e.to) }));
+  const inbound = buildInbound(edges);
+
+  const brokenAggregated = (() => {
+    const map = new Map<string, { target: string; hrefs: Set<string>; reasons: Set<string> }>();
+    for (const b of flow.broken ?? []) {
+      const target = normalizePath(b.href);
+      const entry = map.get(target) ?? {
+        target,
+        hrefs: new Set<string>(),
+        reasons: new Set<string>(),
+      };
+      entry.hrefs.add(b.href);
+      entry.reasons.add(b.reason);
+      map.set(target, entry);
+      const from = normalizePath(b.from);
+      if (!inbound.has(target)) inbound.set(target, new Set());
+      inbound.get(target)!.add(from);
+    }
+
+    return Array.from(map.values())
+      .map<AggregatedBroken>((v) => ({
+        target: v.target,
+        hrefSamples: Array.from(v.hrefs).sort().slice(0, 3),
+        reasons: Array.from(v.reasons).sort(),
+        inbound: Array.from(inbound.get(v.target) ?? [])
+          .sort()
+          .slice(0, 20),
+        suggestions: suggestReplacements(v.target, flowPages),
+      }))
+      .sort((a, b) => a.target.localeCompare(b.target));
+  })();
+  const brokenTargetSet = new Set(brokenAggregated.map((b) => b.target));
 
   const { inDeg, outDeg } = buildDegreeMaps(edges);
 
@@ -200,6 +294,7 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
     .map((p) => ({ page: p, out: outDeg.get(p) ?? 0 }))
     .filter((x) => x.out === 0)
     .sort((a, b) => a.page.localeCompare(b.page));
+  const deadEndsOk = deadEnds.filter((d) => !brokenTargetSet.has(d.page));
 
   const orphans = Array.from(flowPages)
     .map((p) => ({ page: p, in: inDeg.get(p) ?? 0 }))
@@ -215,16 +310,24 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
   const analysisMdPath = path.join(analysisDir, "flow-analysis.md");
   const fixMdPath = path.join(analysisDir, "link-fix-list.md");
 
+  const consoleErrors = aggregateCounts(flow.consoleErrors ?? []);
+  const blockedExternalRequests = aggregateCounts(flow.blockedExternalRequests ?? []);
   const counts = {
     knownRoutes: knownRoutes.length,
     crawledPages: flowPages.size,
     edges: edges.length,
     unreachable: unreachableChecked.length,
     deadEnds: deadEnds.length,
+    deadEndsOk: deadEndsOk.length,
     orphans: orphans.length,
-    broken: (flow.broken ?? []).length,
-    consoleErrors: (flow.consoleErrors ?? []).length,
-    blockedExternalRequests: (flow.blockedExternalRequests ?? []).length,
+    broken: brokenAggregated.length,
+    brokenRaw: (flow.broken ?? []).length,
+    consoleErrors: consoleErrors.length,
+    consoleErrorsTotal: (flow.consoleErrors ?? []).length,
+    consoleErrorsUnique: consoleErrors.length,
+    blockedExternalRequests: blockedExternalRequests.length,
+    blockedExternalRequestsTotal: (flow.blockedExternalRequests ?? []).length,
+    blockedExternalRequestsUnique: blockedExternalRequests.length,
   };
 
   const analysisJson = {
@@ -239,9 +342,6 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
     hubs,
     orphans,
     deadEnds,
-    broken: flow.broken ?? [],
-    consoleErrors: flow.consoleErrors ?? [],
-    blockedExternalRequests: flow.blockedExternalRequests ?? [],
     unreachable: unreachableChecked,
   };
 
@@ -254,8 +354,10 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
   md += `- crawledPages: ${counts.crawledPages}\n`;
   md += `- edges: ${counts.edges}\n`;
   md += `- unreachable: ${counts.unreachable}\n`;
-  md += `- deadEnds: ${counts.deadEnds}\n`;
-  md += `- broken: ${counts.broken}\n\n`;
+  md += `- deadEndsOk: ${deadEndsOk.length}\n`;
+  md += `- broken: ${counts.broken} (raw: ${counts.brokenRaw})\n`;
+  md += `- consoleErrors: uniq ${counts.consoleErrorsUnique} / total ${counts.consoleErrorsTotal}\n`;
+  md += `- blockedExternalRequests: uniq ${counts.blockedExternalRequestsUnique} / total ${counts.blockedExternalRequestsTotal}\n\n`;
 
   md += "## Top Hubs（リンクが多いページ）\n\n";
   for (const h of hubs) md += `- ${h.page} (out=${h.out})\n`;
@@ -268,19 +370,27 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
     md += "\n";
   }
 
-  if (deadEnds.length > 0) {
-    md += "## Dead Ends（遷移先リンクが見つからないページ）\n\n";
-    for (const d of deadEnds.slice(0, 200)) md += `- ${d.page}\n`;
-    if (deadEnds.length > 200) md += `\n…and ${deadEnds.length - 200} more\n`;
+  if (deadEndsOk.length > 0) {
+    md += "## Dead Ends OK（broken を除く、遷移先リンクが見つからないページ）\n\n";
+    for (const d of deadEndsOk.slice(0, 200)) md += `- ${d.page}\n`;
+    if (deadEndsOk.length > 200) md += `\n…and ${deadEndsOk.length - 200} more\n`;
     md += "\n";
   }
 
-  if ((flow.broken ?? []).length > 0) {
+  if (brokenAggregated.length > 0) {
     md += "## Broken（移動失敗・HTTP>=400 等）\n\n";
-    for (const b of (flow.broken ?? []).slice(0, 200)) {
-      md += `- from: \`${b.from}\` / href: \`${b.href}\` / reason: ${b.reason}\n`;
+    for (const b of brokenAggregated.slice(0, 200)) {
+      const inboundList = b.inbound.map((f) => `\`${f}\``).join(", ");
+      const suggestions = b.suggestions.map((s) => `\`${s}\``).join(", ");
+      const reasons = b.reasons.join(" / ");
+      const hrefs = b.hrefSamples.map((h) => `\`${h}\``).join(", ");
+      md += `- target: \`${b.target}\`\n`;
+      md += `  - href samples: ${hrefs}\n`;
+      md += `  - reason: ${reasons}\n`;
+      md += `  - inbound: ${inboundList || "(none)"}\n`;
+      md += `  - 置換候補: ${suggestions || "(なし)"}\n`;
     }
-    if ((flow.broken ?? []).length > 200) md += `\n…and ${(flow.broken ?? []).length - 200} more\n`;
+    if (brokenAggregated.length > 200) md += `\n…and ${brokenAggregated.length - 200} more\n`;
     md += "\n";
   }
 
@@ -296,10 +406,19 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
     md += "\n";
   }
 
-  if ((flow.blockedExternalRequests ?? []).length > 0) {
-    md += "## Blocked External Requests（外部アクセス遮断ログ）\n\n";
-    for (const u of (flow.blockedExternalRequests ?? []).slice(0, 200)) md += `- ${u}\n`;
-    if ((flow.blockedExternalRequests ?? []).length > 200) md += `\n…and ${(flow.blockedExternalRequests ?? []).length - 200} more\n`;
+  if (consoleErrors.length > 0) {
+    md += "## Console Errors（ユニーク）\n\n";
+    for (const c of consoleErrors.slice(0, 200)) {
+      md += `- (${c.count}) ${c.value}\n`;
+    }
+    if (consoleErrors.length > 200) md += `\n…and ${consoleErrors.length - 200} more\n`;
+    md += "\n";
+  }
+
+  if (blockedExternalRequests.length > 0) {
+    md += "## Blocked External Requests（ユニーク外部アクセス遮断ログ）\n\n";
+    for (const u of blockedExternalRequests.slice(0, 200)) md += `- (${u.count}) ${u.value}\n`;
+    if (blockedExternalRequests.length > 200) md += `\n…and ${blockedExternalRequests.length - 200} more\n`;
     md += "\n";
   }
 
@@ -310,7 +429,7 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
   fix += `- startPath: ${startPath}\n`;
   fix += `- knownRoutes: ${counts.knownRoutes}（source: ${known.source}）\n`;
   fix += `- unreachable: ${counts.unreachable}\n`;
-  fix += `- deadEnds: ${counts.deadEnds}\n`;
+  fix += `- deadEndsOk: ${deadEndsOk.length}\n`;
   fix += `- broken: ${counts.broken}\n\n`;
 
   fix += "## A) Unreachable（リンク不足の可能性）\n\n";
@@ -328,27 +447,50 @@ test("qa:flow:analyze (unreachable + fix list)", async ({ request }, testInfo) =
     fix += "\n";
   }
 
-  fix += "## B) Dead Ends（遷移が途切れるページ）\n\n";
-  if (deadEnds.length === 0) {
+  fix += "## B) Dead Ends（broken を除く、遷移が途切れるページ）\n\n";
+  if (deadEndsOk.length === 0) {
     fix += "- なし\n\n";
   } else {
-    for (const d of deadEnds) {
+    for (const d of deadEndsOk) {
       fix += `- [ ] \`${d.page}\` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）\n`;
     }
     fix += "\n";
   }
 
   fix += "## C) Broken（リンク/遷移エラー）\n\n";
-  if ((flow.broken ?? []).length === 0) {
+  if (brokenAggregated.length === 0) {
     fix += "- なし\n\n";
   } else {
-    for (const b of (flow.broken ?? [])) {
-      fix += `- [ ] from \`${b.from}\` / href \`${b.href}\` → ${b.reason}\n`;
+    for (const b of brokenAggregated) {
+      const inboundList = b.inbound.map((f) => `\`${f}\``).join(", ");
+      const suggestions = b.suggestions.map((s) => `\`${s}\``).join(", ");
+      const reasons = b.reasons.join(" / ");
+      fix += `- [ ] target \`${b.target}\` (${reasons})\n`;
+      fix += `  - リンク元: ${inboundList || "(not recorded)"}\n`;
+      fix += `  - 置換候補: ${suggestions || "(なし)"}\n`;
+      if (b.hrefSamples.length > 0) {
+        fix += `  - href samples: ${b.hrefSamples.map((h) => `\`${h}\``).join(", ")}\n`;
+      }
     }
     fix += "\n";
   }
 
-  await fs.writeFile(analysisJsonPath, JSON.stringify(analysisJson, null, 2), "utf8");
+  await fs.writeFile(
+    analysisJsonPath,
+    JSON.stringify(
+      {
+        ...analysisJson,
+        deadEndsOk,
+        brokenRaw: flow.broken ?? [],
+        brokenAggregated,
+        consoleErrors,
+        blockedExternalRequests,
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
   await fs.writeFile(analysisMdPath, md, "utf8");
   await fs.writeFile(fixMdPath, fix, "utf8");
 

--- a/docs/qa/QA_POCKET_RUNLOG.md
+++ b/docs/qa/QA_POCKET_RUNLOG.md
@@ -51,3 +51,30 @@ Summary:
 - blockedExternalRequests: 36
 
 No unreachable routes detected (or known-routes list is empty).
+
+## Run 2026-01-02T00:42:08.075Z
+
+Commands:
+- QA_FLOW_PUBLISH=1 qa:fixlist
+- QA_EXPLORE_SECONDS=60 qa:explore:guided
+
+Outputs (docs):
+- docs/qa/screen-flow.md
+- docs/qa/screen-flow.json
+- docs/qa/flow-analysis.md
+- docs/qa/flow-analysis.json
+- docs/qa/link-fix-list.md
+- docs/qa/guided-coverage.json
+
+Summary:
+- knownRoutes: 5 (source: file:/workspace/stories/.qa/known-routes.txt)
+- crawledPages: 52
+- edges: 106
+- unreachable: 0
+- deadEndsOk: 0
+- broken: 19 (raw: 19)
+- consoleErrors: uniq 2 / total 55
+- blockedExternalRequests: uniq 3 / total 36
+- coverage: 61.5% (visited 32/52)
+
+No unreachable routes detected (or known-routes list is empty).

--- a/docs/qa/flow-analysis.json
+++ b/docs/qa/flow-analysis.json
@@ -4,7 +4,7 @@
     "startPath": "/",
     "flowJsonPath": "/workspace/stories/.qa/artifacts/flow/screen-flow.json",
     "knownRoutesSource": "file:/workspace/stories/.qa/known-routes.txt",
-    "generatedAt": "2026-01-01T21:54:26.089Z"
+    "generatedAt": "2026-01-02T00:41:03.280Z"
   },
   "counts": {
     "knownRoutes": 5,
@@ -12,10 +12,16 @@
     "edges": 106,
     "unreachable": 0,
     "deadEnds": 19,
+    "deadEndsOk": 0,
     "orphans": 0,
     "broken": 19,
-    "consoleErrors": 55,
-    "blockedExternalRequests": 36
+    "brokenRaw": 19,
+    "consoleErrors": 2,
+    "consoleErrorsTotal": 55,
+    "consoleErrorsUnique": 2,
+    "blockedExternalRequests": 3,
+    "blockedExternalRequestsTotal": 36,
+    "blockedExternalRequestsUnique": 3
   },
   "hubs": [
     {
@@ -137,198 +143,6 @@
       "page": "/nagi-s1/shared",
       "out": 0
     }
-  ],
-  "broken": [
-    {
-      "from": "/nagi-s1/generated/list",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/list",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep01",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep01",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep02",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep02",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep03",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep03",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep04",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep04",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep05",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep05",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep06",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep06",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep07",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep07",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep08",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep08",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep09",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep09",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep10",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep10",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep11",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep11",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/generated/posts/ep12",
-      "href": "http://127.0.0.1:3000/nagi-s1/generated/posts/ep12",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/_buildinfo.json",
-      "href": "http://127.0.0.1:3000/nagi-s1/_buildinfo.json",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/hina",
-      "href": "http://127.0.0.1:3000/nagi-s1/hina",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/immersive",
-      "href": "http://127.0.0.1:3000/nagi-s1/immersive",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/magazine",
-      "href": "http://127.0.0.1:3000/nagi-s1/magazine",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/routes.json",
-      "href": "http://127.0.0.1:3000/nagi-s1/routes.json",
-      "reason": "HTTP 404"
-    },
-    {
-      "from": "/nagi-s1/shared",
-      "href": "http://127.0.0.1:3000/nagi-s1/shared",
-      "reason": "HTTP 404"
-    }
-  ],
-  "consoleErrors": [
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: net::ERR_FAILED",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)",
-    "console: Failed to load resource: the server responded with a status of 404 (File not found)"
-  ],
-  "blockedExternalRequests": [
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js",
-    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
   ],
   "unreachable": []
 }

--- a/docs/qa/flow-analysis.md
+++ b/docs/qa/flow-analysis.md
@@ -6,8 +6,10 @@
 - crawledPages: 52
 - edges: 106
 - unreachable: 0
-- deadEnds: 19
-- broken: 19
+- deadEndsOk: 0
+- broken: 19 (raw: 19)
+- consoleErrors: uniq 2 / total 55
+- blockedExternalRequests: uniq 3 / total 36
 
 ## Top Hubs（リンクが多いページ）
 
@@ -22,86 +24,112 @@
 - /nagi-s1/generated/hina/posts/ep02 (out=2)
 - /nagi-s1/generated/hina/posts/ep03 (out=2)
 
-## Dead Ends（遷移先リンクが見つからないページ）
-
-- /nagi-s1/_buildinfo.json
-- /nagi-s1/generated/list
-- /nagi-s1/generated/posts/ep01
-- /nagi-s1/generated/posts/ep02
-- /nagi-s1/generated/posts/ep03
-- /nagi-s1/generated/posts/ep04
-- /nagi-s1/generated/posts/ep05
-- /nagi-s1/generated/posts/ep06
-- /nagi-s1/generated/posts/ep07
-- /nagi-s1/generated/posts/ep08
-- /nagi-s1/generated/posts/ep09
-- /nagi-s1/generated/posts/ep10
-- /nagi-s1/generated/posts/ep11
-- /nagi-s1/generated/posts/ep12
-- /nagi-s1/hina
-- /nagi-s1/immersive
-- /nagi-s1/magazine
-- /nagi-s1/routes.json
-- /nagi-s1/shared
-
 ## Broken（移動失敗・HTTP>=400 等）
 
-- from: `/nagi-s1/generated/list` / href: `http://127.0.0.1:3000/nagi-s1/generated/list` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep01` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep01` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep02` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep02` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep03` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep03` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep04` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep04` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep05` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep05` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep06` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep06` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep07` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep07` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep08` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep08` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep09` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep09` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep10` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep10` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep11` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep11` / reason: HTTP 404
-- from: `/nagi-s1/generated/posts/ep12` / href: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep12` / reason: HTTP 404
-- from: `/nagi-s1/_buildinfo.json` / href: `http://127.0.0.1:3000/nagi-s1/_buildinfo.json` / reason: HTTP 404
-- from: `/nagi-s1/hina` / href: `http://127.0.0.1:3000/nagi-s1/hina` / reason: HTTP 404
-- from: `/nagi-s1/immersive` / href: `http://127.0.0.1:3000/nagi-s1/immersive` / reason: HTTP 404
-- from: `/nagi-s1/magazine` / href: `http://127.0.0.1:3000/nagi-s1/magazine` / reason: HTTP 404
-- from: `/nagi-s1/routes.json` / href: `http://127.0.0.1:3000/nagi-s1/routes.json` / reason: HTTP 404
-- from: `/nagi-s1/shared` / href: `http://127.0.0.1:3000/nagi-s1/shared` / reason: HTTP 404
+- target: `/nagi-s1/_buildinfo.json`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/_buildinfo.json`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/_buildinfo.json`, `/nagi-s1/generated`
+  - 置換候補: (なし)
+- target: `/nagi-s1/generated/list`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/list`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/posts/ep01`, `/nagi-s1/generated/hina/posts/ep02`, `/nagi-s1/generated/hina/posts/ep03`, `/nagi-s1/generated/hina/posts/ep04`, `/nagi-s1/generated/hina/posts/ep05`, `/nagi-s1/generated/hina/posts/ep06`, `/nagi-s1/generated/hina/posts/ep07`, `/nagi-s1/generated/hina/posts/ep08`, `/nagi-s1/generated/hina/posts/ep09`, `/nagi-s1/generated/hina/posts/ep10`, `/nagi-s1/generated/hina/posts/ep11`, `/nagi-s1/generated/hina/posts/ep12`, `/nagi-s1/generated/list`
+  - 置換候補: `/nagi-s1/generated/hina/list`
+- target: `/nagi-s1/generated/posts/ep01`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep01`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep01`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep01`
+- target: `/nagi-s1/generated/posts/ep02`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep02`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep02`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep02`
+- target: `/nagi-s1/generated/posts/ep03`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep03`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep03`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep03`
+- target: `/nagi-s1/generated/posts/ep04`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep04`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep04`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep04`
+- target: `/nagi-s1/generated/posts/ep05`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep05`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep05`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep05`
+- target: `/nagi-s1/generated/posts/ep06`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep06`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep06`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep06`
+- target: `/nagi-s1/generated/posts/ep07`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep07`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep07`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep07`
+- target: `/nagi-s1/generated/posts/ep08`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep08`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep08`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep08`
+- target: `/nagi-s1/generated/posts/ep09`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep09`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep09`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep09`
+- target: `/nagi-s1/generated/posts/ep10`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep10`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep10`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep10`
+- target: `/nagi-s1/generated/posts/ep11`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep11`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep11`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep11`
+- target: `/nagi-s1/generated/posts/ep12`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep12`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep12`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep12`
+- target: `/nagi-s1/hina`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/hina`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated`, `/nagi-s1/hina`
+  - 置換候補: `/nagi-s1/generated/hina`
+- target: `/nagi-s1/immersive`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/immersive`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated`, `/nagi-s1/immersive`
+  - 置換候補: (なし)
+- target: `/nagi-s1/magazine`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/magazine`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated`, `/nagi-s1/magazine`
+  - 置換候補: (なし)
+- target: `/nagi-s1/routes.json`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/routes.json`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated`, `/nagi-s1/routes.json`
+  - 置換候補: (なし)
+- target: `/nagi-s1/shared`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/shared`
+  - reason: HTTP 404
+  - inbound: `/nagi-s1/generated`, `/nagi-s1/shared`
+  - 置換候補: (なし)
 
-## Blocked External Requests（外部アクセス遮断ログ）
+## Console Errors（ユニーク）
 
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
-- https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
+- (36) console: Failed to load resource: net::ERR_FAILED
+- (19) console: Failed to load resource: the server responded with a status of 404 (File not found)
+
+## Blocked External Requests（ユニーク外部アクセス遮断ログ）
+
+- (12) https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js
+- (12) https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css
+- (12) https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js
 

--- a/docs/qa/guided-coverage.json
+++ b/docs/qa/guided-coverage.json
@@ -1,17 +1,19 @@
 {
   "meta": {
     "baseURL": "http://127.0.0.1:3000",
-    "seed": 1767304471594,
+    "seed": 1767314467106,
     "seconds": 60,
     "startPath": "/",
-    "generatedAt": "2026-01-01T21:55:31.665Z",
+    "restartEvery": 15,
+    "generatedAt": "2026-01-02T00:42:07.355Z",
     "flowJsonPath": "/workspace/stories/.qa/artifacts/flow/screen-flow.json"
   },
   "targetsCount": 52,
-  "visitedCount": 16,
-  "coverage": 0.3076923076923077,
+  "visitedCount": 32,
+  "coverage": 0.6153846153846154,
   "visited": [
     "/",
+    "/index.html",
     "/nagi-s1/generated/hina",
     "/nagi-s1/generated/hina/index.html",
     "/nagi-s1/generated/hina/list",
@@ -26,10 +28,24 @@
     "/nagi-s1/generated/hina/posts/ep09",
     "/nagi-s1/generated/hina/posts/ep10",
     "/nagi-s1/generated/hina/posts/ep11",
-    "/nagi-s1/generated/hina/posts/ep12"
+    "/nagi-s1/generated/hina/posts/ep12",
+    "/nagi-s1/index.html",
+    "/nagi-s1/story1.html",
+    "/nagi-s1/story10.html",
+    "/nagi-s1/story11.html",
+    "/nagi-s1/story12.html",
+    "/nagi-s1/story2.html",
+    "/nagi-s1/story3.html",
+    "/nagi-s1/story4.html",
+    "/nagi-s1/story5.html",
+    "/nagi-s1/story6.html",
+    "/nagi-s1/story7.html",
+    "/nagi-s1/story8.html",
+    "/nagi-s1/story9.html",
+    "/nagi-s2/index.html",
+    "/nagi-s3/index.html"
   ],
   "uncovered": [
-    "/index.html",
     "/nagi-s1/_buildinfo.json",
     "/nagi-s1/generated",
     "/nagi-s1/generated/list",
@@ -47,98 +63,78 @@
     "/nagi-s1/generated/posts/ep12",
     "/nagi-s1/hina",
     "/nagi-s1/immersive",
-    "/nagi-s1/index.html",
     "/nagi-s1/magazine",
     "/nagi-s1/routes.json",
-    "/nagi-s1/shared",
-    "/nagi-s1/story1.html",
-    "/nagi-s1/story10.html",
-    "/nagi-s1/story11.html",
-    "/nagi-s1/story12.html",
-    "/nagi-s1/story2.html",
-    "/nagi-s1/story3.html",
-    "/nagi-s1/story4.html",
-    "/nagi-s1/story5.html",
-    "/nagi-s1/story6.html",
-    "/nagi-s1/story7.html",
-    "/nagi-s1/story8.html",
-    "/nagi-s1/story9.html",
-    "/nagi-s2/index.html",
-    "/nagi-s3/index.html"
+    "/nagi-s1/shared"
   ],
   "steps": [
     {
       "from": "/",
+      "to": "/nagi-s2/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s2/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
       "to": "/nagi-s1/generated/hina/index.html",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina/index.html",
-      "to": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep03",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
+      "from": "/nagi-s1/generated/hina/posts/ep03",
       "to": "/nagi-s1/generated/hina",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep07",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep07",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
       "to": "/nagi-s1/generated/hina/posts/ep01",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina/posts/ep01",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
       "to": "/nagi-s1/generated/hina/list",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep10",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep10",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep04",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep04",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
       "to": "/nagi-s1/generated/hina/posts/ep09",
       "via": "goto(link)"
     },
@@ -149,6 +145,131 @@
     },
     {
       "from": "/nagi-s1/generated/hina/list",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story7.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story7.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story1.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story1.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story4.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story4.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story11.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story11.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story2.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story2.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story8.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story8.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story12.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story12.html",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s2/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s2/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/generated/hina/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/index.html",
+      "to": "/nagi-s1/generated/hina/posts/ep11",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep11",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep06",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep06",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
       "to": "/nagi-s1/generated/hina/posts/ep12",
       "via": "goto(link)"
     },
@@ -159,16 +280,6 @@
     },
     {
       "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep10",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep10",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
       "to": "/nagi-s1/generated/hina/posts/ep05",
       "via": "goto(link)"
     },
@@ -179,16 +290,181 @@
     },
     {
       "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
+      "to": "/nagi-s1/generated/hina/posts/ep02",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
+      "from": "/nagi-s1/generated/hina/posts/ep02",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story3.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story3.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story6.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story6.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story5.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story5.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story10.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story10.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story9.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story9.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story12.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story12.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story6.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story6.html",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s2/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s2/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/generated/hina/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/index.html",
+      "to": "/nagi-s1/generated/hina/posts/ep07",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep07",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep08",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep08",
       "to": "/nagi-s1/generated/hina/list",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep11",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep11",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep05",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep05",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep02",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep02",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep08",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep08",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/generated/hina/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/index.html",
       "to": "/nagi-s1/generated/hina/posts/ep03",
       "via": "goto(link)"
     },
@@ -204,6 +480,176 @@
     },
     {
       "from": "/nagi-s1/generated/hina/posts/ep07",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep06",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep06",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep02",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep02",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep08",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep08",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep12",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep12",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story8.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story8.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story1.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story1.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story5.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story5.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story6.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story6.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story10.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story10.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story8.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story8.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story5.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story5.html",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/generated/hina/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/index.html",
+      "to": "/nagi-s1/generated/hina/posts/ep04",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep04",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep11",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep11",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep12",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep12",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep05",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep05",
       "to": "/nagi-s1/generated/hina",
       "via": "goto(link)"
     },
@@ -219,503 +665,23 @@
     },
     {
       "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
       "to": "/nagi-s1/generated/hina/posts/ep03",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina/posts/ep03",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
+      "to": "/",
+      "via": "goto(restart)"
     },
     {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep09",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep09",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep10",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep10",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep10",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep10",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep03",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep03",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep07",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep07",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep07",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep07",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep05",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep05",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep01",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep01",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep10",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep10",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep07",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep07",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep01",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep01",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep05",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep05",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep01",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep01",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep10",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep10",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep05",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep05",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
+      "from": "/",
+      "to": "/nagi-s3/index.html",
       "via": "goto(link)"
     }
+  ],
+  "blockedExternalRequests": [
+    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js",
+    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css",
+    "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
   ]
 }

--- a/docs/qa/link-fix-list.md
+++ b/docs/qa/link-fix-list.md
@@ -4,54 +4,93 @@
 - startPath: /
 - knownRoutes: 5（source: file:/workspace/stories/.qa/known-routes.txt）
 - unreachable: 0
-- deadEnds: 19
+- deadEndsOk: 0
 - broken: 19
 
 ## A) Unreachable（リンク不足の可能性）
 
 - なし
 
-## B) Dead Ends（遷移が途切れるページ）
+## B) Dead Ends（broken を除く、遷移が途切れるページ）
 
-- [ ] `/nagi-s1/_buildinfo.json` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/list` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep01` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep02` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep03` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep04` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep05` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep06` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep07` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep08` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep09` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep10` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep11` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/generated/posts/ep12` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/hina` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/immersive` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/magazine` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/routes.json` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
-- [ ] `/nagi-s1/shared` に **戻る/ナビ/次ページ** のリンクを追加（out-degree=0）
+- なし
 
 ## C) Broken（リンク/遷移エラー）
 
-- [ ] from `/nagi-s1/generated/list` / href `http://127.0.0.1:3000/nagi-s1/generated/list` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep01` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep01` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep02` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep02` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep03` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep03` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep04` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep04` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep05` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep05` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep06` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep06` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep07` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep07` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep08` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep08` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep09` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep09` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep10` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep10` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep11` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep11` → HTTP 404
-- [ ] from `/nagi-s1/generated/posts/ep12` / href `http://127.0.0.1:3000/nagi-s1/generated/posts/ep12` → HTTP 404
-- [ ] from `/nagi-s1/_buildinfo.json` / href `http://127.0.0.1:3000/nagi-s1/_buildinfo.json` → HTTP 404
-- [ ] from `/nagi-s1/hina` / href `http://127.0.0.1:3000/nagi-s1/hina` → HTTP 404
-- [ ] from `/nagi-s1/immersive` / href `http://127.0.0.1:3000/nagi-s1/immersive` → HTTP 404
-- [ ] from `/nagi-s1/magazine` / href `http://127.0.0.1:3000/nagi-s1/magazine` → HTTP 404
-- [ ] from `/nagi-s1/routes.json` / href `http://127.0.0.1:3000/nagi-s1/routes.json` → HTTP 404
-- [ ] from `/nagi-s1/shared` / href `http://127.0.0.1:3000/nagi-s1/shared` → HTTP 404
+- [ ] target `/nagi-s1/_buildinfo.json` (HTTP 404)
+  - リンク元: `/nagi-s1/_buildinfo.json`, `/nagi-s1/generated`
+  - 置換候補: (なし)
+  - href samples: `http://127.0.0.1:3000/nagi-s1/_buildinfo.json`
+- [ ] target `/nagi-s1/generated/list` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/posts/ep01`, `/nagi-s1/generated/hina/posts/ep02`, `/nagi-s1/generated/hina/posts/ep03`, `/nagi-s1/generated/hina/posts/ep04`, `/nagi-s1/generated/hina/posts/ep05`, `/nagi-s1/generated/hina/posts/ep06`, `/nagi-s1/generated/hina/posts/ep07`, `/nagi-s1/generated/hina/posts/ep08`, `/nagi-s1/generated/hina/posts/ep09`, `/nagi-s1/generated/hina/posts/ep10`, `/nagi-s1/generated/hina/posts/ep11`, `/nagi-s1/generated/hina/posts/ep12`, `/nagi-s1/generated/list`
+  - 置換候補: `/nagi-s1/generated/hina/list`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/list`
+- [ ] target `/nagi-s1/generated/posts/ep01` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep01`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep01`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep01`
+- [ ] target `/nagi-s1/generated/posts/ep02` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep02`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep02`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep02`
+- [ ] target `/nagi-s1/generated/posts/ep03` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep03`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep03`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep03`
+- [ ] target `/nagi-s1/generated/posts/ep04` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep04`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep04`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep04`
+- [ ] target `/nagi-s1/generated/posts/ep05` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep05`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep05`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep05`
+- [ ] target `/nagi-s1/generated/posts/ep06` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep06`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep06`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep06`
+- [ ] target `/nagi-s1/generated/posts/ep07` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep07`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep07`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep07`
+- [ ] target `/nagi-s1/generated/posts/ep08` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep08`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep08`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep08`
+- [ ] target `/nagi-s1/generated/posts/ep09` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep09`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep09`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep09`
+- [ ] target `/nagi-s1/generated/posts/ep10` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep10`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep10`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep10`
+- [ ] target `/nagi-s1/generated/posts/ep11` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep11`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep11`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep11`
+- [ ] target `/nagi-s1/generated/posts/ep12` (HTTP 404)
+  - リンク元: `/nagi-s1/generated/hina`, `/nagi-s1/generated/hina/list`, `/nagi-s1/generated/posts/ep12`
+  - 置換候補: `/nagi-s1/generated/hina/posts/ep12`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/generated/posts/ep12`
+- [ ] target `/nagi-s1/hina` (HTTP 404)
+  - リンク元: `/nagi-s1/generated`, `/nagi-s1/hina`
+  - 置換候補: `/nagi-s1/generated/hina`
+  - href samples: `http://127.0.0.1:3000/nagi-s1/hina`
+- [ ] target `/nagi-s1/immersive` (HTTP 404)
+  - リンク元: `/nagi-s1/generated`, `/nagi-s1/immersive`
+  - 置換候補: (なし)
+  - href samples: `http://127.0.0.1:3000/nagi-s1/immersive`
+- [ ] target `/nagi-s1/magazine` (HTTP 404)
+  - リンク元: `/nagi-s1/generated`, `/nagi-s1/magazine`
+  - 置換候補: (なし)
+  - href samples: `http://127.0.0.1:3000/nagi-s1/magazine`
+- [ ] target `/nagi-s1/routes.json` (HTTP 404)
+  - リンク元: `/nagi-s1/generated`, `/nagi-s1/routes.json`
+  - 置換候補: (なし)
+  - href samples: `http://127.0.0.1:3000/nagi-s1/routes.json`
+- [ ] target `/nagi-s1/shared` (HTTP 404)
+  - リンク元: `/nagi-s1/generated`, `/nagi-s1/shared`
+  - 置換候補: (なし)
+  - href samples: `http://127.0.0.1:3000/nagi-s1/shared`
 

--- a/docs/qa/screen-flow.json
+++ b/docs/qa/screen-flow.json
@@ -4,7 +4,7 @@
     "startPath": "/",
     "maxPages": 200,
     "maxDepth": 10,
-    "generatedAt": "2026-01-01T21:54:21.776Z"
+    "generatedAt": "2026-01-02T00:41:00.409Z"
   },
   "pages": [
     "/",
@@ -63,11 +63,11 @@
   "edges": [
     {
       "from": "/",
-      "to": "/nagi-s1/index.html"
+      "to": "/nagi-s1/generated/hina/index.html"
     },
     {
       "from": "/",
-      "to": "/nagi-s1/generated/hina/index.html"
+      "to": "/nagi-s1/index.html"
     },
     {
       "from": "/",
@@ -79,11 +79,11 @@
     },
     {
       "from": "/index.html",
-      "to": "/nagi-s1/index.html"
+      "to": "/nagi-s1/generated/hina/index.html"
     },
     {
       "from": "/index.html",
-      "to": "/nagi-s1/generated/hina/index.html"
+      "to": "/nagi-s1/index.html"
     },
     {
       "from": "/index.html",
@@ -387,6 +387,18 @@
     },
     {
       "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story10.html"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story11.html"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story12.html"
+    },
+    {
+      "from": "/nagi-s1/index.html",
       "to": "/nagi-s1/story2.html"
     },
     {
@@ -416,18 +428,6 @@
     {
       "from": "/nagi-s1/index.html",
       "to": "/nagi-s1/story9.html"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story10.html"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story11.html"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story12.html"
     },
     {
       "from": "/nagi-s1/story1.html",

--- a/docs/qa/screen-flow.md
+++ b/docs/qa/screen-flow.md
@@ -61,12 +61,12 @@ graph TD
   N49["/nagi-s1/story9.html"]
   N50["/nagi-s2/index.html"]
   N51["/nagi-s3/index.html"]
-  N0 --> N34
   N0 --> N5
+  N0 --> N34
   N0 --> N50
   N0 --> N51
-  N1 --> N34
   N1 --> N5
+  N1 --> N34
   N1 --> N50
   N1 --> N51
   N3 --> N2
@@ -142,6 +142,9 @@ graph TD
   N18 --> N3
   N18 --> N19
   N34 --> N38
+  N34 --> N39
+  N34 --> N40
+  N34 --> N41
   N34 --> N42
   N34 --> N43
   N34 --> N44
@@ -150,9 +153,6 @@ graph TD
   N34 --> N47
   N34 --> N48
   N34 --> N49
-  N34 --> N39
-  N34 --> N40
-  N34 --> N41
   N38 --> N34
   N39 --> N34
   N40 --> N34


### PR DESCRIPTION
## Summary
- aggregate broken targets with inbound sources, replacement suggestions, deduplicated console/errors, and a broken-free dead-ends list in flow analysis outputs
- update QA run log summary to include console and blocked-external counts plus guided coverage statistics
- improve guided explorer with periodic restarts, recent-page avoidance, and non-fatal handling of blocked external requests while recording them

## Testing
- bash .qa/run-flow-coverage.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957129db4948333845389f245aa2a45)