### PR TITLE
Install pnpm before running cached setup

### DIFF
--- a/.github/workflows/sitegen-flow.yml
+++ b/.github/workflows/sitegen-flow.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install pnpm
+        run: npm install -g pnpm@10.13.1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- install pnpm 10.13.1 ahead of setup-node so the pnpm cache step can find the executable
- keep existing dependency installation steps while ensuring pnpm is available for frontend commands

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579ad8145083339d2cdfa49ceaa8f6)