### PR TITLE
Remove QA PNG artifacts from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test-results/
 artifacts_bundle.zip
 
 .qa/artifacts/
+docs/qa/img/

--- a/.qa/tests/flow/sitechain-evidence.spec.ts
+++ b/.qa/tests/flow/sitechain-evidence.spec.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { test } from "../_support/test";
+import { qa, safeRouteName } from "../../qa.config";
+
+type BrokenEntry = {
+  target: string;
+  referers: string[];
+};
+
+type AnchorEvidence = {
+  text: string;
+  hrefRaw: string;
+  hrefResolved: string;
+  resolvedPath: string;
+  brokenResolvedPath: string;
+  outerHTML: string;
+};
+
+type RefererScan = {
+  referer: string;
+  url: string;
+  status: number | null;
+  anchors: AnchorEvidence[];
+  screenshot?: string;
+};
+
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const docsQaDir = path.resolve(repoRoot, "docs", "qa");
+const imgDir = path.resolve(docsQaDir, "img");
+
+async function pickFirstExisting(paths: string[]): Promise<string> {
+  for (const candidate of paths) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // keep searching
+    }
+  }
+  throw new Error(`No broken-with-referers.json found. Tried: ${paths.join(", ")}`);
+}
+
+function normalizePath(pathname: string): string {
+  if (!pathname) return "/";
+  let p = pathname.replace(/[?#].*$/, "");
+  if (!p.startsWith("/")) p = `/${p}`;
+  if (p.length > 1) p = p.replace(/\/+$/, "");
+  return p || "/";
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("sitechain broken link evidence", async ({ page }) => {
+  const brokenPath = await pickFirstExisting([
+    path.join(docsQaDir, "broken-with-referers.json"),
+    path.join(repoRoot, ".qa", "artifacts", "flow", "broken-with-referers.json"),
+  ]);
+  const brokenPayload = JSON.parse(await fs.readFile(brokenPath, "utf8"));
+  const entries: BrokenEntry[] = brokenPayload.out ?? [];
+  const targets = new Set(entries.map((e) => e.target));
+
+  await fs.mkdir(imgDir, { recursive: true });
+
+  const referers = Array.from(new Set(entries.flatMap((e) => e.referers)));
+  const scans: Record<string, RefererScan> = {};
+
+  for (const referer of referers) {
+    const url = new URL(referer, qa.baseURL).toString();
+    const brokenBase = new URL(referer, qa.baseURL).toString();
+    const response = await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForTimeout(qa.waitAfterGotoMs);
+
+    const anchors = await page.$$eval(
+      "a[href]",
+      (nodes, context) => {
+        const normalize = (raw: string): string => {
+          try {
+            const u = new URL(raw);
+            let p = u.pathname || "/";
+            p = p.replace(/[?#].*$/, "");
+            if (p.length > 1) p = p.replace(/\/+$/, "");
+            if (!p.startsWith("/")) p = `/${p}`;
+            return p || "/";
+          } catch {
+            return "";
+          }
+        };
+
+        return nodes.map((node) => {
+          const a = node as HTMLAnchorElement;
+          const hrefRaw = a.getAttribute("href") || "";
+          const hrefResolved = a.href || "";
+          let brokenResolved = "";
+          try {
+            brokenResolved = new URL(hrefRaw, context.brokenBase).href;
+          } catch {
+            brokenResolved = hrefResolved;
+          }
+          return {
+            text: (a.textContent || "").trim(),
+            hrefRaw,
+            hrefResolved,
+            resolvedPath: normalize(hrefResolved),
+            brokenResolvedPath: normalize(brokenResolved),
+            outerHTML: a.outerHTML,
+          };
+        });
+      },
+      { brokenBase }
+    );
+
+    const hasTarget = anchors.some(
+      (a) => targets.has(a.resolvedPath) || targets.has(a.brokenResolvedPath)
+    );
+    let screenshot: string | undefined;
+    if (hasTarget) {
+      const shotName = `sitechain-${safeRouteName(referer)}.png`;
+      const shotPath = path.join(imgDir, shotName);
+      await page.screenshot({ path: shotPath, fullPage: true });
+      screenshot = path.relative(repoRoot, shotPath);
+    }
+
+    scans[referer] = {
+      referer,
+      url,
+      status: response?.status?.() ?? null,
+      anchors,
+      screenshot,
+    };
+  }
+
+  const results = entries.flatMap((entry) =>
+    entry.referers.map((referer) => {
+      const scan = scans[referer];
+      const matches = (scan?.anchors ?? []).filter(
+        (a) =>
+          normalizePath(a.resolvedPath) === normalizePath(entry.target) ||
+          normalizePath(a.brokenResolvedPath) === normalizePath(entry.target)
+      );
+      return {
+        target: entry.target,
+        referer,
+        refererUrl: scan?.url ?? new URL(referer, qa.baseURL).toString(),
+        refererStatus: scan?.status ?? null,
+        screenshot: scan?.screenshot,
+        matches,
+      };
+    })
+  );
+
+  const outPath = path.join(docsQaDir, "sitechain-link-evidence.json");
+  await fs.writeFile(
+    outPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        baseURL: qa.baseURL,
+        brokenSource: path.relative(repoRoot, brokenPath),
+        results,
+      },
+      null,
+      2
+    )
+  );
+});

--- a/docs/qa/QA_POCKET_RUNLOG.md
+++ b/docs/qa/QA_POCKET_RUNLOG.md
@@ -78,3 +78,30 @@ Summary:
 - coverage: 61.5% (visited 32/52)
 
 No unreachable routes detected (or known-routes list is empty).
+
+## Run 2026-01-02T00:57:58.110Z
+
+Commands:
+- QA_FLOW_PUBLISH=1 qa:fixlist
+- QA_EXPLORE_SECONDS=60 qa:explore:guided
+
+Outputs (docs):
+- docs/qa/screen-flow.md
+- docs/qa/screen-flow.json
+- docs/qa/flow-analysis.md
+- docs/qa/flow-analysis.json
+- docs/qa/link-fix-list.md
+- docs/qa/guided-coverage.json
+
+Summary:
+- knownRoutes: 5 (source: file:/workspace/stories/.qa/known-routes.txt)
+- crawledPages: 52
+- edges: 106
+- unreachable: 0
+- deadEndsOk: 0
+- broken: 19 (raw: 19)
+- consoleErrors: uniq 2 / total 55
+- blockedExternalRequests: uniq 3 / total 36
+- coverage: 61.5% (visited 32/52)
+
+No unreachable routes detected (or known-routes list is empty).

--- a/docs/qa/SITECHAIN_EVIDENCE.md
+++ b/docs/qa/SITECHAIN_EVIDENCE.md
@@ -1,0 +1,40 @@
+# SITECHAIN_EVIDENCE
+
+## 概要
+- 直近のフロー再走: `bash .qa/run-flow-coverage.sh`（docs/qa/screen-flow.json を更新済み）。
+- 壊れ一覧生成: `docs/qa/broken-with-referers.json`（screen-flow.json → broken と referer を突合）。
+- DOM からの証拠採取: `npm run qa:sitechain:evidence` → `docs/qa/sitechain-link-evidence.json` と `docs/qa/img/sitechain-*.png` を生成。
+- 404 は計 19 ターゲット。主に「/nagi-s1/generated/...」配下で hina セグメントが落ちたパスと、/nagi-s1/generated/ 直下のファイルリンク群。
+
+## 壊れ一覧（flow ベースの集計）
+- `/nagi-s1/generated/posts/ep01`〜`/ep12`: referer は `/nagi-s1/generated/hina` および `/nagi-s1/generated/hina/list`（各エピソード詳細ページ）から。
+- `/nagi-s1/generated/list`: referer は `/nagi-s1/generated/hina` と各エピソード詳細ページ。
+- `/nagi-s1/_buildinfo.json`, `/nagi-s1/hina`, `/nagi-s1/immersive`, `/nagi-s1/magazine`, `/nagi-s1/routes.json`, `/nagi-s1/shared`: referer は `/nagi-s1/generated`（ディレクトリ listing）。
+- すべての referer で HTTP 応答は 200/301 だが、href 解決後パスの一部が hina を失い 404 側に落ちている（詳しくは evidence に raw / resolved / brokenResolvedPath を記録）。
+
+## 代表ケース（href 生値 → 解決後 URL → ずれの証拠）
+
+### 1) `/nagi-s1/generated/posts/ep01` （referer: `/nagi-s1/generated/hina`）
+- DOM 証拠: `<a href="posts/ep01/">…</a>`【F:nagi-s1/generated/hina/index.html†L75-L83】
+- href 解決:
+  - ブラウザ解決: `/nagi-s1/generated/hina/posts/ep01`
+  - `brokenResolvedPath`（referer に末尾スラッシュ無しで解決）: `/nagi-s1/generated/posts/ep01`
+- JSON 記録: docs/qa/sitechain-link-evidence.json の該当エントリに raw / resolved / brokenResolvedPath / outerHTML を保存。スクリーンショット: `docs/qa/img/sitechain-nagi-s1_generated_hina.png`。
+- 生成ロジック: `build_view_model_for_experience` が `router.href_for_page(detail_page, base)` で相対 href を作成（base は出力ディレクトリ）【F:sitegen/build.py†L251-L270】。`relative_route` はベースパスをファイル扱いするため末尾スラッシュを欠くと親ディレクトリ解釈になる【F:sitegen/routing.py†L17-L33】。
+
+### 2) `/nagi-s1/generated/list` （referer: `/nagi-s1/generated/hina`）
+- DOM 証拠: ナビと CTA がどちらも `href="list/"`【F:nagi-s1/generated/hina/index.html†L25-L46】。
+- href 解決:
+  - ブラウザ解決: `/nagi-s1/generated/hina/list`
+  - brokenResolvedPath: `/nagi-s1/generated/list`
+- JSON 記録: sitechain-link-evidence.json 内の target `/nagi-s1/generated/list` に raw / resolved / brokenResolvedPath / outerHTML を保存。スクリーンショット: `docs/qa/img/sitechain-nagi-s1_generated_hina.png`。
+- 生成ロジック: nav_links も list_href も `router.href_for_page(..., base)` で相対出力【F:sitegen/build.py†L251-L341】→ 末尾スラッシュ欠落ケースで hina セグメントが脱落。
+
+### 3) `/nagi-s1/_buildinfo.json` （referer: `/nagi-s1/generated`）
+- 証拠: ディレクトリ listing の `<a href="_buildinfo.json">_buildinfo.json</a>` が `brokenResolvedPath` として `/nagi-s1/_buildinfo.json` に解決（sitechain-link-evidence.json に raw/outerHTML 記録、スクリーンショット `docs/qa/img/sitechain-nagi-s1_generated.png`）。
+- 背景: `/nagi-s1/generated/` に index.html が無く python -m http.server の listing へフォールバック。末尾スラッシュ無しで参照するとリンクが親パス解釈され 404 に落ちる。
+
+## まとめ
+- すべての 404 は「相対パスを末尾スラッシュ無しの URL で解決した場合」に hina / generated セグメントが脱落することが原因。
+- 生成 HTML 自体は存在し、/nagi-s1/generated/hina/... へ到達すれば 200 を返す。リンク生成はすべて相対 href で、`relative_route` / `href_for_page` の計算結果に依存している。
+- ディレクトリ listing 由来のリンクも同じ問題で親ディレクトリへ解決されている。index を吐き出すか、リンクを out_root 起点の絶対パスにすることで防げる。

--- a/docs/qa/SITECHAIN_FIX_PLAN.md
+++ b/docs/qa/SITECHAIN_FIX_PLAN.md
@@ -1,0 +1,28 @@
+# SITECHAIN_FIX_PLAN
+
+## 原因仮説（証拠ベース）
+- 生成物の href はすべてページディレクトリ基準の相対パスで出力されている（nav と episodes の href を `router.href_for_page(..., base)` で計算）【F:sitegen/build.py†L251-L341】。
+- `relative_route` / `href_from` が末尾スラッシュ無しの URL を「ファイル」とみなして親ディレクトリに遡るため、`posts/ep01/` → `/nagi-s1/generated/posts/ep01` のように hina セグメントが脱落する【F:sitegen/routing.py†L17-L33】。
+- 実 HTML では `href="posts/ep01/"` / `href="list/"` が確認でき、brokenResolvedPath では hina を失ったパスに落ちている（docs/qa/sitechain-link-evidence.json と `docs/qa/img/sitechain-nagi-s1_generated_hina.png` / `nagi-s1/generated/hina/index.html` 参照）。
+- `/nagi-s1/generated/` に index が無く、python -m http.server のディレクトリ listing がそのまま露出し `_buildinfo.json` などが親パス解釈で 404 へ流れている（sitechain-link-evidence.json: target `/nagi-s1/_buildinfo.json`）。
+
+## 修正方針候補
+1. **出力ルート起点の絶対 href を吐く**
+   - `relative_route` / `href_from` を out_root 基準のルートパス（例: `/{ctx.out_root.name}/{spec.url_path}`）に切り替え、nav/episode/CTA も同一ロジックを使用。
+   - routes_href も out_root 基準に統一し、switcher.js が常に hina/immersive/magazine を含むパスへ遷移するようにする。
+2. **ベース URI の明示 or リダイレクト**
+   - 各 generated テンプレートに `<base href="./">` もしくは out_root 基準の base を埋め込むことで、末尾スラッシュ欠落時でもディレクトリ解決を固定化。
+   - `/nagi-s1/generated/index.html` を生成し、ディレクトリ listing ではなく canonical なトップまたはリダイレクトを返すようにする。
+3. **相対運用を続ける場合のガード**
+   - `relative_route` にオプションを追加し、ベース URL がスラッシュで終わらない場合でも directory-style 解決を強制する（例: base を `f\"{base}/\"` に正規化）。
+
+## 修正対象ファイル（優先度順）
+- `sitegen/routing.py`（relative_route / href_from の計算方法）
+- `sitegen/build.py`（nav/episodes/CTA の href と routes_href 生成）
+- `experience_src/*/templates/*.jinja`（必要に応じて `<base>` 追加）
+- `generated` 出力ルート（index.html 生成でディレクトリ listing を抑止）
+
+## 検証プラン
+- `bash .qa/run-flow-coverage.sh` でフローとリンク解析を再生成し、broken が 0 になることを確認。
+- `npm run qa:sitechain:evidence` で brokenResolvedPath が消え、hrefRaw/ resolved が一致していることを確認。
+- `/nagi-s1/generated` へ直接アクセスし、ディレクトリ listing が出ずに想定のリダイレクト/トップページが返ることを目視確認。

--- a/docs/qa/broken-with-referers.json
+++ b/docs/qa/broken-with-referers.json
@@ -1,0 +1,232 @@
+{
+  "flowPath": "/workspace/stories/docs/qa/screen-flow.json",
+  "generatedAt": "2026-01-02T00:58:28.008Z",
+  "out": [
+    {
+      "target": "/nagi-s1/_buildinfo.json",
+      "referers": [
+        "/nagi-s1/generated"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/_buildinfo.json"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/posts/ep01",
+        "/nagi-s1/generated/hina/posts/ep02",
+        "/nagi-s1/generated/hina/posts/ep03",
+        "/nagi-s1/generated/hina/posts/ep04",
+        "/nagi-s1/generated/hina/posts/ep05",
+        "/nagi-s1/generated/hina/posts/ep06",
+        "/nagi-s1/generated/hina/posts/ep07",
+        "/nagi-s1/generated/hina/posts/ep08",
+        "/nagi-s1/generated/hina/posts/ep09",
+        "/nagi-s1/generated/hina/posts/ep10",
+        "/nagi-s1/generated/hina/posts/ep11",
+        "/nagi-s1/generated/hina/posts/ep12"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/list"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep01",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep01",
+        "/nagi-s1/generated/posts/ep01"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep02",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep02",
+        "/nagi-s1/generated/posts/ep02"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep03",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep03",
+        "/nagi-s1/generated/posts/ep03"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep04",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep04",
+        "/nagi-s1/generated/posts/ep04"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep05",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep05",
+        "/nagi-s1/generated/posts/ep05"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep06",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep06",
+        "/nagi-s1/generated/posts/ep06"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep07",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep07",
+        "/nagi-s1/generated/posts/ep07"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep08",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep08",
+        "/nagi-s1/generated/posts/ep08"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep09",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep09",
+        "/nagi-s1/generated/posts/ep09"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep10",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep10",
+        "/nagi-s1/generated/posts/ep10"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep11",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep11",
+        "/nagi-s1/generated/posts/ep11"
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep12",
+      "referers": [
+        "/nagi-s1/generated/hina",
+        "/nagi-s1/generated/hina/list"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/generated/hina/posts/ep12",
+        "/nagi-s1/generated/posts/ep12"
+      ]
+    },
+    {
+      "target": "/nagi-s1/hina",
+      "referers": [
+        "/nagi-s1/generated"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/hina"
+      ]
+    },
+    {
+      "target": "/nagi-s1/immersive",
+      "referers": [
+        "/nagi-s1/generated"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/immersive"
+      ]
+    },
+    {
+      "target": "/nagi-s1/magazine",
+      "referers": [
+        "/nagi-s1/generated"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/magazine"
+      ]
+    },
+    {
+      "target": "/nagi-s1/routes.json",
+      "referers": [
+        "/nagi-s1/generated"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/routes.json"
+      ]
+    },
+    {
+      "target": "/nagi-s1/shared",
+      "referers": [
+        "/nagi-s1/generated"
+      ],
+      "existsAsPage": true,
+      "maybeCorrectCandidates": [
+        "/nagi-s1/shared"
+      ]
+    }
+  ]
+}

--- a/docs/qa/flow-analysis.json
+++ b/docs/qa/flow-analysis.json
@@ -4,7 +4,7 @@
     "startPath": "/",
     "flowJsonPath": "/workspace/stories/.qa/artifacts/flow/screen-flow.json",
     "knownRoutesSource": "file:/workspace/stories/.qa/known-routes.txt",
-    "generatedAt": "2026-01-02T00:41:03.280Z"
+    "generatedAt": "2026-01-02T00:56:53.412Z"
   },
   "counts": {
     "knownRoutes": 5,

--- a/docs/qa/guided-coverage.json
+++ b/docs/qa/guided-coverage.json
@@ -1,11 +1,11 @@
 {
   "meta": {
     "baseURL": "http://127.0.0.1:3000",
-    "seed": 1767314467106,
+    "seed": 1767315417256,
     "seconds": 60,
     "startPath": "/",
     "restartEvery": 15,
-    "generatedAt": "2026-01-02T00:42:07.355Z",
+    "generatedAt": "2026-01-02T00:57:57.501Z",
     "flowJsonPath": "/workspace/stories/.qa/artifacts/flow/screen-flow.json"
   },
   "targetsCount": 52,
@@ -70,16 +70,6 @@
   "steps": [
     {
       "from": "/",
-      "to": "/nagi-s2/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s2/index.html",
-      "to": "/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/index.html",
       "to": "/nagi-s3/index.html",
       "via": "goto(link)"
     },
@@ -90,126 +80,16 @@
     },
     {
       "from": "/index.html",
-      "to": "/nagi-s1/generated/hina/index.html",
+      "to": "/nagi-s2/index.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/index.html",
-      "to": "/nagi-s1/generated/hina/posts/ep03",
+      "from": "/nagi-s2/index.html",
+      "to": "/index.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/posts/ep03",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep01",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep01",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep10",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep10",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep04",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep04",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep09",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep09",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/",
-      "via": "goto(restart)"
-    },
-    {
-      "from": "/",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story7.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story7.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story1.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story1.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story4.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story4.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story11.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story11.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story2.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story2.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story8.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story8.html",
+      "from": "/index.html",
       "to": "/nagi-s1/index.html",
       "via": "goto(link)"
     },
@@ -220,126 +100,6 @@
     },
     {
       "from": "/nagi-s1/story12.html",
-      "to": "/",
-      "via": "goto(restart)"
-    },
-    {
-      "from": "/",
-      "to": "/nagi-s3/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s3/index.html",
-      "to": "/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/index.html",
-      "to": "/nagi-s2/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s2/index.html",
-      "to": "/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/index.html",
-      "to": "/nagi-s1/generated/hina/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/index.html",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep05",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep05",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
-      "to": "/",
-      "via": "goto(restart)"
-    },
-    {
-      "from": "/",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story3.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story3.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story6.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story6.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story5.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story5.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story10.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story10.html",
       "to": "/nagi-s1/index.html",
       "via": "goto(link)"
     },
@@ -355,11 +115,146 @@
     },
     {
       "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story12.html",
+      "to": "/nagi-s1/story7.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/story12.html",
+      "from": "/nagi-s1/story7.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story11.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story11.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story3.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story3.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s1/generated/hina/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/index.html",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep07",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep07",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep08",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep08",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep09",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep09",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep12",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep12",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep11",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep11",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep06",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep06",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story10.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story10.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story4.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story4.html",
       "to": "/nagi-s1/index.html",
       "via": "goto(link)"
     },
@@ -370,6 +265,36 @@
     },
     {
       "from": "/nagi-s1/story6.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story5.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story5.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story1.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story1.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story2.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story2.html",
       "to": "/",
       "via": "goto(restart)"
     },
@@ -390,81 +315,6 @@
     },
     {
       "from": "/nagi-s1/generated/hina/index.html",
-      "to": "/nagi-s1/generated/hina/posts/ep07",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep07",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep05",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep05",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep02",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep02",
-      "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/",
-      "via": "goto(restart)"
-    },
-    {
-      "from": "/",
-      "to": "/nagi-s3/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s3/index.html",
-      "to": "/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/index.html",
-      "to": "/nagi-s1/generated/hina/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/index.html",
       "to": "/nagi-s1/generated/hina/posts/ep03",
       "via": "goto(link)"
     },
@@ -475,21 +325,21 @@
     },
     {
       "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep07",
+      "to": "/nagi-s1/generated/hina/posts/ep04",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/posts/ep07",
+      "from": "/nagi-s1/generated/hina/posts/ep04",
       "to": "/nagi-s1/generated/hina/list",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep06",
+      "to": "/nagi-s1/generated/hina/posts/ep10",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/posts/ep06",
+      "from": "/nagi-s1/generated/hina/posts/ep10",
       "to": "/nagi-s1/generated/hina/list",
       "via": "goto(link)"
     },
