### PR TITLE
Regenerate site outputs for all seasons using sitegen

### DIFF
--- a/nagi-s1/generated/_buildinfo.json
+++ b/nagi-s1/generated/_buildinfo.json
@@ -1,7 +1,7 @@
 {
-  "timestamp": "2026-01-02T05:08:08.217208+00:00",
+  "timestamp": "2026-01-02T18:42:30.166274+00:00",
   "git": {
-    "sha": "60d97f952842b5116f2a6892a7657542f633e8a9"
+    "sha": "d872ee46ec2a38deb6eb1cb845b1daa533852ce1"
   },
   "out": "nagi-s1/generated",
   "content": {

--- a/nagi-s1/generated/hina/index.html
+++ b/nagi-s1/generated/hina/index.html
@@ -183,4 +183,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/list/index.html
+++ b/nagi-s1/generated/hina/list/index.html
@@ -110,4 +110,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/about-世界観/index.html
+++ b/nagi-s1/generated/hina/posts/about-世界観/index.html
@@ -49,4 +49,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/about-読みどころ/index.html
+++ b/nagi-s1/generated/hina/posts/about-読みどころ/index.html
@@ -49,4 +49,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/character-サキュバスメイド喫茶∞/index.html
+++ b/nagi-s1/generated/hina/posts/character-サキュバスメイド喫茶∞/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/character-バルハ/index.html
+++ b/nagi-s1/generated/hina/posts/character-バルハ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/character-神崎ナギ/index.html
+++ b/nagi-s1/generated/hina/posts/character-神崎ナギ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/character-結城ユイ/index.html
+++ b/nagi-s1/generated/hina/posts/character-結城ユイ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep01/index.html
+++ b/nagi-s1/generated/hina/posts/ep01/index.html
@@ -262,4 +262,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep02/index.html
+++ b/nagi-s1/generated/hina/posts/ep02/index.html
@@ -199,4 +199,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep03/index.html
+++ b/nagi-s1/generated/hina/posts/ep03/index.html
@@ -221,4 +221,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep04/index.html
+++ b/nagi-s1/generated/hina/posts/ep04/index.html
@@ -166,4 +166,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep05/index.html
+++ b/nagi-s1/generated/hina/posts/ep05/index.html
@@ -179,4 +179,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep06/index.html
+++ b/nagi-s1/generated/hina/posts/ep06/index.html
@@ -150,4 +150,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep07/index.html
+++ b/nagi-s1/generated/hina/posts/ep07/index.html
@@ -143,4 +143,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep08/index.html
+++ b/nagi-s1/generated/hina/posts/ep08/index.html
@@ -118,4 +118,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep09/index.html
+++ b/nagi-s1/generated/hina/posts/ep09/index.html
@@ -121,4 +121,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep10/index.html
+++ b/nagi-s1/generated/hina/posts/ep10/index.html
@@ -105,4 +105,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep11/index.html
+++ b/nagi-s1/generated/hina/posts/ep11/index.html
@@ -127,4 +127,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/ep12/index.html
+++ b/nagi-s1/generated/hina/posts/ep12/index.html
@@ -98,4 +98,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/site-meta/index.html
+++ b/nagi-s1/generated/hina/posts/site-meta/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/hina/posts/welcome-post/index.html
+++ b/nagi-s1/generated/hina/posts/welcome-post/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/index.html
+++ b/nagi-s1/generated/immersive/index.html
@@ -183,4 +183,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/list/index.html
+++ b/nagi-s1/generated/immersive/list/index.html
@@ -110,4 +110,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/about-世界観/index.html
+++ b/nagi-s1/generated/immersive/posts/about-世界観/index.html
@@ -50,4 +50,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/about-読みどころ/index.html
+++ b/nagi-s1/generated/immersive/posts/about-読みどころ/index.html
@@ -50,4 +50,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/character-サキュバスメイド喫茶∞/index.html
+++ b/nagi-s1/generated/immersive/posts/character-サキュバスメイド喫茶∞/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/character-バルハ/index.html
+++ b/nagi-s1/generated/immersive/posts/character-バルハ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/character-神崎ナギ/index.html
+++ b/nagi-s1/generated/immersive/posts/character-神崎ナギ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/character-結城ユイ/index.html
+++ b/nagi-s1/generated/immersive/posts/character-結城ユイ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep01/index.html
+++ b/nagi-s1/generated/immersive/posts/ep01/index.html
@@ -262,4 +262,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep02/index.html
+++ b/nagi-s1/generated/immersive/posts/ep02/index.html
@@ -199,4 +199,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep03/index.html
+++ b/nagi-s1/generated/immersive/posts/ep03/index.html
@@ -221,4 +221,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep04/index.html
+++ b/nagi-s1/generated/immersive/posts/ep04/index.html
@@ -166,4 +166,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep05/index.html
+++ b/nagi-s1/generated/immersive/posts/ep05/index.html
@@ -179,4 +179,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep06/index.html
+++ b/nagi-s1/generated/immersive/posts/ep06/index.html
@@ -150,4 +150,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep07/index.html
+++ b/nagi-s1/generated/immersive/posts/ep07/index.html
@@ -143,4 +143,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep08/index.html
+++ b/nagi-s1/generated/immersive/posts/ep08/index.html
@@ -118,4 +118,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep09/index.html
+++ b/nagi-s1/generated/immersive/posts/ep09/index.html
@@ -121,4 +121,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep10/index.html
+++ b/nagi-s1/generated/immersive/posts/ep10/index.html
@@ -105,4 +105,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep11/index.html
+++ b/nagi-s1/generated/immersive/posts/ep11/index.html
@@ -127,4 +127,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/ep12/index.html
+++ b/nagi-s1/generated/immersive/posts/ep12/index.html
@@ -98,4 +98,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/site-meta/index.html
+++ b/nagi-s1/generated/immersive/posts/site-meta/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/immersive/posts/welcome-post/index.html
+++ b/nagi-s1/generated/immersive/posts/welcome-post/index.html
@@ -48,4 +48,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/index.html
+++ b/nagi-s1/generated/index.html
@@ -14,7 +14,6 @@
         <li><a href="/nagi-s1/generated/immersive/">Immersive Generated Experience</a></li>
         <li><a href="/nagi-s1/generated/magazine/">Magazine Generated Experience</a></li>
       </ul>
-        <p><a href="/nagi-s1/generated/routes.json">routes.json</a></p>
     </main>
   </body>
 </html>

--- a/nagi-s1/generated/magazine/index.html
+++ b/nagi-s1/generated/magazine/index.html
@@ -183,4 +183,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/list/index.html
+++ b/nagi-s1/generated/magazine/list/index.html
@@ -110,4 +110,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/about-世界観/index.html
+++ b/nagi-s1/generated/magazine/posts/about-世界観/index.html
@@ -50,4 +50,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/about-読みどころ/index.html
+++ b/nagi-s1/generated/magazine/posts/about-読みどころ/index.html
@@ -50,4 +50,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/character-サキュバスメイド喫茶∞/index.html
+++ b/nagi-s1/generated/magazine/posts/character-サキュバスメイド喫茶∞/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/character-バルハ/index.html
+++ b/nagi-s1/generated/magazine/posts/character-バルハ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/character-神崎ナギ/index.html
+++ b/nagi-s1/generated/magazine/posts/character-神崎ナギ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/character-結城ユイ/index.html
+++ b/nagi-s1/generated/magazine/posts/character-結城ユイ/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep01/index.html
+++ b/nagi-s1/generated/magazine/posts/ep01/index.html
@@ -262,4 +262,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep02/index.html
+++ b/nagi-s1/generated/magazine/posts/ep02/index.html
@@ -199,4 +199,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep03/index.html
+++ b/nagi-s1/generated/magazine/posts/ep03/index.html
@@ -221,4 +221,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep04/index.html
+++ b/nagi-s1/generated/magazine/posts/ep04/index.html
@@ -166,4 +166,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep05/index.html
+++ b/nagi-s1/generated/magazine/posts/ep05/index.html
@@ -179,4 +179,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep06/index.html
+++ b/nagi-s1/generated/magazine/posts/ep06/index.html
@@ -150,4 +150,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep07/index.html
+++ b/nagi-s1/generated/magazine/posts/ep07/index.html
@@ -143,4 +143,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep08/index.html
+++ b/nagi-s1/generated/magazine/posts/ep08/index.html
@@ -118,4 +118,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep09/index.html
+++ b/nagi-s1/generated/magazine/posts/ep09/index.html
@@ -121,4 +121,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep10/index.html
+++ b/nagi-s1/generated/magazine/posts/ep10/index.html
@@ -105,4 +105,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep11/index.html
+++ b/nagi-s1/generated/magazine/posts/ep11/index.html
@@ -127,4 +127,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/ep12/index.html
+++ b/nagi-s1/generated/magazine/posts/ep12/index.html
@@ -98,4 +98,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/site-meta/index.html
+++ b/nagi-s1/generated/magazine/posts/site-meta/index.html
@@ -46,4 +46,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s1/generated/magazine/posts/welcome-post/index.html
+++ b/nagi-s1/generated/magazine/posts/welcome-post/index.html
@@ -48,4 +48,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=2026-01-02T05:08:08.217208+00:00 sha=60d97f952842b5116f2a6892a7657542f633e8a9 items=20 -->
+<!-- sitegen build: ts=2026-01-02T18:42:30.166274+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=20 -->

--- a/nagi-s2/generated/hina/index.html
+++ b/nagi-s2/generated/hina/index.html
@@ -145,4 +145,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/list/index.html
+++ b/nagi-s2/generated/hina/list/index.html
@@ -116,4 +116,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep01/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep01/index.html
@@ -85,4 +85,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep02/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep02/index.html
@@ -91,4 +91,4 @@ SDKが入らない。
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep03/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep03/index.html
@@ -95,4 +95,4 @@ Assert：世界が理想通りか言い切る
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep04/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep04/index.html
@@ -90,4 +90,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep05/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep05/index.html
@@ -96,4 +96,4 @@ WorldState → Lens → 操作・判定
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep06/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep06/index.html
@@ -95,4 +95,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep07/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep07/index.html
@@ -98,4 +98,4 @@ Factory / Fixture
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep08/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep08/index.html
@@ -96,4 +96,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep09/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep09/index.html
@@ -102,4 +102,4 @@ LGTM
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep10/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep10/index.html
@@ -101,4 +101,4 @@ PMがチームチャットに書く。
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep11/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep11/index.html
@@ -104,4 +104,4 @@ PMが画面を見て、青ざめてから、息を吐いた。
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep12/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep12/index.html
@@ -99,4 +99,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated/hina/posts/nagi-s2-ep13/index.html
+++ b/nagi-s2/generated/hina/posts/nagi-s2-ep13/index.html
@@ -94,4 +94,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/index.html
+++ b/nagi-s2/generated_v2/hina/index.html
@@ -145,4 +145,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/list/index.html
+++ b/nagi-s2/generated_v2/hina/list/index.html
@@ -116,4 +116,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep01/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep01/index.html
@@ -85,4 +85,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep02/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep02/index.html
@@ -91,4 +91,4 @@ SDKが入らない。
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep03/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep03/index.html
@@ -95,4 +95,4 @@ Assert：世界が理想通りか言い切る
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep04/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep04/index.html
@@ -90,4 +90,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep05/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep05/index.html
@@ -96,4 +96,4 @@ WorldState → Lens → 操作・判定
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep06/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep06/index.html
@@ -95,4 +95,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep07/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep07/index.html
@@ -98,4 +98,4 @@ Factory / Fixture
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep08/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep08/index.html
@@ -96,4 +96,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep09/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep09/index.html
@@ -102,4 +102,4 @@ LGTM
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep10/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep10/index.html
@@ -101,4 +101,4 @@ PMがチームチャットに書く。
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep11/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep11/index.html
@@ -104,4 +104,4 @@ PMが画面を見て、青ざめてから、息を吐いた。
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep12/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep12/index.html
@@ -99,4 +99,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s2/generated_v2/hina/posts/nagi-s2-ep13/index.html
+++ b/nagi-s2/generated_v2/hina/posts/nagi-s2-ep13/index.html
@@ -94,4 +94,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/index.html
+++ b/nagi-s3/generated/hina/index.html
@@ -145,4 +145,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/list/index.html
+++ b/nagi-s3/generated/hina/list/index.html
@@ -116,4 +116,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep01/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep01/index.html
@@ -75,4 +75,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep02/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep02/index.html
@@ -81,4 +81,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep03/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep03/index.html
@@ -76,4 +76,4 @@ Appium のスクリプトは、画面ロケータが直書き、待機がベタ�
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep04/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep04/index.html
@@ -83,4 +83,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep05/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep05/index.html
@@ -78,4 +78,4 @@ shows_error(message)
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep06/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep06/index.html
@@ -77,4 +77,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep07/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep07/index.html
@@ -82,4 +82,4 @@ A(S)：代表ユーザー（該当フラグの境界）での確認
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep08/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep08/index.html
@@ -74,4 +74,4 @@ CFO も頷く。「教育計画と移行計画を出して。投資判断は通�
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep09/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep09/index.html
@@ -74,4 +74,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep10/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep10/index.html
@@ -80,4 +80,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep11/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep11/index.html
@@ -75,4 +75,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep12/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep12/index.html
@@ -79,4 +79,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated/hina/posts/nagi-s3-ep13/index.html
+++ b/nagi-s3/generated/hina/posts/nagi-s3-ep13/index.html
@@ -79,4 +79,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/index.html
+++ b/nagi-s3/generated_v2/hina/index.html
@@ -145,4 +145,4 @@
   </footer>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/list/index.html
+++ b/nagi-s3/generated_v2/hina/list/index.html
@@ -116,4 +116,4 @@
   </main>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep01/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep01/index.html
@@ -75,4 +75,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep02/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep02/index.html
@@ -81,4 +81,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep03/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep03/index.html
@@ -76,4 +76,4 @@ Appium のスクリプトは、画面ロケータが直書き、待機がベタ�
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep04/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep04/index.html
@@ -83,4 +83,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep05/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep05/index.html
@@ -78,4 +78,4 @@ shows_error(message)
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep06/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep06/index.html
@@ -77,4 +77,4 @@ G : (W, E) → (S, A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep07/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep07/index.html
@@ -82,4 +82,4 @@ A(S)：代表ユーザー（該当フラグの境界）での確認
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep08/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep08/index.html
@@ -74,4 +74,4 @@ CFO も頷く。「教育計画と移行計画を出して。投資判断は通�
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep09/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep09/index.html
@@ -74,4 +74,4 @@
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep10/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep10/index.html
@@ -80,4 +80,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep11/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep11/index.html
@@ -75,4 +75,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep12/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep12/index.html
@@ -79,4 +79,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->

--- a/nagi-s3/generated_v2/hina/posts/nagi-s3-ep13/index.html
+++ b/nagi-s3/generated_v2/hina/posts/nagi-s3-ep13/index.html
@@ -79,4 +79,4 @@ G : (W,E) → (S,A(S))
   </article>
   </body>
 </html>
-<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=2dfb7658b1ad2482f9fed8cb1cdb77bce1852bdc items=13 -->
+<!-- sitegen build: ts=1970-01-01T00:00:00+00:00 sha=d872ee46ec2a38deb6eb1cb845b1daa533852ce1 items=13 -->


### PR DESCRIPTION
## Summary
- Regenerated the season 1 site output with the sitegen build pipeline to refresh links and shared assets.
- Rebuilt season 2 and season 3 via the v2 preview script, including deterministic checks and refreshed alias copies under generated/.

## Testing
- python -m sitegen validate --experiences config/experiences.yaml --content content/posts
- python -m sitegen build --experiences config/experiences.yaml --src experience_src --out nagi-s1/generated --content content/posts --all --legacy-base nagi-s1
- python scripts/build_preview_v2.py --force

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69581147468c8333a5120a05ce4758cb)