### PR TITLE
Fix deterministic micro build outputs

### DIFF
--- a/sitegen/build.py
+++ b/sitegen/build.py
@@ -28,6 +28,7 @@ class BuildContext:
 
     src_root: Path
     out_root: Path
+    href_root: Path | None = None
     routes_filename: str = "routes.json"
     shared_init_features: Path | None = None
     shared_assets_dir: Path | None = None

--- a/sitegen/cli_build_site.py
+++ b/sitegen/cli_build_site.py
@@ -100,7 +100,7 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _build_once(args: argparse.Namespace, out_root: Path) -> None:
+def _build_once(args: argparse.Namespace, out_root: Path, *, href_root: Path | None = None) -> None:
     micro_store = MicroStore.load(args.micro_store)
     compiled = compile_store_v2(micro_store)
 
@@ -111,6 +111,7 @@ def _build_once(args: argparse.Namespace, out_root: Path) -> None:
     ctx = BuildContext(
         src_root=args.src,
         out_root=out_root,
+        href_root=href_root,
         routes_filename=args.routes_filename,
         build_label=build_label,
     )
@@ -137,8 +138,9 @@ def main() -> None:
             tmp_dir = Path(tmp)
             run1 = tmp_dir / "run1"
             run2 = tmp_dir / "run2"
-            _build_once(args, run1)
-            _build_once(args, run2)
+            href_root = args.out
+            _build_once(args, run1, href_root=href_root)
+            _build_once(args, run2, href_root=href_root)
             if _hash_dir(run1) != _hash_dir(run2):
                 raise SystemExit("Determinism check failed: outputs differ between runs")
             _copy_output(run1, args.out)

--- a/sitegen/routing.py
+++ b/sitegen/routing.py
@@ -80,13 +80,13 @@ class SiteRouter:
         self._build()
 
     def _compute_out_href_prefix(self) -> str:
-        out_root = self.ctx.out_root
-        if out_root.is_absolute():
+        href_root = self.ctx.href_root or self.ctx.out_root
+        if href_root.is_absolute():
             try:
-                out_root = out_root.relative_to(Path.cwd())
+                href_root = href_root.relative_to(Path.cwd())
             except ValueError:
-                out_root = Path(out_root.name)
-        prefix = "/" + out_root.as_posix().lstrip("./")
+                href_root = Path(href_root.name)
+        prefix = "/" + href_root.as_posix().lstrip("./")
         return prefix.rstrip("/")
 
     def _absolute_from_url_path(self, url_path: str) -> str:


### PR DESCRIPTION
## Summary
- allow BuildContext to accept an href root separate from the on-disk output root
- compute route href prefixes from the intended output path during micro CLI runs
- keep deterministic build checks stable when staging outputs in temporary directories

## Testing
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957583551948333bb7c4b728584b006)