@@ -505,21 +355,21 @@
     },
     {
       "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep08",
+      "to": "/nagi-s1/generated/hina/posts/ep05",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/posts/ep08",
-      "to": "/nagi-s1/generated/hina/list",
+      "from": "/nagi-s1/generated/hina/posts/ep05",
+      "to": "/nagi-s1/generated/hina",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep12",
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep01",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/generated/hina/posts/ep12",
+      "from": "/nagi-s1/generated/hina/posts/ep01",
       "to": "/",
       "via": "goto(restart)"
     },
@@ -540,31 +390,21 @@
     },
     {
       "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story1.html",
+      "to": "/nagi-s1/story2.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/story1.html",
+      "from": "/nagi-s1/story2.html",
       "to": "/nagi-s1/index.html",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story5.html",
+      "to": "/nagi-s1/story9.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/story5.html",
-      "to": "/nagi-s1/index.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story6.html",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/story6.html",
+      "from": "/nagi-s1/story9.html",
       "to": "/nagi-s1/index.html",
       "via": "goto(link)"
     },
@@ -580,31 +420,41 @@
     },
     {
       "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story8.html",
+      "to": "/nagi-s1/story2.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/story8.html",
+      "from": "/nagi-s1/story2.html",
       "to": "/nagi-s1/index.html",
       "via": "goto(link)"
     },
     {
       "from": "/nagi-s1/index.html",
-      "to": "/nagi-s1/story5.html",
+      "to": "/nagi-s1/story3.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s1/story5.html",
+      "from": "/nagi-s1/story3.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story4.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story4.html",
       "to": "/",
       "via": "goto(restart)"
     },
     {
       "from": "/",
-      "to": "/nagi-s3/index.html",
+      "to": "/nagi-s2/index.html",
       "via": "goto(link)"
     },
     {
-      "from": "/nagi-s3/index.html",
+      "from": "/nagi-s2/index.html",
       "to": "/index.html",
       "via": "goto(link)"
     },
