### PR TITLE
Add rl-bandit exploratory strategy with feedback rewards

### DIFF
--- a/.qa/tests/exploratory/env.ts
+++ b/.qa/tests/exploratory/env.ts
@@ -21,6 +21,11 @@ function parseAllowedPrefixes(input: string | undefined, fallback?: string[]): s
   return prefixes.length > 0 ? prefixes : fallback;
 }
 
+function parseRewardMode(input: string | undefined): ExploreConfig["rewardMode"] {
+  const normalized = (input ?? "").trim().toLowerCase();
+  return normalized === "bughunt" ? "bughunt" : "coverage";
+}
+
 export function loadExploreConfig(defaults?: Partial<ExploreConfig> & { defaultStrategy?: string }): ExploreConfig {
   const seconds = parseNumber(process.env.QA_EXPLORE_SECONDS, defaults?.seconds ?? 120);
   const seed = parseNumber(process.env.QA_EXPLORE_SEED, defaults?.seed ?? Date.now());
@@ -44,6 +49,7 @@ export function loadExploreConfig(defaults?: Partial<ExploreConfig> & { defaultS
   const benchRunDirEnv = process.env.QA_EXPLORE_BENCH_RUN_DIR;
   const benchMode = (process.env.QA_EXPLORE_BENCH ?? "0") === "1" || Boolean(benchRunDirEnv);
   const benchRunDir = benchRunDirEnv || (benchMode ? artifactsDir : undefined);
+  const rewardMode = parseRewardMode(process.env.QA_EXPLORE_RL_REWARD_MODE ?? defaults?.rewardMode);
 
   return {
     seconds,
@@ -59,5 +65,6 @@ export function loadExploreConfig(defaults?: Partial<ExploreConfig> & { defaultS
     benchRunDir,
     baseURL: defaults?.baseURL ?? qa.baseURL,
     waitAfterGotoMs: defaults?.waitAfterGotoMs ?? qa.waitAfterGotoMs,
+    rewardMode: rewardMode ?? "coverage",
   };
 }

--- a/.qa/tests/exploratory/rl-bandit.spec.ts
+++ b/.qa/tests/exploratory/rl-bandit.spec.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { createRng } from "./rng";
+import { RLBanditLearner } from "./strategies/rl-bandit";
+import type { StepFeedback } from "./types";
+
+function baseFeedback(fromPath: string, toPath: string, reward: number): StepFeedback {
+  return {
+    fromPath,
+    toPath,
+    reward,
+    gain: { newPages: 0, newRoutes: 0, newApis: 0, newAssets: 0 },
+    revisited: false,
+    recentLoop: false,
+    stepIndex: 0,
+    rewardMode: "coverage",
+  };
+}
+
+function createOptions(modelPath: string, persist: boolean, reset = false) {
+  return {
+    algo: "ucb1" as const,
+    eps: 0.1,
+    ucbC: 1.2,
+    persist,
+    modelPath,
+    reset,
+    maxArmsPerState: 500,
+    persistEvery: 1,
+    rewardMode: "coverage" as const,
+  };
+}
+
+test("rl-bandit prefers untried arms then UCB1 score", async () => {
+  const learner = new RLBanditLearner(createOptions("noop.json", false));
+  await learner.init();
+
+  await learner.onFeedback({ ...baseFeedback("/from", "/a", 1), gain: { newPages: 1, newRoutes: 0, newApis: 0, newAssets: 0 } });
+  await learner.onFeedback({ ...baseFeedback("/from", "/a", 1), gain: { newPages: 1, newRoutes: 0, newApis: 0, newAssets: 0 } });
+  await learner.onFeedback(baseFeedback("/from", "/b", 3));
+  await learner.onFeedback(baseFeedback("/from", "/b", 2));
+
+  const candidates = [
+    { href: "/a", abs: "http://example.com/a", path: "/a" },
+    { href: "/b", abs: "http://example.com/b", path: "/b" },
+    { href: "/c", abs: "http://example.com/c", path: "/c" },
+  ];
+
+  const pickUntried = learner.select("/from", candidates, createRng(7));
+  expect(pickUntried.path).toBe("/c");
+
+  // make /c tried once to test UCB scores
+  await learner.onFeedback(baseFeedback("/from", "/c", 0.5));
+  const pickByScore = learner.select("/from", candidates, createRng(11));
+  expect(pickByScore.path).toBe("/b");
+});
+
+test("rl-bandit updates incremental mean and count", async () => {
+  const learner = new RLBanditLearner(createOptions("noop.json", false));
+  await learner.init();
+
+  await learner.onFeedback(baseFeedback("/state", "/next", 1));
+  await learner.onFeedback(baseFeedback("/state", "/next", 3));
+
+  const table = (learner as any).model.table as Record<string, Record<string, { n: number; mean: number }>>;
+  expect(table["/state"]["/next"].n).toBe(2);
+  expect(table["/state"]["/next"].mean).toBeCloseTo(2);
+});
+
+test("rl-bandit saves and loads model", async ({}, testInfo) => {
+  const modelPath = path.join(testInfo.outputPath(), "bandit-model.json");
+  const learner = new RLBanditLearner(createOptions(modelPath, true));
+  await learner.init();
+  await learner.onFeedback(baseFeedback("/s", "/t", 4));
+  await learner.onEnd();
+
+  const raw = await fs.readFile(modelPath, "utf8");
+  expect(raw).toContain("/t");
+
+  const loaded = new RLBanditLearner(createOptions(modelPath, true));
+  await loaded.init();
+  const table = (loaded as any).model.table as Record<string, Record<string, { n: number; mean: number }>>;
+  expect(table["/s"]["/t"].n).toBe(1);
+  expect(table["/s"]["/t"].mean).toBeCloseTo(4);
+});
+
+test("rl-bandit tolerates broken JSON on load", async ({}, testInfo) => {
+  const modelPath = path.join(testInfo.outputPath(), "broken-model.json");
+  await fs.writeFile(modelPath, "{not-json", "utf8");
+
+  const learner = new RLBanditLearner(createOptions(modelPath, true));
+  await expect(learner.init()).resolves.not.toThrow();
+
+  const table = (learner as any).model.table as Record<string, unknown>;
+  expect(Object.keys(table)).toHaveLength(0);
+});

--- a/.qa/tests/exploratory/runner.ts
+++ b/.qa/tests/exploratory/runner.ts
@@ -9,6 +9,9 @@ import type {
   ExploreContext,
   ExploreStrategy,
   FlowData,
+  RewardMode,
+  StepErrors,
+  StepFeedback,
 } from "./types";
 import { normalizePathFromUrl } from "./types";
 import { createBenchmarkRecorder } from "./bench-logger";
@@ -21,14 +24,82 @@ export type RunExploreOptions = {
 };
 
 type Navigator = {
-  goto: (url: string) => Promise<void>;
+  goto: (url: string) => Promise<NavigationResult>;
   errors: string[];
   blockedExternalRequests: string[];
+  getLastErrors: () => NavigationErrorFlags;
+};
+
+type NavigationErrorFlags = { httpStatusGE400: boolean; pageerror: boolean; consoleError: boolean };
+type NavigationResult = { errors: NavigationErrorFlags };
+
+type CoverageSnapshot = {
+  pagesVisited: number;
+  routesVisited: number;
+  apisVisited: number;
+  assetsVisited: number;
+};
+
+type PendingFeedback = {
+  fromPath: string;
+  toPath: string;
+  before: CoverageSnapshot;
+  revisited: boolean;
+  recentLoop: boolean;
+  stepIndex: number;
+  errors?: NavigationErrorFlags;
 };
 
 function rememberRecent(recent: string[], path: string) {
   recent.push(path);
   if (recent.length > 5) recent.shift();
+}
+
+function snapshotCoverage(coverage: ReturnType<typeof createCoverageState>): CoverageSnapshot {
+  let routesVisited = 0;
+  let apisVisited = 0;
+  let assetsVisited = 0;
+
+  for (const item of coverage.covered) {
+    if (item.startsWith("route:")) routesVisited += 1;
+    else if (item.startsWith("api:")) apisVisited += 1;
+    else if (item.startsWith("asset:")) assetsVisited += 1;
+  }
+
+  return {
+    pagesVisited: coverage.pathToObserved.size,
+    routesVisited,
+    apisVisited,
+    assetsVisited,
+  };
+}
+
+function diffCoverage(before: CoverageSnapshot, after: CoverageSnapshot) {
+  return {
+    newPages: Math.max(0, after.pagesVisited - before.pagesVisited),
+    newRoutes: Math.max(0, after.routesVisited - before.routesVisited),
+    newApis: Math.max(0, after.apisVisited - before.apisVisited),
+    newAssets: Math.max(0, after.assetsVisited - before.assetsVisited),
+  };
+}
+
+function computeReward(
+  gain: ReturnType<typeof diffCoverage>,
+  rewardMode: RewardMode,
+  revisited: boolean,
+  recentLoop: boolean,
+  foundError: boolean
+): number {
+  const base =
+    2 * gain.newPages + 1 * gain.newRoutes + 0.5 * gain.newApis + 0.2 * gain.newAssets - 0.3 * (revisited ? 1 : 0) -
+    0.6 * (recentLoop ? 1 : 0);
+
+  const errorTerm = rewardMode === "bughunt" ? 5 * (foundError ? 1 : 0) : -3 * (foundError ? 1 : 0);
+  return base + errorTerm;
+}
+
+function hasError(errors?: StepErrors): boolean {
+  return Boolean(errors?.httpStatusGE400 || errors?.consoleError || errors?.pageerror);
 }
 
 async function loadFlowData(flowJsonPath: string): Promise<FlowData> {
@@ -48,11 +119,21 @@ function createNavigator(
   recordBenchError?: (err: { type: "http" | "console" | "pageerror" | "navigation"; message: string; url?: string; status?: number }) => void
 ): Navigator {
   const blockedExternalRequests: string[] = [];
+  const freshErrorFlags = (): NavigationErrorFlags => ({ httpStatusGE400: false, pageerror: false, consoleError: false });
+  let lastErrors = freshErrorFlags();
+
+  const markErrorsFromMessages = (messages: string[]) => {
+    for (const msg of messages) {
+      if (msg.startsWith("console:")) lastErrors.consoleError = true;
+      if (msg.startsWith("pageerror:")) lastErrors.pageerror = true;
+    }
+  };
 
   if (mode === "random") {
     page.on("pageerror", (e) => {
       const msg = `pageerror: ${String(e)}`;
       errors.push(msg);
+      lastErrors.pageerror = true;
       recordBenchError?.({ type: "pageerror", message: msg });
     });
     page.on("console", (msg) => {
@@ -63,12 +144,15 @@ function createNavigator(
       if (isBlockedErr && blockedFromTestInfo.length > 0) return;
 
       errors.push(`console: ${text}`);
+      lastErrors.consoleError = true;
       recordBenchError?.({ type: "console", message: text });
     });
 
     return {
       goto: async (url: string) => {
+        lastErrors = freshErrorFlags();
         resetCoverage();
+        const previousErrors = errors.length;
         const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 20_000 });
         await page.waitForTimeout(waitAfterGotoMs);
 
@@ -76,29 +160,39 @@ function createNavigator(
 
         const status = resp?.status?.();
         if (typeof status === "number" && status >= 400) {
+          lastErrors.httpStatusGE400 = true;
           recordBenchError?.({ type: "http", message: `HTTP ${status} at ${url}`, url, status });
           throw new Error(`HTTP ${status} at ${url}`);
         }
 
+        if (errors.length > previousErrors) markErrorsFromMessages(errors.slice(previousErrors));
+
         if (errors.length > 0) {
+          if (errors.length > previousErrors) markErrorsFromMessages(errors.slice(previousErrors));
+          if (errors.length === previousErrors) markErrorsFromMessages(errors);
           recordBenchError?.({ type: "navigation", message: errors.join(" | "), url });
           throw new Error(`Console/Page error at ${url}: ${errors.join(" | ")}`);
         }
+
+        return { errors: { ...lastErrors } };
       },
       errors,
       blockedExternalRequests,
+      getLastErrors: () => ({ ...lastErrors }),
     };
   }
 
   page.on("pageerror", (e) => {
     const msg = `pageerror: ${String(e)}`;
     errors.push(msg);
+    lastErrors.pageerror = true;
     recordBenchError?.({ type: "pageerror", message: msg });
   });
   page.on("console", (msg) => {
     if (msg.type() === "error") {
       const text = msg.text();
       errors.push(`console: ${text}`);
+      lastErrors.consoleError = true;
       recordBenchError?.({ type: "console", message: text });
     }
   });
@@ -113,6 +207,7 @@ function createNavigator(
 
   return {
     goto: async (url: string) => {
+      lastErrors = freshErrorFlags();
       resetCoverage();
       errors.length = 0;
       const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 20_000 });
@@ -120,6 +215,7 @@ function createNavigator(
 
       const status = resp?.status?.();
       if (typeof status === "number" && status >= 400) {
+        lastErrors.httpStatusGE400 = true;
         recordBenchError?.({ type: "http", message: `HTTP ${status} at ${url}`, url, status });
         throw new Error(`HTTP ${status} at ${url}`);
       }
@@ -127,14 +223,18 @@ function createNavigator(
       if (errors.length > 0) {
         const nonNoise = errors.filter((e) => !/Failed to load resource/i.test(e));
         if (nonNoise.length > 0) {
+          markErrorsFromMessages(nonNoise);
           recordBenchError?.({ type: "navigation", message: nonNoise.join(" | "), url });
           throw new Error(`Console/Page error at ${url}: ${nonNoise.join(" | ")}`);
         }
         errors.length = 0;
       }
+
+      return { errors: { ...lastErrors } };
     },
     errors,
     blockedExternalRequests,
+    getLastErrors: () => ({ ...lastErrors }),
   };
 }
 
@@ -206,19 +306,56 @@ export async function runExplore({ page, testInfo, strategy, config }: RunExplor
       : undefined
   );
 
-  const perform = async () => {
-    await navigator.goto(startUrl);
+  const defaultErrors: NavigationErrorFlags = { httpStatusGE400: false, pageerror: false, consoleError: false };
+  let pendingFeedback: PendingFeedback | null = null;
+  let lastProcessedPath: string | null = null;
 
-    while (Date.now() < deadline) {
-      const currentUrl = page.url();
-      const currentPath = normalizePathFromUrl(currentUrl);
+  const emitFeedback = async (pending: PendingFeedback, afterSnapshot: CoverageSnapshot, errorsForStep?: NavigationErrorFlags) => {
+    const gain = diffCoverage(pending.before, afterSnapshot);
+    const errorsInfo: StepErrors | undefined = errorsForStep ?? pending.errors;
+    const foundError = hasError(errorsInfo);
+    const reward = computeReward(gain, config.rewardMode, pending.revisited, pending.recentLoop, foundError);
+    const feedback: StepFeedback = {
+      fromPath: pending.fromPath,
+      toPath: pending.toPath,
+      reward,
+      gain,
+      errors: errorsInfo,
+      revisited: pending.revisited,
+      recentLoop: pending.recentLoop,
+      stepIndex: pending.stepIndex,
+      rewardMode: config.rewardMode,
+    };
+    await strategy.onFeedback?.(feedback);
+  };
+
+  const processCurrentPage = () => {
+    const currentUrl = page.url();
+    const currentPath = normalizePathFromUrl(currentUrl);
+    const alreadyProcessed = lastProcessedPath === currentPath && observedSinceLastGoto.size === 0;
+    if (!alreadyProcessed) {
       const observedForPage = new Set<string>(observedSinceLastGoto);
       observedForPage.add(`route:${currentPath}`);
       updateCoverage(coverage, currentPath, observedForPage);
       observedSinceLastGoto.clear();
+      lastProcessedPath = currentPath;
+      bench.recordVisit(currentPath);
       visited.add(currentPath);
       rememberRecent(recent, currentPath);
-      bench.recordVisit(currentPath);
+    }
+
+    return { currentUrl, currentPath, afterSnapshot: snapshotCoverage(coverage) };
+  };
+
+  const perform = async () => {
+    await navigator.goto(startUrl);
+
+    while (Date.now() < deadline) {
+      const { currentUrl, currentPath, afterSnapshot } = processCurrentPage();
+      if (pendingFeedback) {
+        await emitFeedback(pendingFeedback, afterSnapshot, pendingFeedback.errors);
+        pendingFeedback = null;
+      }
 
       const candidates = await collectCandidates({
         page,
@@ -258,11 +395,30 @@ export async function runExplore({ page, testInfo, strategy, config }: RunExplor
       bench.recordStep({ stepIndex, from: currentPath, action, candidates, coverage, visited });
       if (action.action === "stop") break;
 
+      const beforeSnapshot = snapshotCoverage(coverage);
+
       if (action.action === "restart") {
         if (strategy.name !== "random-walk") {
           steps.push({ from: currentPath, to: startPathNormalized, via: action.via ?? "goto(start)" });
         }
-        await navigator.goto(startUrl);
+        pendingFeedback = {
+          fromPath: currentPath,
+          toPath: startPathNormalized,
+          before: beforeSnapshot,
+          revisited: visited.has(startPathNormalized),
+          recentLoop: recent.includes(startPathNormalized),
+          stepIndex,
+          errors: defaultErrors,
+        };
+        try {
+          const result = await navigator.goto(startUrl);
+          pendingFeedback.errors = result.errors;
+        } catch (err) {
+          pendingFeedback.errors = navigator.getLastErrors();
+          await emitFeedback(pendingFeedback, snapshotCoverage(coverage), pendingFeedback.errors);
+          pendingFeedback = null;
+          throw err;
+        }
         stepIndex += 1;
         continue;
       }
@@ -272,8 +428,34 @@ export async function runExplore({ page, testInfo, strategy, config }: RunExplor
         steps.push({ from: currentPath, to: toPath, via: action.via ?? "goto(link)" });
       }
 
-      await navigator.goto(action.url);
+      const toPath = action.targetPath ?? normalizePathFromUrl(action.url);
+      pendingFeedback = {
+        fromPath: currentPath,
+        toPath,
+        before: beforeSnapshot,
+        revisited: visited.has(toPath),
+        recentLoop: recent.includes(toPath),
+        stepIndex,
+        errors: defaultErrors,
+      };
+
+      try {
+        const navResult = await navigator.goto(action.url);
+        pendingFeedback.errors = navResult.errors;
+      } catch (err) {
+        pendingFeedback.errors = navigator.getLastErrors();
+        await emitFeedback(pendingFeedback, snapshotCoverage(coverage), pendingFeedback.errors);
+        pendingFeedback = null;
+        throw err;
+      }
+
       stepIndex += 1;
+    }
+
+    if (pendingFeedback) {
+      const { afterSnapshot } = processCurrentPage();
+      await emitFeedback(pendingFeedback, afterSnapshot, pendingFeedback.errors);
+      pendingFeedback = null;
     }
   };
 
@@ -286,20 +468,24 @@ export async function runExplore({ page, testInfo, strategy, config }: RunExplor
       runError = err;
       throw err;
     } finally {
-      await attachText(testInfo, "explore-seed.txt", String(config.seed));
-      await attachText(testInfo, "explore-history.txt", history.join("\n"));
-      if (errors.length > 0) {
-        await attachText(testInfo, "explore-errors.txt", errors.join("\n"));
+      try {
+        await attachText(testInfo, "explore-seed.txt", String(config.seed));
+        await attachText(testInfo, "explore-history.txt", history.join("\n"));
+        if (errors.length > 0) {
+          await attachText(testInfo, "explore-errors.txt", errors.join("\n"));
+        }
+        await bench.finish({
+          coverage,
+          visited,
+          targetSet,
+          blockedRequests: navigator.blockedExternalRequests,
+          status: runError ? "failed" : "passed",
+          error: runError,
+          history,
+        });
+      } finally {
+        await strategy.onEnd?.();
       }
-      await bench.finish({
-        coverage,
-        visited,
-        targetSet,
-        blockedRequests: navigator.blockedExternalRequests,
-        status: runError ? "failed" : "passed",
-        error: runError,
-        history,
-      });
     }
     return;
   }
@@ -310,43 +496,47 @@ export async function runExplore({ page, testInfo, strategy, config }: RunExplor
     runError = err;
     throw err;
   } finally {
-    const visitedList = Array.from(visited).sort();
-    const targets = Array.from(targetSet ?? new Set<string>()).sort();
-    const uncovered = targets.filter((p) => !visited.has(p));
-    const coverageRatio =
-      targets.length === 0 ? 1 : visitedList.filter((p) => targetSet?.has(p)).length / targets.length;
+    try {
+      const visitedList = Array.from(visited).sort();
+      const targets = Array.from(targetSet ?? new Set<string>()).sort();
+      const uncovered = targets.filter((p) => !visited.has(p));
+      const coverageRatio =
+        targets.length === 0 ? 1 : visitedList.filter((p) => targetSet?.has(p)).length / targets.length;
 
-    const report = {
-      meta: {
-        baseURL: config.baseURL,
-        seed: config.seed,
-        seconds: config.seconds,
-        startPath: config.startPath,
-        restartEvery: config.restartEvery,
-        generatedAt: new Date().toISOString(),
-        flowJsonPath: config.flowJsonPath,
-      },
-      targetsCount: targets.length,
-      visitedCount: visitedList.length,
-      coverage: coverageRatio,
-      visited: visitedList,
-      uncovered,
-      steps,
-      blockedExternalRequests: Array.from(new Set(navigator.blockedExternalRequests)).sort(),
-    };
+      const report = {
+        meta: {
+          baseURL: config.baseURL,
+          seed: config.seed,
+          seconds: config.seconds,
+          startPath: config.startPath,
+          restartEvery: config.restartEvery,
+          generatedAt: new Date().toISOString(),
+          flowJsonPath: config.flowJsonPath,
+        },
+        targetsCount: targets.length,
+        visitedCount: visitedList.length,
+        coverage: coverageRatio,
+        visited: visitedList,
+        uncovered,
+        steps,
+        blockedExternalRequests: Array.from(new Set(navigator.blockedExternalRequests)).sort(),
+      };
 
-    await writeGuidedCoverage(report, config, testInfo);
-    await attachText(testInfo, "guided-seed.txt", String(config.seed));
-    await attachText(testInfo, "guided-visited.txt", visitedList.join("\n"));
-    await attachText(testInfo, "guided-uncovered.txt", uncovered.join("\n"));
-    await bench.finish({
-      coverage,
-      visited,
-      targetSet,
-      blockedRequests: navigator.blockedExternalRequests,
-      status: runError ? "failed" : "passed",
-      error: runError,
-      history,
-    });
+      await writeGuidedCoverage(report, config, testInfo);
+      await attachText(testInfo, "guided-seed.txt", String(config.seed));
+      await attachText(testInfo, "guided-visited.txt", visitedList.join("\n"));
+      await attachText(testInfo, "guided-uncovered.txt", uncovered.join("\n"));
+      await bench.finish({
+        coverage,
+        visited,
+        targetSet,
+        blockedRequests: navigator.blockedExternalRequests,
+        status: runError ? "failed" : "passed",
+        error: runError,
+        history,
+      });
+    } finally {
+      await strategy.onEnd?.();
+    }
   }
 }

--- a/.qa/tests/exploratory/strategies/index.ts
+++ b/.qa/tests/exploratory/strategies/index.ts
@@ -1,6 +1,7 @@
 import type { ExploreStrategy } from "../types";
 import { guidedCoverageStrategy } from "./guided-coverage";
 import { randomWalkStrategy } from "./random-walk";
+import { rlBanditStrategy } from "./rl-bandit";
 import { setCoverGreedyStrategy } from "./set-cover-greedy";
 
 const strategies: Record<string, ExploreStrategy> = {
@@ -8,6 +9,8 @@ const strategies: Record<string, ExploreStrategy> = {
   [guidedCoverageStrategy.name]: guidedCoverageStrategy,
   [setCoverGreedyStrategy.name]: setCoverGreedyStrategy,
   ["set-cover"]: setCoverGreedyStrategy,
+  [rlBanditStrategy.name]: rlBanditStrategy,
+  ["bandit"]: rlBanditStrategy,
 };
 
 export function getStrategy(name: string): ExploreStrategy {

--- a/.qa/tests/exploratory/strategies/rl-bandit.ts
+++ b/.qa/tests/exploratory/strategies/rl-bandit.ts
@@ -1,0 +1,257 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ExploreCandidate, ExploreContext, ExploreStrategy, RewardMode, StepFeedback } from "../types";
+
+type ArmStats = { n: number; mean: number };
+type ArmTable = Record<string, ArmStats>;
+
+type BanditModel = {
+  version: 1;
+  algo: "ucb1" | "eps-greedy";
+  params: { eps: number; ucbC: number; rewardMode: RewardMode };
+  table: Record<string, ArmTable>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type RLBanditOptions = {
+  algo: "ucb1" | "eps-greedy";
+  eps: number;
+  ucbC: number;
+  persist: boolean;
+  modelPath: string;
+  reset: boolean;
+  maxArmsPerState: number;
+  persistEvery: number;
+  rewardMode: RewardMode;
+};
+
+function parseNumberEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseAlgo(value: string | undefined): "ucb1" | "eps-greedy" {
+  const normalized = (value ?? "").trim().toLowerCase();
+  return normalized === "eps-greedy" ? "eps-greedy" : "ucb1";
+}
+
+export class RLBanditLearner {
+  private model: BanditModel;
+  private readonly options: RLBanditOptions;
+  private feedbackSincePersist = 0;
+
+  constructor(options: RLBanditOptions) {
+    const now = new Date().toISOString();
+    this.options = options;
+    this.model = {
+      version: 1,
+      algo: options.algo,
+      params: { eps: options.eps, ucbC: options.ucbC, rewardMode: options.rewardMode },
+      table: {},
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async init(): Promise<void> {
+    if (!this.options.persist || this.options.reset) return;
+
+    try {
+      const raw = await fs.readFile(this.options.modelPath, "utf8");
+      const parsed = JSON.parse(raw) as Partial<BanditModel>;
+      if (parsed?.version !== 1 || !parsed.table) return;
+      this.model = {
+        version: 1,
+        algo: parseAlgo(parsed.algo),
+        params: {
+          eps: typeof parsed.params?.eps === "number" ? parsed.params.eps : this.options.eps,
+          ucbC: typeof parsed.params?.ucbC === "number" ? parsed.params.ucbC : this.options.ucbC,
+          rewardMode: (parsed.params?.rewardMode as RewardMode) ?? this.options.rewardMode,
+        },
+        table: parsed.table,
+        createdAt: parsed.createdAt ?? this.model.createdAt,
+        updatedAt: parsed.updatedAt ?? this.model.updatedAt,
+      };
+    } catch {
+      // fallback to fresh model
+      this.model.table = {};
+    }
+  }
+
+  private armStats(fromPath: string, toPath: string): ArmStats {
+    const state = this.model.table[fromPath] ?? {};
+    return state[toPath] ?? { n: 0, mean: 0 };
+  }
+
+  private ensureState(fromPath: string): ArmTable {
+    if (!this.model.table[fromPath]) {
+      this.model.table[fromPath] = {};
+    }
+    return this.model.table[fromPath];
+  }
+
+  private pruneState(fromPath: string) {
+    const state = this.model.table[fromPath];
+    if (!state) return;
+    const entries = Object.entries(state);
+    if (entries.length <= this.options.maxArmsPerState) return;
+
+    entries.sort((a, b) => {
+      const nDiff = a[1].n - b[1].n;
+      if (nDiff !== 0) return nDiff;
+      return a[1].mean - b[1].mean;
+    });
+
+    const removeCount = entries.length - this.options.maxArmsPerState;
+    for (let i = 0; i < removeCount; i += 1) {
+      const [toPath] = entries[i];
+      delete state[toPath];
+    }
+  }
+
+  private pickByUcb(fromPath: string, candidates: ExploreCandidate[], rng: ExploreContext["rng"]): ExploreCandidate {
+    const stats = candidates.map((candidate) => ({ candidate, stats: this.armStats(fromPath, candidate.path) }));
+    const untried = stats.filter((s) => s.stats.n === 0);
+    if (untried.length > 0) {
+      return untried[rng.nextInt(untried.length)].candidate;
+    }
+
+    const totalN = stats.reduce((sum, s) => sum + s.stats.n, 1);
+    let best = Number.NEGATIVE_INFINITY;
+    const bestPool: Array<{ candidate: ExploreCandidate; score: number }> = [];
+
+    for (const { candidate, stats: stat } of stats) {
+      const score = stat.mean + this.options.ucbC * Math.sqrt(Math.log(totalN) / stat.n);
+      if (score > best) {
+        best = score;
+        bestPool.length = 0;
+        bestPool.push({ candidate, score });
+      } else if (score === best) {
+        bestPool.push({ candidate, score });
+      }
+    }
+
+    return bestPool[rng.nextInt(bestPool.length)].candidate;
+  }
+
+  private pickByEpsGreedy(fromPath: string, candidates: ExploreCandidate[], rng: ExploreContext["rng"]): ExploreCandidate {
+    if (candidates.length === 1) return candidates[0];
+    const explore = rng.next() < this.options.eps;
+    if (explore) {
+      return candidates[rng.nextInt(candidates.length)];
+    }
+
+    let bestMean = Number.NEGATIVE_INFINITY;
+    const bestPool: ExploreCandidate[] = [];
+    for (const candidate of candidates) {
+      const stats = this.armStats(fromPath, candidate.path);
+      if (stats.mean > bestMean) {
+        bestMean = stats.mean;
+        bestPool.length = 0;
+        bestPool.push(candidate);
+      } else if (stats.mean === bestMean) {
+        bestPool.push(candidate);
+      }
+    }
+
+    return bestPool[rng.nextInt(bestPool.length)];
+  }
+
+  select(fromPath: string, candidates: ExploreCandidate[], rng: ExploreContext["rng"]): ExploreCandidate {
+    const algo = this.options.algo;
+    if (algo === "eps-greedy") {
+      return this.pickByEpsGreedy(fromPath, candidates, rng);
+    }
+    return this.pickByUcb(fromPath, candidates, rng);
+  }
+
+  async onFeedback(fb: StepFeedback): Promise<void> {
+    const state = this.ensureState(fb.fromPath);
+    const prev = state[fb.toPath] ?? { n: 0, mean: 0 };
+    const nextN = prev.n + 1;
+    const nextMean = prev.mean + (fb.reward - prev.mean) / nextN;
+    state[fb.toPath] = { n: nextN, mean: nextMean };
+    this.model.updatedAt = new Date().toISOString();
+    this.feedbackSincePersist += 1;
+    this.pruneState(fb.fromPath);
+    await this.persistIfNeeded();
+  }
+
+  private async persistIfNeeded(force = false): Promise<void> {
+    if (!this.options.persist) return;
+    if (!force && this.feedbackSincePersist < this.options.persistEvery) return;
+    this.feedbackSincePersist = 0;
+
+    const dir = path.dirname(this.options.modelPath);
+    await fs.mkdir(dir, { recursive: true });
+    const tmpPath = `${this.options.modelPath}.tmp-${Date.now()}`;
+    const payload = JSON.stringify(this.model, null, 2);
+    await fs.writeFile(tmpPath, payload, "utf8");
+    await fs.rename(tmpPath, this.options.modelPath);
+  }
+
+  async onEnd(): Promise<void> {
+    await this.persistIfNeeded(true);
+  }
+}
+
+function readOptionsFromEnv(): RLBanditOptions {
+  return {
+    algo: parseAlgo(process.env.QA_EXPLORE_RL_ALGO),
+    eps: parseNumberEnv(process.env.QA_EXPLORE_RL_EPS, 0.1),
+    ucbC: parseNumberEnv(process.env.QA_EXPLORE_RL_UCB_C, 1.2),
+    persist: (process.env.QA_EXPLORE_RL_PERSIST ?? "0") === "1",
+    modelPath: process.env.QA_EXPLORE_RL_MODEL_PATH ?? path.join(".qa", "artifacts", "explore", "rl-bandit-model.json"),
+    reset: (process.env.QA_EXPLORE_RL_RESET ?? "0") === "1",
+    maxArmsPerState: parseNumberEnv(process.env.QA_EXPLORE_RL_MAX_ARMS_PER_STATE, 500),
+    persistEvery: parseNumberEnv(process.env.QA_EXPLORE_RL_PERSIST_EVERY, 10),
+    rewardMode: (process.env.QA_EXPLORE_RL_REWARD_MODE as RewardMode) === "bughunt" ? "bughunt" : "coverage",
+  };
+}
+
+let learner: RLBanditLearner | null = null;
+
+async function ensureLearner(): Promise<RLBanditLearner> {
+  if (!learner) {
+    learner = new RLBanditLearner(readOptionsFromEnv());
+    await learner.init();
+  }
+  return learner;
+}
+
+export const rlBanditStrategy: ExploreStrategy = {
+  name: "rl-bandit",
+  candidateLimit: 400,
+  dedupeByPath: true,
+  skipSelf: true,
+  skipBeforeSlice: false,
+  init: async () => {
+    await ensureLearner();
+  },
+  nextAction: ({ candidates, rng, config, stepIndex, currentPath }) => {
+    if (config.restartEvery > 0 && stepIndex > 0 && stepIndex % config.restartEvery === 0) {
+      return { action: "restart", reason: "scheduled", via: "goto(restart)" };
+    }
+
+    if (candidates.length === 0) {
+      return { action: "restart", reason: "dead-end", via: "goto(start)" };
+    }
+
+    const bandit = learner;
+    if (!bandit) {
+      throw new Error("rl-bandit strategy not initialized");
+    }
+    const pick = bandit.select(currentPath, candidates, rng);
+    return { action: "goto", url: pick.abs, reason: "rl-bandit-pick", targetPath: pick.path, via: "goto(link)" };
+  },
+  onFeedback: async (fb) => {
+    const bandit = await ensureLearner();
+    await bandit.onFeedback(fb);
+  },
+  onEnd: async () => {
+    const bandit = learner;
+    if (bandit) await bandit.onEnd();
+  },
+};

--- a/.qa/tests/exploratory/types.ts
+++ b/.qa/tests/exploratory/types.ts
@@ -17,6 +17,8 @@ export type ExploreCandidate = {
   path: string;
 };
 
+export type RewardMode = "coverage" | "bughunt";
+
 export type ExploreConfig = {
   seconds: number;
   seed: number;
@@ -31,6 +33,7 @@ export type ExploreConfig = {
   waitAfterGotoMs: number;
   benchMode: boolean;
   benchRunDir?: string;
+  rewardMode: RewardMode;
 };
 
 export type ExploreContext = {
@@ -52,6 +55,31 @@ export type ExploreContext = {
   targetSet?: Set<string>;
   stepIndex: number;
   coverage: CoverageState;
+};
+
+export type StepGain = {
+  newPages: number;
+  newRoutes: number;
+  newApis: number;
+  newAssets: number;
+};
+
+export type StepErrors = {
+  httpStatusGE400?: boolean;
+  pageerror?: boolean;
+  consoleError?: boolean;
+};
+
+export type StepFeedback = {
+  fromPath: string;
+  toPath: string;
+  reward: number;
+  gain: StepGain;
+  errors?: StepErrors;
+  revisited: boolean;
+  recentLoop: boolean;
+  stepIndex: number;
+  rewardMode: RewardMode;
 };
 
 export type FlowData = {
@@ -77,6 +105,8 @@ export type ExploreStrategy = {
   skipBeforeSlice: boolean;
   init?: (options: ExploreInitOptions) => Promise<ExploreInitResult | void> | ExploreInitResult | void;
   nextAction: (ctx: ExploreContext) => ExploreAction;
+  onFeedback?: (fb: StepFeedback) => void | Promise<void>;
+  onEnd?: () => void | Promise<void>;
 };
 
 export function normalizePathFromUrl(urlLike: string): string {

--- a/docs/qa/QA_POCKET_MANUAL.md
+++ b/docs/qa/QA_POCKET_MANUAL.md
@@ -24,6 +24,7 @@ QA Pocket は、Playwright ベースの QA 用ツールキットです。ロー�
 - 到達不能分析 + リンク修正リスト: `npm run qa:flow:analyze`（公開付きは `npm run qa:flow:analyze:publish`）。【F:.qa/README.md†L78-L83】
 - 探索的テスト（ランダム）: `QA_EXPLORE_SECONDS=120 npm run qa:explore`。【F:.qa/README.md†L52-L66】
 - 探索的テスト（未訪問優先 guided）: `QA_EXPLORE_SECONDS=120 npm run qa:explore:guided`（`QA_EXPLORE_PUBLISH=1` で JSON を `docs/qa` へ）。【F:.qa/README.md†L91-L104】
+- 強化学習バンディット探索: `QA_EXPLORE_STRATEGY=rl-bandit QA_EXPLORE_SECONDS=60 QA_EXPLORE_RL_PERSIST=1 npm run qa:explore`（モデルは `.qa/artifacts/explore/rl-bandit-model.json` に保存）。【F:.qa/README.md†L52-L66】【F:.qa/tests/exploratory/strategies/rl-bandit.ts†L152-L196】
 - まとめて実行（推奨）: `bash .qa/run-flow-coverage.sh`。【F:.qa/README.md†L96-L104】
 
 ### 生成物の例


### PR DESCRIPTION
## Summary
- add a new rl-bandit exploration strategy that supports UCB1/epsilon-greedy selection and optional persisted JSON models
- feed per-step reward feedback from the runner (coverage delta, errors, loops) into strategies and support a configurable reward mode
- expand docs and tests to cover the new strategy, persistence, and feedback handling

## Testing
- npx playwright test -c .qa/playwright.config.ts .qa/tests/exploratory/rl-bandit.spec.ts .qa/tests/exploratory/runner.spec.ts .qa/tests/exploratory/strategies.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695893408acc8333a0a1495f9b8ab6a8)