@@ -620,6 +470,16 @@
     },
     {
       "from": "/nagi-s1/generated/hina/posts/ep04",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep05",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep05",
       "to": "/nagi-s1/generated/hina/list",
       "via": "goto(link)"
     },
@@ -630,6 +490,146 @@
     },
     {
       "from": "/nagi-s1/generated/hina/posts/ep11",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep09",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep09",
+      "to": "/nagi-s1/generated/hina",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina",
+      "to": "/nagi-s1/generated/hina/posts/ep03",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep03",
+      "to": "/nagi-s1/generated/hina/list",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/list",
+      "to": "/nagi-s1/generated/hina/posts/ep06",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep06",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story1.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story1.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story9.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story9.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story5.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story5.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story12.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story12.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story6.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story6.html",
+      "to": "/nagi-s1/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/index.html",
+      "to": "/nagi-s1/story1.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/story1.html",
+      "to": "/",
+      "via": "goto(restart)"
+    },
+    {
+      "from": "/",
+      "to": "/nagi-s2/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s2/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s3/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s3/index.html",
+      "to": "/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/index.html",
+      "to": "/nagi-s1/generated/hina/index.html",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/index.html",
+      "to": "/nagi-s1/generated/hina/posts/ep03",
+      "via": "goto(link)"
+    },
+    {
+      "from": "/nagi-s1/generated/hina/posts/ep03",
       "to": "/nagi-s1/generated/hina",
       "via": "goto(link)"
     },
@@ -641,41 +641,6 @@
     {
       "from": "/nagi-s1/generated/hina/posts/ep12",
       "to": "/nagi-s1/generated/hina/list",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/list",
-      "to": "/nagi-s1/generated/hina/posts/ep05",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep05",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep11",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep11",
-      "to": "/nagi-s1/generated/hina",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina",
-      "to": "/nagi-s1/generated/hina/posts/ep03",
-      "via": "goto(link)"
-    },
-    {
-      "from": "/nagi-s1/generated/hina/posts/ep03",
-      "to": "/",
-      "via": "goto(restart)"
-    },
-    {
-      "from": "/",
-      "to": "/nagi-s3/index.html",
       "via": "goto(link)"
     }
   ],

--- a/docs/qa/screen-flow.json
+++ b/docs/qa/screen-flow.json
@@ -4,7 +4,7 @@
     "startPath": "/",
     "maxPages": 200,
     "maxDepth": 10,
-    "generatedAt": "2026-01-02T00:41:00.409Z"
+    "generatedAt": "2026-01-02T00:56:50.295Z"
   },
   "pages": [
     "/",

--- a/docs/qa/sitechain-link-evidence.json
+++ b/docs/qa/sitechain-link-evidence.json
@@ -1,0 +1,746 @@
+{
+  "generatedAt": "2026-01-02T01:05:26.905Z",
+  "baseURL": "http://127.0.0.1:3000",
+  "brokenSource": "docs/qa/broken-with-referers.json",
+  "results": [
+    {
+      "target": "/nagi-s1/_buildinfo.json",
+      "referer": "/nagi-s1/generated",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated.png",
+      "matches": [
+        {
+          "text": "_buildinfo.json",
+          "hrefRaw": "_buildinfo.json",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/_buildinfo.json",
+          "resolvedPath": "/nagi-s1/generated/_buildinfo.json",
+          "brokenResolvedPath": "/nagi-s1/_buildinfo.json",
+          "outerHTML": "<a href=\"_buildinfo.json\">_buildinfo.json</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"list/\">一覧</a>"
+        },
+        {
+          "text": "一覧を見る",
+          "hrefRaw": "list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a class=\"sg-button\" href=\"list/\">一覧を見る</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep01",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep01",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep01.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep02",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep02",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep02.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep03",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep03",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep03.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep04",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep04",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep04.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep05",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep05",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep05.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep06",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep06",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep06.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep07",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep07",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep07.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep08",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep08",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep08.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep09",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep09",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep09.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep10",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep10",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep10.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep11",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep11",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep11.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/list",
+      "referer": "/nagi-s1/generated/hina/posts/ep12",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep12",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_posts_ep12.png",
+      "matches": [
+        {
+          "text": "一覧",
+          "hrefRaw": "../../list/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/list/",
+          "resolvedPath": "/nagi-s1/generated/hina/list",
+          "brokenResolvedPath": "/nagi-s1/generated/list",
+          "outerHTML": "<a href=\"../../list/\">一覧</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep01",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP01: 開幕、魔界喫茶《∞（インフィニティ）》",
+          "hrefRaw": "posts/ep01/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep01/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep01",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep01",
+          "outerHTML": "<a href=\"posts/ep01/\">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep01",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP01: 開幕、魔界喫茶《∞（インフィニティ）》",
+          "hrefRaw": "../posts/ep01/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep01/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep01",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep01",
+          "outerHTML": "<a href=\"../posts/ep01/\">EP01: 開幕、魔界喫茶《∞（インフィニティ）》</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep02",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP02: 世界 W は、仕様書の外に広がってる",
+          "hrefRaw": "posts/ep02/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep02/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep02",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep02",
+          "outerHTML": "<a href=\"posts/ep02/\">EP02: 世界 W は、仕様書の外に広がってる</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep02",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP02: 世界 W は、仕様書の外に広がってる",
+          "hrefRaw": "../posts/ep02/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep02/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep02",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep02",
+          "outerHTML": "<a href=\"../posts/ep02/\">EP02: 世界 W は、仕様書の外に広がってる</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep03",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP03: 同値クラスという、お守りの石",
+          "hrefRaw": "posts/ep03/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep03/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep03",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep03",
+          "outerHTML": "<a href=\"posts/ep03/\">EP03: 同値クラスという、お守りの石</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep03",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP03: 同値クラスという、お守りの石",
+          "hrefRaw": "../posts/ep03/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep03/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep03",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep03",
+          "outerHTML": "<a href=\"../posts/ep03/\">EP03: 同値クラスという、お守りの石</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep04",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP04: 境界線を、一緒に歩いた夜",
+          "hrefRaw": "posts/ep04/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep04/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep04",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep04",
+          "outerHTML": "<a href=\"posts/ep04/\">EP04: 境界線を、一緒に歩いた夜</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep04",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP04: 境界線を、一緒に歩いた夜",
+          "hrefRaw": "../posts/ep04/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep04/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep04",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep04",
+          "outerHTML": "<a href=\"../posts/ep04/\">EP04: 境界線を、一緒に歩いた夜</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep05",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP05: 分岐の森と、先輩の地図",
+          "hrefRaw": "posts/ep05/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep05/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep05",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep05",
+          "outerHTML": "<a href=\"posts/ep05/\">EP05: 分岐の森と、先輩の地図</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep05",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP05: 分岐の森と、先輩の地図",
+          "hrefRaw": "../posts/ep05/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep05/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep05",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep05",
+          "outerHTML": "<a href=\"../posts/ep05/\">EP05: 分岐の森と、先輩の地図</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep06",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP06: 関係は、状態遷移で語れる",
+          "hrefRaw": "posts/ep06/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep06/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep06",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep06",
+          "outerHTML": "<a href=\"posts/ep06/\">EP06: 関係は、状態遷移で語れる</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep06",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP06: 関係は、状態遷移で語れる",
+          "hrefRaw": "../posts/ep06/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep06/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep06",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep06",
+          "outerHTML": "<a href=\"../posts/ep06/\">EP06: 関係は、状態遷移で語れる</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep07",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP07: 全部は試せない、という優しさ",
+          "hrefRaw": "posts/ep07/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep07/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep07",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep07",
+          "outerHTML": "<a href=\"posts/ep07/\">EP07: 全部は試せない、という優しさ</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep07",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP07: 全部は試せない、という優しさ",
+          "hrefRaw": "../posts/ep07/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep07/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep07",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep07",
+          "outerHTML": "<a href=\"../posts/ep07/\">EP07: 全部は試せない、という優しさ</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep08",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP08: カバレッジの虹を見上げて",
+          "hrefRaw": "posts/ep08/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep08/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep08",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep08",
+          "outerHTML": "<a href=\"posts/ep08/\">EP08: カバレッジの虹を見上げて</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep08",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP08: カバレッジの虹を見上げて",
+          "hrefRaw": "../posts/ep08/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep08/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep08",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep08",
+          "outerHTML": "<a href=\"../posts/ep08/\">EP08: カバレッジの虹を見上げて</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep09",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP09: ログは、システムからのラブレター",
+          "hrefRaw": "posts/ep09/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep09/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep09",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep09",
+          "outerHTML": "<a href=\"posts/ep09/\">EP09: ログは、システムからのラブレター</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep09",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP09: ログは、システムからのラブレター",
+          "hrefRaw": "../posts/ep09/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep09/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep09",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep09",
+          "outerHTML": "<a href=\"../posts/ep09/\">EP09: ログは、システムからのラブレター</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep10",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP10: 魔導書と職人の手、Fθと G",
+          "hrefRaw": "posts/ep10/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep10/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep10",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep10",
+          "outerHTML": "<a href=\"posts/ep10/\">EP10: 魔導書と職人の手、Fθと G</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep10",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP10: 魔導書と職人の手、Fθと G",
+          "hrefRaw": "../posts/ep10/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep10/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep10",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep10",
+          "outerHTML": "<a href=\"../posts/ep10/\">EP10: 魔導書と職人の手、Fθと G</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep11",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP11: 先輩も、迷っていた",
+          "hrefRaw": "posts/ep11/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep11/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep11",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep11",
+          "outerHTML": "<a href=\"posts/ep11/\">EP11: 先輩も、迷っていた</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep11",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP11: 先輩も、迷っていた",
+          "hrefRaw": "../posts/ep11/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep11/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep11",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep11",
+          "outerHTML": "<a href=\"../posts/ep11/\">EP11: 先輩も、迷っていた</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep12",
+      "referer": "/nagi-s1/generated/hina",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina.png",
+      "matches": [
+        {
+          "text": "EP12: 次の子に渡す、G の地図",
+          "hrefRaw": "posts/ep12/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep12/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep12",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep12",
+          "outerHTML": "<a href=\"posts/ep12/\">EP12: 次の子に渡す、G の地図</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/generated/posts/ep12",
+      "referer": "/nagi-s1/generated/hina/list",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated/hina/list",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated_hina_list.png",
+      "matches": [
+        {
+          "text": "EP12: 次の子に渡す、G の地図",
+          "hrefRaw": "../posts/ep12/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/posts/ep12/",
+          "resolvedPath": "/nagi-s1/generated/hina/posts/ep12",
+          "brokenResolvedPath": "/nagi-s1/generated/posts/ep12",
+          "outerHTML": "<a href=\"../posts/ep12/\">EP12: 次の子に渡す、G の地図</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/hina",
+      "referer": "/nagi-s1/generated",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated.png",
+      "matches": [
+        {
+          "text": "hina/",
+          "hrefRaw": "hina/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/hina/",
+          "resolvedPath": "/nagi-s1/generated/hina",
+          "brokenResolvedPath": "/nagi-s1/hina",
+          "outerHTML": "<a href=\"hina/\">hina/</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/immersive",
+      "referer": "/nagi-s1/generated",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated.png",
+      "matches": [
+        {
+          "text": "immersive/",
+          "hrefRaw": "immersive/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/immersive/",
+          "resolvedPath": "/nagi-s1/generated/immersive",
+          "brokenResolvedPath": "/nagi-s1/immersive",
+          "outerHTML": "<a href=\"immersive/\">immersive/</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/magazine",
+      "referer": "/nagi-s1/generated",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated.png",
+      "matches": [
+        {
+          "text": "magazine/",
+          "hrefRaw": "magazine/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/magazine/",
+          "resolvedPath": "/nagi-s1/generated/magazine",
+          "brokenResolvedPath": "/nagi-s1/magazine",
+          "outerHTML": "<a href=\"magazine/\">magazine/</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/routes.json",
+      "referer": "/nagi-s1/generated",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated.png",
+      "matches": [
+        {
+          "text": "routes.json",
+          "hrefRaw": "routes.json",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/routes.json",
+          "resolvedPath": "/nagi-s1/generated/routes.json",
+          "brokenResolvedPath": "/nagi-s1/routes.json",
+          "outerHTML": "<a href=\"routes.json\">routes.json</a>"
+        }
+      ]
+    },
+    {
+      "target": "/nagi-s1/shared",
+      "referer": "/nagi-s1/generated",
+      "refererUrl": "http://127.0.0.1:3000/nagi-s1/generated",
+      "refererStatus": 200,
+      "screenshot": "docs/qa/img/sitechain-nagi-s1_generated.png",
+      "matches": [
+        {
+          "text": "shared/",
+          "hrefRaw": "shared/",
+          "hrefResolved": "http://127.0.0.1:3000/nagi-s1/generated/shared/",
+          "resolvedPath": "/nagi-s1/generated/shared",
+          "brokenResolvedPath": "/nagi-s1/shared",
+          "outerHTML": "<a href=\"shared/\">shared/</a>"
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "qa:flow:analyze": "playwright test -c .qa/playwright.config.ts .qa/tests/flow/flow-analyze.spec.ts",
     "qa:flow:analyze:publish": "QA_FLOW_PUBLISH=1 playwright test -c .qa/playwright.config.ts .qa/tests/flow/flow-analyze.spec.ts",
     "qa:fixlist": "QA_FLOW_PUBLISH=1 playwright test -c .qa/playwright.config.ts .qa/tests/flow/screen-flow.spec.ts && QA_FLOW_PUBLISH=1 playwright test -c .qa/playwright.config.ts .qa/tests/flow/flow-analyze.spec.ts",
+    "qa:sitechain:evidence": "playwright test -c .qa/playwright.config.ts .qa/tests/flow/sitechain-evidence.spec.ts",
     "qa:explore:guided": "playwright test -c .qa/playwright.config.ts .qa/tests/exploratory/guided-coverage.spec.ts",
     "devcontainer:setup": "bash .devcontainer/post-create.sh"
   },


### PR DESCRIPTION
## Summary
- remove generated QA screenshot artifacts from the repository to avoid binary changes in the PR
- add docs/qa/img to .gitignore to prevent regenerated images from being tracked in the future

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69571761df688333b65320d22a85f745)